### PR TITLE
feat: implement incremental search and search/replace

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,6 +48,12 @@ pub struct EditorSettings {
     pub scroll_off: usize,
     /// Enable smart auto-indentation (default: true)
     pub auto_indent: bool,
+    /// Enable soft word wrap (default: false)
+    pub wrap: bool,
+    /// Column to wrap at (default: 80)
+    pub wrap_width: usize,
+    /// Enable auto-pairs (auto-close brackets/quotes) (default: true)
+    pub auto_pairs: bool,
 }
 
 impl Default for EditorSettings {
@@ -59,6 +65,9 @@ impl Default for EditorSettings {
             cursor_line: false,
             scroll_off: 0,
             auto_indent: true,
+            wrap: false,
+            wrap_width: 80,
+            auto_pairs: true,
         }
     }
 }

--- a/src/editor/undo.rs
+++ b/src/editor/undo.rs
@@ -30,6 +30,11 @@ impl Change {
         Self::new(line, col, text, String::new())
     }
 
+    /// Create a change for replacing an entire line
+    pub fn replace_line(line: usize, old_text: String, new_text: String) -> Self {
+        Self::new(line, 0, old_text, new_text)
+    }
+
     /// Create the inverse of this change (for undo)
     pub fn inverse(&self) -> Self {
         Self {


### PR DESCRIPTION
Incremental Search:
  - Highlight all matches in yellow/amber as you type in search mode
  - Cursor jumps to first match while typing
  - Highlights persist after executing search (Enter)
  - Works with n/N (next/prev) and */ # (word search)
  - Add :noh/:nohlsearch command to clear highlights
  - Highlights work in both wrapped and non-wrapped modes

  Search and Replace:
  - :s/pattern/replacement/ - replace first match on current line
  - :s/pattern/replacement/g - replace all matches on current line
  - :%s/pattern/replacement/g - replace all matches in entire file
  - Support any delimiter (e.g., :s#old#new#g)
  - Support escaped delimiters in pattern/replacement
  - Full undo support (all replacements as single undo group)
  - Report substitution count or "Pattern not found"