### PR TITLE
feat: delete marks functionally 

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -112,6 +112,10 @@ pub enum Command {
     Themes,
     /// :marks - Show all marks
     Marks,
+    /// :delmarks {marks} - Delete specified marks
+    DeleteMarks(String),
+    /// :delmarks! - Delete all lowercase marks in current buffer
+    DeleteMarksAll,
     /// Unknown command
     Unknown(String),
 }
@@ -298,8 +302,16 @@ pub fn parse_command(input: &str) -> Command {
         }
         "Themes" | "themes" => Command::Themes,
 
-        // Marks command
+        // Marks commands
         "marks" => Command::Marks,
+        "delmarks" | "delm" => {
+            if let Some(arg) = args.filter(|s| !s.is_empty()) {
+                Command::DeleteMarks(arg.to_string())
+            } else {
+                Command::Unknown("delmarks: missing mark argument".to_string())
+            }
+        }
+        "delmarks!" | "delm!" => Command::DeleteMarksAll,
 
         // Unknown command
         _ => Command::Unknown(cmd.to_string()),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -110,6 +110,8 @@ pub enum Command {
     Theme(String),
     /// :Themes - Open theme picker
     Themes,
+    /// :marks - Show all marks
+    Marks,
     /// Unknown command
     Unknown(String),
 }
@@ -295,6 +297,9 @@ pub fn parse_command(input: &str) -> Command {
             }
         }
         "Themes" | "themes" => Command::Themes,
+
+        // Marks command
+        "marks" => Command::Marks,
 
         // Unknown command
         _ => Command::Unknown(cmd.to_string()),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -737,6 +737,9 @@ fn default_config_template() -> &'static str {
 # m{a-zA-Z}        - Set mark (a-z local, A-Z global)
 # '{a-zA-Z}        - Jump to line of mark
 # `{a-zA-Z}        - Jump to exact position of mark
+# :marks           - Show all marks in interactive picker
+# :delmarks {m}    - Delete marks (e.g., :delmarks a, :delmarks a-d)
+# :delmarks!       - Delete all lowercase marks in buffer
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Macros

--- a/src/editor/marks.rs
+++ b/src/editor/marks.rs
@@ -120,4 +120,130 @@ impl Marks {
             self.global.remove(&name).is_some()
         }
     }
+
+    /// Delete all lowercase marks for a specific buffer
+    /// Used by :delmarks! command
+    pub fn delete_all_local(&mut self, buffer_key: &str) -> usize {
+        if let Some(marks) = self.local.get_mut(buffer_key) {
+            let count = marks.len();
+            marks.clear();
+            count
+        } else {
+            0
+        }
+    }
+
+    /// Parse a delmarks argument string and return marks to delete
+    /// Supports: "a", "a b c", "a-d", "aB", "a-dXY"
+    pub fn parse_delmarks_arg(arg: &str) -> Vec<char> {
+        let mut marks = Vec::new();
+        let chars: Vec<char> = arg.chars().collect();
+        let mut i = 0;
+
+        while i < chars.len() {
+            let c = chars[i];
+
+            // Skip whitespace
+            if c.is_whitespace() {
+                i += 1;
+                continue;
+            }
+
+            // Check for range (e.g., "a-d")
+            if i + 2 < chars.len() && chars[i + 1] == '-' && c.is_ascii_alphabetic() {
+                let start = c;
+                let end = chars[i + 2];
+
+                // Range must be same case and end >= start
+                if end.is_ascii_alphabetic()
+                    && ((start.is_lowercase() && end.is_lowercase())
+                        || (start.is_uppercase() && end.is_uppercase()))
+                    && end >= start
+                {
+                    for mark in start..=end {
+                        if !marks.contains(&mark) {
+                            marks.push(mark);
+                        }
+                    }
+                    i += 3;
+                    continue;
+                }
+            }
+
+            // Single mark
+            if c.is_ascii_alphabetic() && !marks.contains(&c) {
+                marks.push(c);
+            }
+
+            i += 1;
+        }
+
+        marks
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_delmarks_single() {
+        assert_eq!(Marks::parse_delmarks_arg("a"), vec!['a']);
+        assert_eq!(Marks::parse_delmarks_arg("A"), vec!['A']);
+    }
+
+    #[test]
+    fn test_parse_delmarks_multiple() {
+        assert_eq!(Marks::parse_delmarks_arg("a b c"), vec!['a', 'b', 'c']);
+        assert_eq!(Marks::parse_delmarks_arg("aB"), vec!['a', 'B']);
+        assert_eq!(Marks::parse_delmarks_arg("abc"), vec!['a', 'b', 'c']);
+    }
+
+    #[test]
+    fn test_parse_delmarks_range() {
+        assert_eq!(Marks::parse_delmarks_arg("a-d"), vec!['a', 'b', 'c', 'd']);
+        assert_eq!(Marks::parse_delmarks_arg("A-C"), vec!['A', 'B', 'C']);
+    }
+
+    #[test]
+    fn test_parse_delmarks_mixed() {
+        assert_eq!(
+            Marks::parse_delmarks_arg("a-c X Y"),
+            vec!['a', 'b', 'c', 'X', 'Y']
+        );
+    }
+
+    #[test]
+    fn test_parse_delmarks_no_duplicates() {
+        // Range followed by individual mark that's in range
+        assert_eq!(Marks::parse_delmarks_arg("a-c b"), vec!['a', 'b', 'c']);
+    }
+
+    #[test]
+    fn test_delete_marks() {
+        let mut marks = Marks::new();
+        marks.set_local("test", 'a', 10, 5);
+        marks.set_local("test", 'b', 20, 0);
+
+        assert!(marks.get_local("test", 'a').is_some());
+        assert!(marks.delete("test", 'a'));
+        assert!(marks.get_local("test", 'a').is_none());
+
+        // Delete non-existent mark
+        assert!(!marks.delete("test", 'z'));
+    }
+
+    #[test]
+    fn test_delete_all_local() {
+        let mut marks = Marks::new();
+        marks.set_local("test", 'a', 10, 5);
+        marks.set_local("test", 'b', 20, 0);
+        marks.set_local("test", 'c', 30, 0);
+
+        let count = marks.delete_all_local("test");
+        assert_eq!(count, 3);
+        assert!(marks.get_local("test", 'a').is_none());
+        assert!(marks.get_local("test", 'b').is_none());
+        assert!(marks.get_local("test", 'c').is_none());
+    }
 }

--- a/src/editor/marks.rs
+++ b/src/editor/marks.rs
@@ -90,4 +90,34 @@ impl Marks {
     pub fn is_valid_mark(c: char) -> bool {
         c.is_ascii_alphabetic()
     }
+
+    /// Get all local marks for a specific buffer (sorted by name)
+    pub fn get_local_marks(&self, buffer_key: &str) -> Vec<(char, &Mark)> {
+        let mut marks: Vec<(char, &Mark)> = self
+            .local
+            .get(buffer_key)
+            .map(|m| m.iter().map(|(c, mark)| (*c, mark)).collect())
+            .unwrap_or_default();
+        marks.sort_by_key(|(c, _)| *c);
+        marks
+    }
+
+    /// Get all global marks (sorted by name)
+    pub fn get_global_marks(&self) -> Vec<(char, &Mark)> {
+        let mut marks: Vec<(char, &Mark)> = self.global.iter().map(|(c, mark)| (*c, mark)).collect();
+        marks.sort_by_key(|(c, _)| *c);
+        marks
+    }
+
+    /// Delete a mark by name
+    pub fn delete(&mut self, buffer_key: &str, name: char) -> bool {
+        if name.is_lowercase() {
+            self.local
+                .get_mut(buffer_key)
+                .map(|marks| marks.remove(&name).is_some())
+                .unwrap_or(false)
+        } else {
+            self.global.remove(&name).is_some()
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -223,6 +223,8 @@ fn main() -> anyhow::Result<()> {
                     editor.hover_content = None;
                     // Dismiss diagnostic float on any key press (it can be reopened with gl)
                     editor.show_diagnostic_float = false;
+                    // Dismiss marks picker on any key press (handled separately below)
+                    // Note: marks_picker has its own key handling
 
                     // Check for manual completion trigger (Ctrl+Space) in insert mode
                     let manual_completion = editor.mode == Mode::Insert

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6669,6 +6669,57 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
+        Command::DeleteMarks(arg) => {
+            use crate::editor::Marks;
+
+            let buffer_key = editor
+                .buffer()
+                .path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| format!("buffer_{}", editor.current_buffer_index()));
+
+            let marks_to_delete = Marks::parse_delmarks_arg(&arg);
+            let mut deleted_count = 0;
+
+            for mark in marks_to_delete {
+                if editor.marks.delete(&buffer_key, mark) {
+                    deleted_count += 1;
+                }
+            }
+
+            if deleted_count > 0 {
+                CommandResult::Message(format!(
+                    "Deleted {} mark{}",
+                    deleted_count,
+                    if deleted_count == 1 { "" } else { "s" }
+                ))
+            } else {
+                CommandResult::Message("No marks deleted".to_string())
+            }
+        }
+
+        Command::DeleteMarksAll => {
+            let buffer_key = editor
+                .buffer()
+                .path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| format!("buffer_{}", editor.current_buffer_index()));
+
+            let deleted_count = editor.marks.delete_all_local(&buffer_key);
+
+            if deleted_count > 0 {
+                CommandResult::Message(format!(
+                    "Deleted {} mark{}",
+                    deleted_count,
+                    if deleted_count == 1 { "" } else { "s" }
+                ))
+            } else {
+                CommandResult::Message("No local marks to delete".to_string())
+            }
+        }
+
         Command::Unknown(cmd) => {
             if cmd.is_empty() {
                 CommandResult::Ok

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8,7 +8,7 @@ use crossterm::{
 use std::io::{self, Write, Stdout};
 use std::time::Instant;
 
-use crate::editor::{Editor, Mode, PaneDirection, Pane, SplitLayout, LspAction};
+use crate::editor::{Editor, Mode, PaneDirection, Pane, SplitLayout, LspAction, MarkEntry, MarksPicker};
 use crate::input::{KeyAction, InsertPosition, Operator, TextObject, TextObjectModifier, TextObjectType};
 use crate::commands::{Command, CommandResult, parse_command};
 use crate::config::LeaderAction;
@@ -269,6 +269,11 @@ impl Terminal {
         // Render diagnostic floating popup if active
         if editor.show_diagnostic_float {
             self.render_diagnostic_float(editor)?;
+        }
+
+        // Render marks picker if active
+        if editor.marks_picker.is_some() {
+            self.render_marks_picker(editor)?;
         }
 
         // Render references picker if active
@@ -2471,6 +2476,164 @@ impl Terminal {
         Ok(())
     }
 
+    /// Render the marks picker as an interactive popup
+    fn render_marks_picker(&mut self, editor: &Editor) -> anyhow::Result<()> {
+        let picker = match &editor.marks_picker {
+            Some(p) => p,
+            None => return Ok(()),
+        };
+
+        if picker.items.is_empty() {
+            return Ok(());
+        }
+
+        // Get theme colors
+        let theme = &editor.theme_manager.current;
+        let bg_color = theme.ui.finder_bg;
+        let border_color = theme.ui.finder_border;
+        let selection_bg = theme.ui.finder_selected;
+        let text_color = theme.ui.foreground;
+        let dim_color = Color::Rgb { r: 108, g: 112, b: 134 };
+        let local_mark_color = Color::Rgb { r: 137, g: 180, b: 250 }; // Blue for local
+        let global_mark_color = Color::Rgb { r: 249, g: 226, b: 175 }; // Yellow for global
+
+        // Calculate popup dimensions
+        let popup_width: u16 = 44; // Fixed width for consistency
+        let max_visible_items = 10.min(picker.items.len());
+        let popup_height: u16 = (max_visible_items + 4) as u16; // +4 for top border, header, separator, bottom border
+        let inner_width = (popup_width - 2) as usize; // Width inside the borders
+
+        // Center the popup
+        let popup_x = (editor.term_width.saturating_sub(popup_width)) / 2;
+        let popup_y = (editor.term_height.saturating_sub(popup_height)) / 2;
+
+        // Helper to draw a full-width line with borders
+        let draw_line = |stdout: &mut std::io::Stdout, y: u16, content: &str, fg: Color, bg: Color, left_border: &str, right_border: &str| -> anyhow::Result<()> {
+            execute!(stdout, cursor::MoveTo(popup_x, y))?;
+            execute!(stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+            print!("{}", left_border);
+            execute!(stdout, SetForegroundColor(fg), SetBackgroundColor(bg))?;
+            let content_chars: Vec<char> = content.chars().collect();
+            let content_len = content_chars.len();
+            if content_len >= inner_width {
+                let truncated: String = content_chars.into_iter().take(inner_width).collect();
+                print!("{}", truncated);
+            } else {
+                print!("{}", content);
+                print!("{:width$}", "", width = inner_width - content_len);
+            }
+            execute!(stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+            print!("{}", right_border);
+            Ok(())
+        };
+
+        // Draw top border with title
+        execute!(self.stdout, cursor::MoveTo(popup_x, popup_y))?;
+        execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+        let title = " Marks ";
+        let border_inner = inner_width.saturating_sub(title.len());
+        let left_dashes = border_inner / 2;
+        let right_dashes = border_inner - left_dashes;
+        print!("╭");
+        for _ in 0..left_dashes { print!("─"); }
+        execute!(self.stdout, SetForegroundColor(text_color))?;
+        print!("{}", title);
+        execute!(self.stdout, SetForegroundColor(border_color))?;
+        for _ in 0..right_dashes { print!("─"); }
+        print!("╮");
+
+        // Draw header row
+        let header = format!(" {:<4}{:>6}{:>5}  {:<}", "mark", "line", "col", "file");
+        draw_line(&mut self.stdout, popup_y + 1, &header, dim_color, bg_color, "│", "│")?;
+
+        // Draw separator
+        execute!(self.stdout, cursor::MoveTo(popup_x, popup_y + 2))?;
+        execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+        print!("├");
+        for _ in 0..inner_width { print!("─"); }
+        print!("┤");
+
+        // Calculate visible range based on selection
+        let scroll_offset = if picker.selected >= max_visible_items {
+            picker.selected - max_visible_items + 1
+        } else {
+            0
+        };
+
+        // Draw items
+        for (i, item) in picker.items.iter().skip(scroll_offset).take(max_visible_items).enumerate() {
+            let actual_idx = scroll_offset + i;
+            let is_selected = actual_idx == picker.selected;
+            let row_y = popup_y + 3 + i as u16;
+
+            execute!(self.stdout, cursor::MoveTo(popup_x, row_y))?;
+
+            // Left border
+            execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+            print!("│");
+
+            // Row background
+            let row_bg = if is_selected { selection_bg } else { bg_color };
+            execute!(self.stdout, SetBackgroundColor(row_bg))?;
+
+            // Selection indicator
+            if is_selected {
+                execute!(self.stdout, SetForegroundColor(local_mark_color))?;
+                print!(" ▸");
+            } else {
+                print!("  ");
+            }
+
+            // Mark name
+            let mark_color = if item.is_global { global_mark_color } else { local_mark_color };
+            execute!(self.stdout, SetForegroundColor(mark_color))?;
+            print!("{:<3}", item.name);
+
+            // Line and col
+            execute!(self.stdout, SetForegroundColor(text_color))?;
+            print!("{:>6}{:>5}  ", item.line + 1, item.col);
+
+            // File name - calculate remaining space
+            // Used so far: 2 (indicator) + 3 (mark) + 6 (line) + 5 (col) + 2 (spaces) = 18
+            let file_max_len = inner_width.saturating_sub(18);
+            let file_display: String = item.file_name.chars().take(file_max_len).collect();
+            execute!(self.stdout, SetForegroundColor(dim_color))?;
+            print!("{:<width$}", file_display, width = file_max_len);
+
+            // Right border
+            execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+            print!("│");
+        }
+
+        // Fill remaining rows if fewer items than max
+        for i in picker.items.len()..max_visible_items {
+            let row_y = popup_y + 3 + i as u16;
+            execute!(self.stdout, cursor::MoveTo(popup_x, row_y))?;
+            execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+            print!("│");
+            print!("{:width$}", "", width = inner_width);
+            print!("│");
+        }
+
+        // Draw bottom border with hints
+        execute!(self.stdout, cursor::MoveTo(popup_x, popup_y + popup_height - 1))?;
+        execute!(self.stdout, SetForegroundColor(border_color), SetBackgroundColor(bg_color))?;
+        let hint = " j/k Enter Esc ";
+        let hint_inner = inner_width.saturating_sub(hint.len());
+        let hint_left = hint_inner / 2;
+        let hint_right = hint_inner - hint_left;
+        print!("╰");
+        for _ in 0..hint_left { print!("─"); }
+        execute!(self.stdout, SetForegroundColor(dim_color))?;
+        print!("{}", hint);
+        execute!(self.stdout, SetForegroundColor(border_color))?;
+        for _ in 0..hint_right { print!("─"); }
+        print!("╯");
+
+        execute!(self.stdout, ResetColor)?;
+        Ok(())
+    }
+
     /// Render the references picker as a floating popup
     fn render_references_picker(&mut self, editor: &Editor) -> anyhow::Result<()> {
         let picker = match &editor.references_picker {
@@ -3756,6 +3919,96 @@ fn handle_harpoon_menu_key(editor: &mut Editor, key: KeyEvent) {
     }
 }
 
+/// Handle key input for the marks picker
+fn handle_marks_picker_key(editor: &mut Editor, key: KeyEvent) {
+    match (key.modifiers, key.code) {
+        // Close picker
+        (KeyModifiers::NONE, KeyCode::Esc) |
+        (KeyModifiers::CONTROL, KeyCode::Char('[')) |
+        (KeyModifiers::NONE, KeyCode::Char('q')) => {
+            editor.marks_picker = None;
+        }
+
+        // Navigate up
+        (KeyModifiers::NONE, KeyCode::Up) |
+        (KeyModifiers::NONE, KeyCode::Char('k')) |
+        (KeyModifiers::CONTROL, KeyCode::Char('k')) |
+        (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
+            if let Some(picker) = &mut editor.marks_picker {
+                picker.move_up();
+            }
+        }
+
+        // Navigate down
+        (KeyModifiers::NONE, KeyCode::Down) |
+        (KeyModifiers::NONE, KeyCode::Char('j')) |
+        (KeyModifiers::CONTROL, KeyCode::Char('j')) |
+        (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
+            if let Some(picker) = &mut editor.marks_picker {
+                picker.move_down();
+            }
+        }
+
+        // Jump to selected mark
+        (KeyModifiers::NONE, KeyCode::Enter) |
+        (KeyModifiers::NONE, KeyCode::Char('l')) => {
+            if let Some(picker) = &editor.marks_picker {
+                if let Some(mark) = picker.selected_mark() {
+                    let line = mark.line;
+                    let col = mark.col;
+                    let file_path = mark.file_path.clone();
+                    let is_global = mark.is_global;
+
+                    // Close picker first
+                    editor.marks_picker = None;
+
+                    // If it's a global mark with a different file, open it
+                    if is_global {
+                        if let Some(path) = file_path {
+                            let current_path = editor.buffer().path.clone();
+                            if current_path.as_ref() != Some(&path) {
+                                // Open the file
+                                if let Err(e) = editor.open_file(path.clone()) {
+                                    editor.set_status(format!("Error opening file: {}", e));
+                                    return;
+                                }
+                            }
+                        }
+                    }
+
+                    // Record jump before moving
+                    editor.record_jump();
+
+                    // Jump to position
+                    editor.cursor.line = line;
+                    editor.cursor.col = col;
+                    editor.scroll_cursor_center();
+                }
+            } else {
+                editor.marks_picker = None;
+            }
+        }
+
+        // Go to top
+        (KeyModifiers::NONE, KeyCode::Char('g')) => {
+            if let Some(picker) = &mut editor.marks_picker {
+                picker.selected = 0;
+            }
+        }
+
+        // Go to bottom
+        (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
+            if let Some(picker) = &mut editor.marks_picker {
+                if !picker.items.is_empty() {
+                    picker.selected = picker.items.len() - 1;
+                }
+            }
+        }
+
+        _ => {}
+    }
+}
+
 /// Handle key input for the theme picker
 fn handle_theme_picker_key(editor: &mut Editor, key: KeyEvent) {
     match (key.modifiers, key.code) {
@@ -3916,6 +4169,12 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
     // Handle harpoon menu if active
     if editor.harpoon.menu_open {
         handle_harpoon_menu_key(editor, key);
+        return;
+    }
+
+    // Handle marks picker if active
+    if editor.marks_picker.is_some() {
+        handle_marks_picker_key(editor, key);
         return;
     }
 
@@ -6348,6 +6607,66 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
         Command::Themes => {
             editor.open_theme_picker();
             CommandResult::Ok
+        }
+
+        Command::Marks => {
+            // Get buffer key for local marks
+            let buffer_key = editor
+                .buffer()
+                .path
+                .as_ref()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|| format!("buffer_{}", editor.current_buffer_index()));
+
+            let local_marks = editor.marks.get_local_marks(&buffer_key);
+            let global_marks = editor.marks.get_global_marks();
+
+            if local_marks.is_empty() && global_marks.is_empty() {
+                CommandResult::Message("No marks set".to_string())
+            } else {
+                // Build mark entries
+                let mut items = Vec::new();
+
+                // Add local marks
+                let current_file = editor.buffer().path.clone();
+                let current_file_name = current_file
+                    .as_ref()
+                    .and_then(|p| p.file_name())
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                for (name, mark) in local_marks {
+                    items.push(MarkEntry {
+                        name,
+                        line: mark.line,
+                        col: mark.col,
+                        file_path: current_file.clone(),
+                        file_name: current_file_name.clone(),
+                        is_global: false,
+                    });
+                }
+
+                // Add global marks
+                for (name, mark) in global_marks {
+                    let file_name = mark
+                        .path
+                        .as_ref()
+                        .and_then(|p| p.file_name())
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_default();
+                    items.push(MarkEntry {
+                        name,
+                        line: mark.line,
+                        col: mark.col,
+                        file_path: mark.path.clone(),
+                        file_name,
+                        is_global: true,
+                    });
+                }
+
+                editor.marks_picker = Some(MarksPicker::new(items));
+                CommandResult::Ok
+            }
         }
 
         Command::Unknown(cmd) => {


### PR DESCRIPTION
PR covers:

- You can now delete marks just as you would in Neovim default keybinds