### PR TITLE
Refresh explorer after external file changes

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1125,6 +1125,11 @@ impl Editor {
         reload_result
     }
 
+    /// Refresh editor state after returning from an external terminal command.
+    pub fn handle_external_process_finished(&mut self) -> Option<String> {
+        self.handle_focus_gained()
+    }
+
     /// Set the project root directory
     pub fn set_project_root(&mut self, path: std::path::PathBuf) {
         self.project_root = Some(path.clone());
@@ -7559,6 +7564,44 @@ mod tests {
             .flat_view
             .iter()
             .any(|node| node.name == "created-outside"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn external_process_return_removes_deleted_files_from_visible_explorer_tree() {
+        let tmp = unique_temp_dir("nevi_explorer_external_refresh");
+        let examples = tmp.join("examples");
+        std::fs::create_dir_all(&examples).expect("create examples dir");
+        let removed_file = examples.join("dump_toml_nodes.rs");
+        std::fs::write(&removed_file, "fn main() {}\n").expect("write file");
+        let root = tmp.clone();
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.open_explorer();
+        editor.explorer.selected = editor
+            .explorer
+            .flat_view
+            .iter()
+            .position(|node| node.path == root.join("examples"))
+            .expect("examples dir should be visible");
+        editor.explorer.expand();
+        assert!(editor
+            .explorer
+            .flat_view
+            .iter()
+            .any(|node| node.path == removed_file));
+
+        std::fs::remove_file(&removed_file).expect("remove external file");
+
+        let _ = editor.handle_external_process_finished();
+
+        assert!(!editor
+            .explorer
+            .flat_view
+            .iter()
+            .any(|node| node.path == removed_file));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1115,6 +1115,16 @@ impl Editor {
         }
     }
 
+    /// Refresh editor state that can change while the terminal is unfocused.
+    pub fn handle_focus_gained(&mut self) -> Option<String> {
+        let reload_result = self.check_and_reload_external_changes();
+        if self.explorer.visible {
+            self.explorer.refresh();
+        }
+        self.refresh_git_state();
+        reload_result
+    }
+
     /// Set the project root directory
     pub fn set_project_root(&mut self, path: std::path::PathBuf) {
         self.project_root = Some(path.clone());
@@ -7515,6 +7525,40 @@ mod tests {
         editor.update_all_git_diffs();
 
         assert_eq!(editor.git_status_for_line(0), None);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn focus_gained_refreshes_visible_explorer_tree() {
+        let tmp = unique_temp_dir("nevi_explorer_focus_refresh");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        std::fs::create_dir(root.join("existing")).expect("create existing dir");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.open_explorer();
+        assert!(editor
+            .explorer
+            .flat_view
+            .iter()
+            .any(|node| node.name == "existing"));
+        assert!(!editor
+            .explorer
+            .flat_view
+            .iter()
+            .any(|node| node.name == "created-outside"));
+
+        std::fs::create_dir(root.join("created-outside")).expect("create external dir");
+
+        let _ = editor.handle_focus_gained();
+
+        assert!(editor
+            .explorer
+            .flat_view
+            .iter()
+            .any(|node| node.name == "created-outside"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1562,7 +1562,9 @@ fn main() -> anyhow::Result<()> {
             if let Err(e) = terminal.run_external_process(&cmd) {
                 editor.set_status(format!("Error running command: {}", e));
             }
-            editor.refresh_git_state();
+            if let Some(msg) = editor.handle_external_process_finished() {
+                editor.set_status(msg);
+            }
             needs_redraw = true;
             continue;
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,9 +351,8 @@ fn main() -> anyhow::Result<()> {
                     // Handle focus gained for autoread
                     let key = match event {
                         EditorEvent::FocusGained => {
-                            // Check all open buffers for external changes
-                            let reload_result = editor.check_and_reload_external_changes();
-                            editor.refresh_git_state();
+                            // Refresh state that may have changed while unfocused.
+                            let reload_result = editor.handle_focus_gained();
                             if let Some(msg) = reload_result {
                                 editor.set_status(msg);
                             }


### PR DESCRIPTION
## Summary
- refresh the visible explorer when the terminal regains focus
- refresh after returning from external commands such as LazyGit
- preserve expanded explorer directories while removing deleted entries

## Verification
- cargo test explorer -- --nocapture
- cargo test
- git diff --check

## Manual testing
- confirmed external file deletion/discard from LazyGit removes stale entries from the explorer