### PR TITLE
feat: add terminal-native markdown preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ nevi file1.rs file2.rs
 - `:w` - Save
 - `:q` - Quit
 - `:wq` - Save and quit
-- `:MarkdownPreview` - Open rendered Markdown reader for `.md` files
+- `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
 - `<Space>e` - File explorer

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A fast, native terminal editor where your existing vim/neovim muscle memory just
 - **File explorer** - Built-in tree view
 - **Git signs** - Gutter indicators for added/modified/deleted lines
 - **Harpoon-style quick file switching** - Pin and jump to frequently used files
+- **Markdown preview** - Open a fast, terminal-native rendered reader with `:MarkdownPreview`
 - **External formatter support** - Biome, Prettier, and other formatters
 - **Split windows** - Vertical and horizontal splits
 - **Configurable via TOML** - Simple, readable configuration
@@ -74,6 +75,7 @@ nevi file1.rs file2.rs
 - `:w` - Save
 - `:q` - Quit
 - `:wq` - Save and quit
+- `:MarkdownPreview` - Open rendered Markdown reader for `.md` files
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
 - `<Space>e` - File explorer

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -59,6 +59,8 @@ pub enum Command {
     FindDiagnostics,
     /// :DiagnosticFloat - Show diagnostic floating popup at cursor line
     DiagnosticFloat,
+    /// :MarkdownPreview - Open a rendered floating Markdown preview
+    MarkdownPreview,
     /// :noh or :nohlsearch - Clear search highlights
     NoHighlight,
     /// :s/pattern/replacement/flags or :%s/pattern/replacement/flags - Search and replace
@@ -336,6 +338,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         command: "DiagnosticFloat",
         aliases: &["diagnosticfloat", "df", "linediag"],
         description: "Show diagnostics at cursor line",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "MarkdownPreview",
+        aliases: &["markdownpreview", "mdpreview", "mdp"],
+        description: "Open rendered Markdown preview",
         takes_args: false,
     },
     CommandSpec {
@@ -824,6 +832,9 @@ pub fn parse_command(input: &str) -> Command {
             Command::FindDiagnostics
         }
         "DiagnosticFloat" | "diagnosticfloat" | "df" | "linediag" => Command::DiagnosticFloat,
+        "MarkdownPreview" | "markdownpreview" | "mdpreview" | "mdp" => {
+            Command::MarkdownPreview
+        }
 
         // Clear search highlight
         "noh" | "nohlsearch" => Command::NoHighlight,
@@ -1481,6 +1492,26 @@ mod tests {
                 .iter()
                 .any(|item| item.command == "DiagnosticFloat"),
             "expected DiagnosticFloat to match fuzzy query"
+        );
+    }
+
+    #[test]
+    fn markdown_preview_command_is_parseable_and_suggested() {
+        assert!(matches!(
+            parse_command("MarkdownPreview"),
+            Command::MarkdownPreview
+        ));
+        assert!(matches!(
+            parse_command("mdpreview"),
+            Command::MarkdownPreview
+        ));
+
+        let suggestions = command_suggestions("mdp", 8);
+        assert!(
+            suggestions
+                .iter()
+                .any(|item| item.command == "MarkdownPreview"),
+            "expected MarkdownPreview to match fuzzy query"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1034,6 +1034,12 @@ fn default_config_template() -> &'static str {
 # action = ":w"
 # desc = "Save file"
 #
+# Example: open the Markdown preview with <leader>md
+# [[keymap.leader_mappings]]
+# key = "md"
+# action = ":MarkdownPreview"
+# desc = "Open Markdown preview"
+#
 # To override command-mode command-line UX bindings:
 # [[keymap.command_mappings]]
 # key = "<A-r>"

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1288,6 +1288,20 @@ impl Editor {
         preview.scroll = next.min(preview.max_scroll(visible_rows));
     }
 
+    /// Jump the Markdown preview to the first rendered row.
+    pub fn jump_markdown_preview_to_top(&mut self) {
+        if let Some(preview) = &mut self.markdown_preview {
+            preview.scroll = 0;
+        }
+    }
+
+    /// Jump the Markdown preview to the last rendered row that can start a page.
+    pub fn jump_markdown_preview_to_bottom(&mut self, visible_rows: usize) {
+        if let Some(preview) = &mut self.markdown_preview {
+            preview.scroll = preview.max_scroll(visible_rows);
+        }
+    }
+
     /// Get the project root or current working directory
     pub fn working_directory(&self) -> std::path::PathBuf {
         self.project_root.clone().unwrap_or_else(|| {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1262,7 +1262,10 @@ impl Editor {
         }
 
         let rendered = crate::markdown_preview::render_markdown(&self.buffer().content());
-        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::new(rendered));
+        let width = crate::markdown_preview::preview_content_width(self.term_width);
+        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::new(
+            rendered, width,
+        ));
         Ok(())
     }
 
@@ -2336,6 +2339,9 @@ impl Editor {
     pub fn set_size(&mut self, width: u16, height: u16) {
         self.term_width = width;
         self.term_height = height;
+        if let Some(preview) = &mut self.markdown_preview {
+            preview.reflow(crate::markdown_preview::preview_content_width(width));
+        }
         self.update_pane_rects();
         self.sync_floating_terminal_size();
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -810,6 +810,8 @@ pub struct Editor {
     pub theme_manager: ThemeManager,
     /// Theme picker state (Some if picker is open)
     pub theme_picker: Option<ThemePicker>,
+    /// Floating rendered Markdown preview state.
+    pub markdown_preview: Option<crate::markdown_preview::MarkdownPreviewState>,
     /// Marks for navigation (m{a-z}, '{a-z}, `{a-z})
     pub marks: Marks,
     /// Last visual selection for gv command
@@ -1093,6 +1095,7 @@ impl Editor {
             git_repo: None,
             theme_manager,
             theme_picker: None,
+            markdown_preview: None,
             marks: Marks::new(),
             last_visual_selection: None,
             macros: MacroState::new(),
@@ -1243,6 +1246,43 @@ impl Editor {
         if self.theme_manager.preview_theme(name) {
             self.syntax.sync_theme(self.theme_manager.theme());
         }
+    }
+
+    /// Open a snapshot-based Markdown preview for the active buffer.
+    pub fn open_markdown_preview(&mut self) -> Result<(), &'static str> {
+        let is_markdown = self
+            .buffer()
+            .path
+            .as_deref()
+            .and_then(crate::lsp::LanguageId::from_path)
+            == Some(crate::lsp::LanguageId::Markdown);
+
+        if !is_markdown {
+            return Err("Markdown preview is only available for Markdown buffers");
+        }
+
+        let rendered = crate::markdown_preview::render_markdown(&self.buffer().content());
+        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::new(rendered));
+        Ok(())
+    }
+
+    /// Close the floating Markdown preview.
+    pub fn close_markdown_preview(&mut self) {
+        self.markdown_preview = None;
+    }
+
+    /// Scroll the Markdown preview while clamping to its visible content range.
+    pub fn scroll_markdown_preview(&mut self, delta: isize, visible_rows: usize) {
+        let Some(preview) = &mut self.markdown_preview else {
+            return;
+        };
+
+        let next = if delta.is_negative() {
+            preview.scroll.saturating_sub(delta.unsigned_abs())
+        } else {
+            preview.scroll.saturating_add(delta as usize)
+        };
+        preview.scroll = next.min(preview.max_scroll(visible_rows));
     }
 
     /// Get the project root or current working directory
@@ -7328,6 +7368,85 @@ mod tests {
         assert!(editor.switch_to_buffer(0));
         editor.undo();
         assert_eq!(editor.buffer().content(), "abc\n");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_opens_for_markdown_buffers_and_snapshots_content() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_snapshot");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown = tmp.join("notes.md");
+        std::fs::write(&markdown, "# Seed\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor
+            .open_file(markdown)
+            .expect("open markdown buffer");
+        editor.replace_buffer_content("# Before\n");
+
+        editor.open_markdown_preview().expect("open preview");
+        assert_eq!(
+            editor
+                .markdown_preview
+                .as_ref()
+                .expect("preview")
+                .lines[0]
+                .plain_text(),
+            "Before"
+        );
+
+        editor.replace_buffer_content("# After\n");
+        assert_eq!(
+            editor
+                .markdown_preview
+                .as_ref()
+                .expect("preview")
+                .lines[0]
+                .plain_text(),
+            "Before"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_rejects_non_markdown_buffers() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_non_markdown");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let rust = tmp.join("main.rs");
+        std::fs::write(&rust, "fn main() {}\n").expect("write rust");
+
+        let mut editor = Editor::default();
+        editor.open_file(rust).expect("open rust buffer");
+
+        let result = editor.open_markdown_preview();
+
+        assert!(result.is_err());
+        assert!(editor.markdown_preview.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_scroll_is_clamped_to_visible_content() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_scroll");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown = tmp.join("notes.md");
+        std::fs::write(&markdown, "# Seed\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor
+            .open_file(markdown)
+            .expect("open markdown buffer");
+        editor.replace_buffer_content(&(0..20).map(|i| format!("line {i}\n")).collect::<String>());
+        editor.open_markdown_preview().expect("open preview");
+
+        editor.scroll_markdown_preview(100, 5);
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 15);
+
+        editor.scroll_markdown_preview(-100, 5);
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 0);
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod harpoon;
 pub mod indent;
 pub mod input;
 pub mod lsp;
+pub mod markdown_preview;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;
@@ -27,5 +28,8 @@ pub use explorer::FileExplorer;
 pub use finder::{FuzzyFinder, FinderMode, FloatingWindow};
 pub use frecency::FrecencyDb;
 pub use lsp::{LspManager, LspNotification, LspStatus, MultiLspManager, LanguageId};
+pub use markdown_preview::{
+    render_markdown, MarkdownPreview, PreviewLine, PreviewLineKind, PreviewSpan, PreviewSpanStyle,
+};
 pub use terminal::Terminal;
 pub use theme::{Theme, ThemeManager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@ pub use finder::{FuzzyFinder, FinderMode, FloatingWindow};
 pub use frecency::FrecencyDb;
 pub use lsp::{LspManager, LspNotification, LspStatus, MultiLspManager, LanguageId};
 pub use markdown_preview::{
-    render_markdown, MarkdownPreview, PreviewLine, PreviewLineKind, PreviewSpan, PreviewSpanStyle,
+    render_markdown, MarkdownPreview, MarkdownPreviewState, PreviewLine, PreviewLineKind,
+    PreviewSpan, PreviewSpanStyle,
 };
 pub use terminal::Terminal;
 pub use theme::{Theme, ThemeManager};

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,16 +366,7 @@ fn main() -> anyhow::Result<()> {
                             continue 'main_loop;
                         }
                         EditorEvent::Mouse(mouse) => {
-                            if editor.markdown_preview.is_some()
-                                && nevi::terminal::handle_markdown_preview_mouse(
-                                    &mut editor,
-                                    mouse,
-                                )
-                            {
-                                last_input_at = Some(Instant::now());
-                                needs_redraw = true;
-                                redraw_from_input = true;
-                            } else if editor.floating_terminal.is_visible() {
+                            if editor.floating_terminal.is_visible() {
                                 let terminal_settings = &editor.settings.terminal;
                                 let content_area = nevi::floating_terminal::content_area_for_screen(
                                     editor.term_width,

--- a/src/main.rs
+++ b/src/main.rs
@@ -366,7 +366,16 @@ fn main() -> anyhow::Result<()> {
                             continue 'main_loop;
                         }
                         EditorEvent::Mouse(mouse) => {
-                            if editor.floating_terminal.is_visible() {
+                            if editor.markdown_preview.is_some()
+                                && nevi::terminal::handle_markdown_preview_mouse(
+                                    &mut editor,
+                                    mouse,
+                                )
+                            {
+                                last_input_at = Some(Instant::now());
+                                needs_redraw = true;
+                                redraw_from_input = true;
+                            } else if editor.floating_terminal.is_visible() {
                                 let terminal_settings = &editor.settings.terminal;
                                 let content_area = nevi::floating_terminal::content_area_for_screen(
                                     editor.term_width,

--- a/src/markdown_preview.rs
+++ b/src/markdown_preview.rs
@@ -1,0 +1,344 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewSpanStyle {
+    Plain,
+    Emphasis,
+    Strong,
+    InlineCode,
+    Link,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PreviewLineKind {
+    Blank,
+    Paragraph,
+    Heading(u8),
+    Quote,
+    ListItem,
+    Rule,
+    CodeBlock,
+    Placeholder,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewSpan {
+    pub text: String,
+    pub style: PreviewSpanStyle,
+}
+
+impl PreviewSpan {
+    fn plain(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            style: PreviewSpanStyle::Plain,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreviewLine {
+    pub kind: PreviewLineKind,
+    pub spans: Vec<PreviewSpan>,
+}
+
+impl PreviewLine {
+    fn from_text(kind: PreviewLineKind, text: impl Into<String>) -> Self {
+        Self {
+            kind,
+            spans: vec![PreviewSpan::plain(text)],
+        }
+    }
+
+    fn from_spans(kind: PreviewLineKind, spans: Vec<PreviewSpan>) -> Self {
+        Self { kind, spans }
+    }
+
+    pub fn plain_text(&self) -> String {
+        self.spans.iter().map(|span| span.text.as_str()).collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MarkdownPreview {
+    pub lines: Vec<PreviewLine>,
+}
+
+pub fn render_markdown(source: &str) -> MarkdownPreview {
+    if source.trim().is_empty() {
+        return MarkdownPreview {
+            lines: vec![PreviewLine::from_text(
+                PreviewLineKind::Placeholder,
+                "Nothing to preview yet.",
+            )],
+        };
+    }
+
+    let mut lines = Vec::new();
+    let mut in_code_block = false;
+
+    for raw_line in source.lines() {
+        let line = raw_line.trim_end_matches('\r');
+        let trimmed = line.trim();
+
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+
+        if in_code_block {
+            lines.push(PreviewLine::from_text(PreviewLineKind::CodeBlock, line));
+            continue;
+        }
+
+        if trimmed.is_empty() {
+            lines.push(PreviewLine::from_text(PreviewLineKind::Blank, ""));
+            continue;
+        }
+
+        if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+            lines.push(PreviewLine::from_text(PreviewLineKind::Rule, ""));
+            continue;
+        }
+
+        if let Some((level, text)) = parse_heading(trimmed) {
+            lines.push(PreviewLine::from_spans(
+                PreviewLineKind::Heading(level),
+                parse_inline(text),
+            ));
+            continue;
+        }
+
+        if let Some(text) = trimmed.strip_prefix('>') {
+            lines.push(PreviewLine::from_spans(
+                PreviewLineKind::Quote,
+                parse_inline(text.trim_start()),
+            ));
+            continue;
+        }
+
+        if let Some(text) = parse_task_item(trimmed) {
+            lines.push(PreviewLine::from_spans(
+                PreviewLineKind::ListItem,
+                parse_inline(&text),
+            ));
+            continue;
+        }
+
+        if let Some(text) = parse_unordered_item(trimmed) {
+            lines.push(PreviewLine::from_spans(
+                PreviewLineKind::ListItem,
+                parse_inline(&text),
+            ));
+            continue;
+        }
+
+        if let Some(text) = parse_ordered_item(trimmed) {
+            lines.push(PreviewLine::from_spans(
+                PreviewLineKind::ListItem,
+                parse_inline(&text),
+            ));
+            continue;
+        }
+
+        lines.push(PreviewLine::from_spans(
+            PreviewLineKind::Paragraph,
+            parse_inline(line),
+        ));
+    }
+
+    MarkdownPreview { lines }
+}
+
+fn parse_heading(line: &str) -> Option<(u8, &str)> {
+    let level = line.chars().take_while(|ch| *ch == '#').count();
+    if level == 0 || level > 6 {
+        return None;
+    }
+
+    let rest = line.get(level..)?.trim_start();
+    Some((level as u8, rest))
+}
+
+fn parse_task_item(line: &str) -> Option<String> {
+    for (prefix, marker) in [("- [x] ", "☑ "), ("- [X] ", "☑ "), ("- [ ] ", "☐ ")] {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            return Some(format!("{marker}{rest}"));
+        }
+    }
+    None
+}
+
+fn parse_unordered_item(line: &str) -> Option<String> {
+    for prefix in ["- ", "* ", "+ "] {
+        if let Some(rest) = line.strip_prefix(prefix) {
+            return Some(format!("• {rest}"));
+        }
+    }
+    None
+}
+
+fn parse_ordered_item(line: &str) -> Option<String> {
+    let dot = line.find(". ")?;
+    let (number, rest) = line.split_at(dot);
+    if number.chars().all(|ch| ch.is_ascii_digit()) {
+        Some(format!("{}. {}", number, &rest[2..]))
+    } else {
+        None
+    }
+}
+
+fn parse_inline(text: &str) -> Vec<PreviewSpan> {
+    let mut spans = Vec::new();
+    let mut chars = text.chars().peekable();
+    let mut plain = String::new();
+
+    while let Some(ch) = chars.next() {
+        match ch {
+            '`' => {
+                flush_plain(&mut spans, &mut plain);
+                let mut code = String::new();
+                while let Some(next) = chars.next() {
+                    if next == '`' {
+                        break;
+                    }
+                    code.push(next);
+                }
+                spans.push(PreviewSpan {
+                    text: code,
+                    style: PreviewSpanStyle::InlineCode,
+                });
+            }
+            '*' if chars.peek() == Some(&'*') => {
+                chars.next();
+                flush_plain(&mut spans, &mut plain);
+                let mut strong = String::new();
+                while let Some(next) = chars.next() {
+                    if next == '*' && chars.peek() == Some(&'*') {
+                        chars.next();
+                        break;
+                    }
+                    strong.push(next);
+                }
+                spans.push(PreviewSpan {
+                    text: strong,
+                    style: PreviewSpanStyle::Strong,
+                });
+            }
+            '*' => {
+                flush_plain(&mut spans, &mut plain);
+                let mut emphasis = String::new();
+                while let Some(next) = chars.next() {
+                    if next == '*' {
+                        break;
+                    }
+                    emphasis.push(next);
+                }
+                spans.push(PreviewSpan {
+                    text: emphasis,
+                    style: PreviewSpanStyle::Emphasis,
+                });
+            }
+            '[' => {
+                flush_plain(&mut spans, &mut plain);
+                let mut label = String::new();
+                while let Some(next) = chars.next() {
+                    if next == ']' {
+                        break;
+                    }
+                    label.push(next);
+                }
+                if chars.next() == Some('(') {
+                    while let Some(next) = chars.next() {
+                        if next == ')' {
+                            break;
+                        }
+                    }
+                    spans.push(PreviewSpan {
+                        text: label,
+                        style: PreviewSpanStyle::Link,
+                    });
+                } else {
+                    plain.push('[');
+                    plain.push_str(&label);
+                }
+            }
+            _ => plain.push(ch),
+        }
+    }
+
+    flush_plain(&mut spans, &mut plain);
+    spans
+}
+
+fn flush_plain(spans: &mut Vec<PreviewSpan>, plain: &mut String) {
+    if !plain.is_empty() {
+        spans.push(PreviewSpan::plain(std::mem::take(plain)));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renders_common_block_markdown_into_readable_lines() {
+        let preview = render_markdown(
+            "# Title\n\n> note\n\n- first\n1. second\n- [x] done\n\n---\n\n```rust\nfn main() {}\n```",
+        );
+
+        assert_eq!(preview.lines[0].kind, PreviewLineKind::Heading(1));
+        assert_eq!(preview.lines[0].plain_text(), "Title");
+        assert_eq!(preview.lines[2].kind, PreviewLineKind::Quote);
+        assert_eq!(preview.lines[4].plain_text(), "• first");
+        assert_eq!(preview.lines[5].plain_text(), "1. second");
+        assert_eq!(preview.lines[6].plain_text(), "☑ done");
+        assert_eq!(preview.lines[8].kind, PreviewLineKind::Rule);
+        assert_eq!(preview.lines[10].kind, PreviewLineKind::CodeBlock);
+        assert_eq!(preview.lines[10].plain_text(), "fn main() {}");
+    }
+
+    #[test]
+    fn renders_inline_markup_as_styled_spans() {
+        let preview =
+            render_markdown("Read **bold**, *soft*, `code`, and [docs](https://example.com).");
+        let spans = &preview.lines[0].spans;
+
+        assert!(spans
+            .iter()
+            .any(|span| span.text == "bold" && span.style == PreviewSpanStyle::Strong));
+        assert!(spans
+            .iter()
+            .any(|span| span.text == "soft" && span.style == PreviewSpanStyle::Emphasis));
+        assert!(spans
+            .iter()
+            .any(|span| span.text == "code" && span.style == PreviewSpanStyle::InlineCode));
+        assert!(spans
+            .iter()
+            .any(|span| span.text == "docs" && span.style == PreviewSpanStyle::Link));
+    }
+
+    #[test]
+    fn empty_documents_render_a_placeholder_line() {
+        let preview = render_markdown("");
+
+        assert_eq!(preview.lines.len(), 1);
+        assert_eq!(preview.lines[0].plain_text(), "Nothing to preview yet.");
+        assert_eq!(preview.lines[0].kind, PreviewLineKind::Placeholder);
+    }
+
+    #[test]
+    fn unsupported_markdown_stays_readable_instead_of_failing() {
+        let preview = render_markdown("| a | b |\n|---|---|");
+
+        assert_eq!(preview.lines[0].plain_text(), "| a | b |");
+        assert_eq!(preview.lines[1].plain_text(), "|---|---|");
+    }
+
+    #[test]
+    fn large_documents_render_without_special_cases_or_extra_dependencies() {
+        let source = "# Heading\n\nparagraph\n".repeat(10_000);
+        let preview = render_markdown(&source);
+
+        assert_eq!(preview.lines.len(), 30_000);
+        assert_eq!(preview.lines[0].plain_text(), "Heading");
+    }
+}

--- a/src/markdown_preview.rs
+++ b/src/markdown_preview.rs
@@ -65,20 +65,48 @@ pub struct MarkdownPreview {
 #[derive(Debug, Clone)]
 pub struct MarkdownPreviewState {
     pub lines: Vec<PreviewLine>,
+    display_lines: Vec<PreviewLine>,
     pub scroll: usize,
+    wrap_width: usize,
 }
 
 impl MarkdownPreviewState {
-    pub fn new(preview: MarkdownPreview) -> Self {
+    pub fn new(preview: MarkdownPreview, width: usize) -> Self {
+        let display_lines = wrap_preview_lines(&preview.lines, width);
         Self {
             lines: preview.lines,
+            display_lines,
             scroll: 0,
+            wrap_width: width,
         }
     }
 
-    pub fn max_scroll(&self, visible_rows: usize) -> usize {
-        self.lines.len().saturating_sub(visible_rows)
+    pub fn display_lines(&self) -> &[PreviewLine] {
+        &self.display_lines
     }
+
+    pub fn max_scroll(&self, visible_rows: usize) -> usize {
+        self.display_lines.len().saturating_sub(visible_rows)
+    }
+
+    pub fn reflow(&mut self, width: usize) {
+        if self.wrap_width == width {
+            return;
+        }
+
+        self.display_lines = wrap_preview_lines(&self.lines, width);
+        self.wrap_width = width;
+    }
+}
+
+pub fn preview_popup_width(term_width: u16) -> u16 {
+    let preferred_width = term_width.saturating_mul(9) / 10;
+    let max_width = term_width.saturating_sub(4);
+    preferred_width.min(max_width).max(term_width.min(20))
+}
+
+pub fn preview_content_width(term_width: u16) -> usize {
+    preview_popup_width(term_width).saturating_sub(2) as usize
 }
 
 pub fn render_markdown(source: &str) -> MarkdownPreview {
@@ -294,6 +322,153 @@ fn flush_plain(spans: &mut Vec<PreviewSpan>, plain: &mut String) {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct StyledChar {
+    ch: char,
+    style: PreviewSpanStyle,
+}
+
+pub fn wrap_preview_lines(lines: &[PreviewLine], width: usize) -> Vec<PreviewLine> {
+    lines
+        .iter()
+        .flat_map(|line| wrap_preview_line(line, width))
+        .collect()
+}
+
+fn wrap_preview_line(line: &PreviewLine, width: usize) -> Vec<PreviewLine> {
+    use unicode_width::UnicodeWidthChar;
+
+    if width == 0
+        || matches!(
+            line.kind,
+            PreviewLineKind::Blank | PreviewLineKind::Rule | PreviewLineKind::CodeBlock
+        )
+    {
+        return vec![line.clone()];
+    }
+
+    let mut remaining = styled_chars(line);
+    if remaining.is_empty() {
+        return vec![line.clone()];
+    }
+
+    let continuation_indent = continuation_indent(line);
+    let continuation_width = continuation_indent.chars().count().min(width);
+    let continuation_prefix = vec![
+        StyledChar {
+            ch: ' ',
+            style: PreviewSpanStyle::Plain,
+        };
+        continuation_width
+    ];
+
+    let mut wrapped = Vec::new();
+    let mut first_row = true;
+
+    while !remaining.is_empty() {
+        let prefix = if first_row {
+            Vec::new()
+        } else {
+            continuation_prefix.clone()
+        };
+        let prefix_width = prefix
+            .iter()
+            .map(|styled| UnicodeWidthChar::width(styled.ch).unwrap_or(0))
+            .sum::<usize>();
+        let available_width = width.saturating_sub(prefix_width).max(1);
+
+        let mut consumed_width = 0usize;
+        let mut fit_count = 0usize;
+        let mut last_whitespace = None;
+
+        for (idx, styled) in remaining.iter().enumerate() {
+            let char_width = UnicodeWidthChar::width(styled.ch).unwrap_or(0);
+            if consumed_width.saturating_add(char_width) > available_width {
+                break;
+            }
+
+            consumed_width += char_width;
+            fit_count = idx + 1;
+            if styled.ch.is_whitespace() {
+                last_whitespace = Some(idx);
+            }
+        }
+
+        let (line_count, mut consume_count) = if fit_count == remaining.len() {
+            (fit_count, fit_count)
+        } else if let Some(last_whitespace) = last_whitespace.filter(|idx| *idx > 0) {
+            (last_whitespace, last_whitespace + 1)
+        } else {
+            let forced = fit_count.max(1);
+            (forced, forced)
+        };
+
+        while consume_count < remaining.len() && remaining[consume_count].ch.is_whitespace() {
+            consume_count += 1;
+        }
+
+        let mut row = prefix;
+        row.extend_from_slice(&remaining[..line_count]);
+        wrapped.push(PreviewLine::from_spans(
+            line.kind,
+            spans_from_styled_chars(row),
+        ));
+
+        remaining.drain(..consume_count);
+        first_row = false;
+    }
+
+    wrapped
+}
+
+fn continuation_indent(line: &PreviewLine) -> String {
+    match line.kind {
+        PreviewLineKind::ListItem => {
+            let text = line.plain_text();
+            let indent = text
+                .chars()
+                .position(|ch| ch == ' ')
+                .map(|idx| idx + 1)
+                .unwrap_or(2);
+            " ".repeat(indent)
+        }
+        PreviewLineKind::Quote => "  ".to_string(),
+        _ => String::new(),
+    }
+}
+
+fn styled_chars(line: &PreviewLine) -> Vec<StyledChar> {
+    line.spans
+        .iter()
+        .flat_map(|span| {
+            span.text.chars().map(move |ch| StyledChar {
+                ch,
+                style: span.style,
+            })
+        })
+        .collect()
+}
+
+fn spans_from_styled_chars(chars: Vec<StyledChar>) -> Vec<PreviewSpan> {
+    let mut spans: Vec<PreviewSpan> = Vec::new();
+
+    for styled in chars {
+        if let Some(last) = spans.last_mut() {
+            if last.style == styled.style {
+                last.text.push(styled.ch);
+                continue;
+            }
+        }
+
+        spans.push(PreviewSpan {
+            text: styled.ch.to_string(),
+            style: styled.style,
+        });
+    }
+
+    spans
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,6 +525,44 @@ mod tests {
 
         assert_eq!(preview.lines[0].plain_text(), "| a | b |");
         assert_eq!(preview.lines[1].plain_text(), "|---|---|");
+    }
+
+    #[test]
+    fn wraps_prose_at_word_boundaries_for_the_preview_width() {
+        let preview = render_markdown("alpha beta gamma delta");
+        let wrapped = wrap_preview_lines(&preview.lines, 12);
+        let text: Vec<_> = wrapped.iter().map(PreviewLine::plain_text).collect();
+
+        assert_eq!(text, vec!["alpha beta", "gamma delta"]);
+    }
+
+    #[test]
+    fn wraps_list_continuations_with_indent_but_keeps_code_blocks_unwrapped() {
+        let preview = render_markdown("- alpha beta gamma\n\n```txt\nalpha beta gamma\n```");
+        let wrapped = wrap_preview_lines(&preview.lines, 10);
+        let text: Vec<_> = wrapped.iter().map(PreviewLine::plain_text).collect();
+
+        assert_eq!(
+            text,
+            vec!["• alpha", "  beta", "  gamma", "", "alpha beta gamma"]
+        );
+    }
+
+    #[test]
+    fn wrapped_rows_drive_scroll_limits() {
+        let preview = MarkdownPreviewState::new(render_markdown("alpha beta gamma"), 10);
+
+        assert_eq!(preview.max_scroll(1), 1);
+        assert_eq!(preview.max_scroll(2), 0);
+    }
+
+    #[test]
+    fn reflows_cached_rows_when_the_preview_width_changes() {
+        let mut preview = MarkdownPreviewState::new(render_markdown("alpha beta gamma"), 20);
+        assert_eq!(preview.display_lines().len(), 1);
+
+        preview.reflow(10);
+        assert_eq!(preview.display_lines().len(), 2);
     }
 
     #[test]

--- a/src/markdown_preview.rs
+++ b/src/markdown_preview.rs
@@ -62,6 +62,25 @@ pub struct MarkdownPreview {
     pub lines: Vec<PreviewLine>,
 }
 
+#[derive(Debug, Clone)]
+pub struct MarkdownPreviewState {
+    pub lines: Vec<PreviewLine>,
+    pub scroll: usize,
+}
+
+impl MarkdownPreviewState {
+    pub fn new(preview: MarkdownPreview) -> Self {
+        Self {
+            lines: preview.lines,
+            scroll: 0,
+        }
+    }
+
+    pub fn max_scroll(&self, visible_rows: usize) -> usize {
+        self.lines.len().saturating_sub(visible_rows)
+    }
+}
+
 pub fn render_markdown(source: &str) -> MarkdownPreview {
     if source.trim().is_empty() {
         return MarkdownPreview {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3656,8 +3656,11 @@ impl Terminal {
     }
 
     fn markdown_preview_rect(editor: &Editor) -> crate::editor::Rect {
-        let max_width = editor.term_width.saturating_sub(4).min(100);
-        let width = max_width.max(editor.term_width.min(20));
+        let preferred_width = editor.term_width.saturating_mul(9) / 10;
+        let max_width = editor.term_width.saturating_sub(4);
+        let width = preferred_width
+            .min(max_width)
+            .max(editor.term_width.min(20));
         let max_height = editor.term_height.saturating_sub(4);
         let height = max_height.max(editor.term_height.min(5));
 
@@ -3674,7 +3677,7 @@ impl Terminal {
     }
 
     fn should_capture_mouse(editor: &Editor) -> bool {
-        editor.floating_terminal.is_visible() || editor.markdown_preview.is_some()
+        editor.floating_terminal.is_visible()
     }
 
     fn should_skip_background(editor: &Editor) -> bool {
@@ -5973,36 +5976,6 @@ fn handle_markdown_preview_key(editor: &mut Editor, key: KeyEvent) {
             editor.scroll_markdown_preview(-half_page, visible_rows)
         }
         _ => {}
-    }
-}
-
-pub fn handle_markdown_preview_mouse(editor: &mut Editor, mouse: MouseEvent) -> bool {
-    use crossterm::event::MouseEventKind;
-
-    if editor.markdown_preview.is_none() {
-        return false;
-    }
-
-    let rect = Terminal::markdown_preview_rect(editor);
-    let inside_preview = mouse.column >= rect.x
-        && mouse.column < rect.x.saturating_add(rect.width)
-        && mouse.row >= rect.y
-        && mouse.row < rect.y.saturating_add(rect.height);
-    if !inside_preview {
-        return false;
-    }
-
-    let visible_rows = Terminal::markdown_preview_visible_rows(editor).max(1);
-    match mouse.kind {
-        MouseEventKind::ScrollUp => {
-            editor.scroll_markdown_preview(-3, visible_rows);
-            true
-        }
-        MouseEventKind::ScrollDown => {
-            editor.scroll_markdown_preview(3, visible_rows);
-            true
-        }
-        _ => false,
     }
 }
 
@@ -9160,15 +9133,15 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 mod tests {
     use super::{
         apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        finder_preview_match_ranges, handle_insert_mode, handle_key,
-        handle_markdown_preview_mouse, replace_completion_text, Terminal,
+        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
+        Terminal,
     };
     use crate::commands::Command;
     use crate::config::{KeymapEntry, Settings};
     use crate::editor::{Editor, Mode, RegisterContent};
     use crate::input::Motion;
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use crossterm::style::Color;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -9371,15 +9344,15 @@ mod tests {
     }
 
     #[test]
-    fn markdown_preview_rect_is_centered_and_sized_for_reading() {
+    fn markdown_preview_rect_uses_ninety_percent_width_for_reading() {
         let mut editor = Editor::default();
         editor.set_size(140, 50);
 
         let rect = Terminal::markdown_preview_rect(&editor);
 
-        assert_eq!(rect.width, 100);
+        assert_eq!(rect.width, 126);
         assert_eq!(rect.height, 46);
-        assert_eq!(rect.x, 20);
+        assert_eq!(rect.x, 7);
         assert_eq!(rect.y, 2);
     }
 
@@ -9411,7 +9384,7 @@ mod tests {
     }
 
     #[test]
-    fn markdown_preview_mouse_capture_is_enabled_while_overlay_is_open() {
+    fn markdown_preview_does_not_capture_mouse_while_overlay_is_open() {
         let tmp = unique_temp_dir("nevi_markdown_preview_mouse_capture");
         std::fs::create_dir_all(&tmp).expect("create temp dir");
         let markdown_path = tmp.join("notes.md");
@@ -9422,50 +9395,10 @@ mod tests {
         assert!(!Terminal::should_capture_mouse(&editor));
 
         editor.open_markdown_preview().expect("open preview");
-        assert!(Terminal::should_capture_mouse(&editor));
+        assert!(!Terminal::should_capture_mouse(&editor));
 
         editor.close_markdown_preview();
         assert!(!Terminal::should_capture_mouse(&editor));
-
-        let _ = std::fs::remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn markdown_preview_mouse_wheel_scrolls_only_inside_the_overlay() {
-        let tmp = unique_temp_dir("nevi_markdown_preview_mouse_wheel");
-        std::fs::create_dir_all(&tmp).expect("create temp dir");
-        let markdown_path = tmp.join("notes.md");
-        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
-
-        let mut editor = Editor::default();
-        editor.set_size(120, 40);
-        editor.open_file(markdown_path).expect("open markdown");
-        editor.replace_buffer_content(&(0..40).map(|i| format!("line {i}\n")).collect::<String>());
-        editor.open_markdown_preview().expect("open preview");
-
-        let rect = Terminal::markdown_preview_rect(&editor);
-        let inside = MouseEvent {
-            kind: crossterm::event::MouseEventKind::ScrollDown,
-            column: rect.x + 1,
-            row: rect.y + 1,
-            modifiers: KeyModifiers::NONE,
-        };
-        let outside = MouseEvent {
-            kind: crossterm::event::MouseEventKind::ScrollDown,
-            column: 0,
-            row: 0,
-            modifiers: KeyModifiers::NONE,
-        };
-
-        assert!(handle_markdown_preview_mouse(&mut editor, inside));
-        assert!(editor.markdown_preview.as_ref().unwrap().scroll > 0);
-
-        let scroll_after_inside = editor.markdown_preview.as_ref().unwrap().scroll;
-        assert!(!handle_markdown_preview_mouse(&mut editor, outside));
-        assert_eq!(
-            editor.markdown_preview.as_ref().unwrap().scroll,
-            scroll_after_inside
-        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3656,11 +3656,7 @@ impl Terminal {
     }
 
     fn markdown_preview_rect(editor: &Editor) -> crate::editor::Rect {
-        let preferred_width = editor.term_width.saturating_mul(9) / 10;
-        let max_width = editor.term_width.saturating_sub(4);
-        let width = preferred_width
-            .min(max_width)
-            .max(editor.term_width.min(20));
+        let width = crate::markdown_preview::preview_popup_width(editor.term_width);
         let max_height = editor.term_height.saturating_sub(4);
         let height = max_height.max(editor.term_height.min(5));
 
@@ -3826,6 +3822,10 @@ impl Terminal {
         let rect = Self::markdown_preview_rect(editor);
         let visible_rows = rect.height.saturating_sub(3) as usize;
         let inner_width = rect.width.saturating_sub(2) as usize;
+        let display_lines = preview.display_lines();
+        let scroll = preview
+            .scroll
+            .min(display_lines.len().saturating_sub(visible_rows));
         let theme = editor.theme();
 
         execute!(
@@ -3857,7 +3857,7 @@ impl Terminal {
             )?;
             print!("│");
 
-            if let Some(line) = preview.lines.get(preview.scroll + row) {
+            if let Some(line) = display_lines.get(scroll + row) {
                 Self::render_markdown_preview_line(&mut self.stdout, line, inner_width, editor)?;
             } else {
                 print!("{:width$}", "", width = inner_width);

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8552,6 +8552,11 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
+        Command::MarkdownPreview => match editor.open_markdown_preview() {
+            Ok(()) => CommandResult::Ok,
+            Err(message) => CommandResult::Message(message.to_string()),
+        },
+
         Command::NoHighlight => {
             editor.search_matches.clear();
             CommandResult::Ok
@@ -9080,6 +9085,32 @@ mod tests {
         assert!(rendered.contains("\x1b[24m"));
         assert!(rendered.contains("\x1b[59m"));
         assert!(rendered.ends_with("\x1b[38;2;198;120;221m"));
+    }
+
+    #[test]
+    fn markdown_preview_command_opens_only_for_markdown_buffers() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_command");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        let rust_path = tmp.join("main.rs");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+        std::fs::write(&rust_path, "fn main() {}\n").expect("write rust");
+
+        let mut markdown = Editor::default();
+        markdown.open_file(markdown_path).expect("open markdown");
+        execute_command(&mut markdown, Command::MarkdownPreview);
+        assert!(markdown.markdown_preview.is_some());
+
+        let mut rust = Editor::default();
+        rust.open_file(rust_path).expect("open rust");
+        execute_command(&mut rust, Command::MarkdownPreview);
+        assert!(rust.markdown_preview.is_none());
+        assert_eq!(
+            rust.status_message.as_deref(),
+            Some("Markdown preview is only available for Markdown buffers")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -597,9 +597,9 @@ impl Terminal {
         self.set_mouse_capture(Self::should_capture_mouse(editor))?;
         execute!(self.stdout, cursor::MoveTo(0, 0))?;
 
-        // Skip rendering background when finder is open - it's a large overlay
-        // that covers most of the screen, so rendering underneath is wasted work
-        let skip_background = editor.mode == Mode::Finder;
+        // Large overlays fully cover the content area, so repainting the editor
+        // behind them only wastes work and can flash between redraw phases.
+        let skip_background = Self::should_skip_background(editor);
 
         if !skip_background {
             let num_panes = editor.panes().len();
@@ -3675,6 +3675,10 @@ impl Terminal {
 
     fn should_capture_mouse(editor: &Editor) -> bool {
         editor.floating_terminal.is_visible() || editor.markdown_preview.is_some()
+    }
+
+    fn should_skip_background(editor: &Editor) -> bool {
+        editor.mode == Mode::Finder || editor.markdown_preview.is_some()
     }
 
     /// Render the diagnostic floating popup (like vim.diagnostic.open_float())
@@ -9462,6 +9466,23 @@ mod tests {
             editor.markdown_preview.as_ref().unwrap().scroll,
             scroll_after_inside
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_skips_background_redraw_while_overlay_is_open() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_skip_background");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.open_file(markdown_path).expect("open markdown");
+        assert!(!Terminal::should_skip_background(&editor));
+
+        editor.open_markdown_preview().expect("open preview");
+        assert!(Terminal::should_skip_background(&editor));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3672,6 +3672,22 @@ impl Terminal {
         Self::markdown_preview_rect(editor).height.saturating_sub(3) as usize
     }
 
+    fn markdown_preview_footer(scroll: usize, total_rows: usize, visible_rows: usize) -> String {
+        let position = if total_rows == 0 {
+            "0/0".to_string()
+        } else {
+            let start = scroll.saturating_add(1).min(total_rows);
+            let end = scroll.saturating_add(visible_rows).min(total_rows).max(start);
+            if start == end {
+                format!("{start}/{total_rows}")
+            } else {
+                format!("{start}-{end}/{total_rows}")
+            }
+        };
+
+        format!(" j/k scroll • Ctrl-d/u page • g/G top/bottom • {position} • q close ")
+    }
+
     fn should_capture_mouse(editor: &Editor) -> bool {
         editor.floating_terminal.is_visible()
     }
@@ -3878,7 +3894,8 @@ impl Terminal {
             SetBackgroundColor(theme.ui.popup_bg)
         )?;
         print!("│");
-        let footer = " j/k scroll • Ctrl-d/u page • q close ";
+        let footer = Self::markdown_preview_footer(scroll, display_lines.len(), visible_rows);
+        let footer = take_display_width(&footer, 0, inner_width, editor.settings.editor.tab_width);
         print!("{:^width$}", footer, width = inner_width);
         execute!(self.stdout, SetForegroundColor(theme.ui.popup_border))?;
         print!("│");
@@ -5974,6 +5991,10 @@ fn handle_markdown_preview_key(editor: &mut Editor, key: KeyEvent) {
         }
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
             editor.scroll_markdown_preview(-half_page, visible_rows)
+        }
+        (KeyModifiers::NONE, KeyCode::Char('g')) => editor.jump_markdown_preview_to_top(),
+        (KeyModifiers::SHIFT, KeyCode::Char('G')) | (KeyModifiers::NONE, KeyCode::Char('G')) => {
+            editor.jump_markdown_preview_to_bottom(visible_rows)
         }
         _ => {}
     }
@@ -9381,6 +9402,46 @@ mod tests {
         assert!(editor.markdown_preview.is_none());
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_keys_jump_to_top_and_bottom() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_jump_keys");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.set_size(80, 20);
+        editor.open_file(markdown_path).expect("open markdown");
+        editor.replace_buffer_content(&(0..50).map(|i| format!("line {i}\n")).collect::<String>());
+        editor.open_markdown_preview().expect("open preview");
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        let visible_rows = Terminal::markdown_preview_visible_rows(&editor).max(1);
+        let max_scroll = editor
+            .markdown_preview
+            .as_ref()
+            .unwrap()
+            .max_scroll(visible_rows);
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, max_scroll);
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_footer_includes_position_and_jump_hint() {
+        assert_eq!(
+            Terminal::markdown_preview_footer(12, 42, 10),
+            " j/k scroll • Ctrl-d/u page • g/G top/bottom • 13-22/42 • q close "
+        );
+        assert_eq!(
+            Terminal::markdown_preview_footer(0, 1, 10),
+            " j/k scroll • Ctrl-d/u page • g/G top/bottom • 1/1 • q close "
+        );
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -665,6 +665,11 @@ impl Terminal {
             self.render_code_actions_picker(editor)?;
         }
 
+        // Render Markdown preview if active
+        if editor.markdown_preview.is_some() {
+            self.render_markdown_preview(editor)?;
+        }
+
         // Render theme picker if active
         if editor.theme_picker.is_some() {
             self.render_theme_picker(editor)?;
@@ -673,6 +678,8 @@ impl Terminal {
         // Position cursor
         if editor.floating_terminal.is_visible() {
             self.render_floating_terminal(editor)?;
+        } else if editor.markdown_preview.is_some() {
+            execute!(self.stdout, cursor::Hide)?;
         } else {
             self.position_cursor(editor)?;
         }
@@ -3648,6 +3655,24 @@ impl Terminal {
         (popup_x, popup_y)
     }
 
+    fn markdown_preview_rect(editor: &Editor) -> crate::editor::Rect {
+        let max_width = editor.term_width.saturating_sub(4).min(100);
+        let width = max_width.max(editor.term_width.min(20));
+        let max_height = editor.term_height.saturating_sub(4);
+        let height = max_height.max(editor.term_height.min(5));
+
+        crate::editor::Rect::new(
+            (editor.term_width.saturating_sub(width)) / 2,
+            (editor.term_height.saturating_sub(height)) / 2,
+            width,
+            height,
+        )
+    }
+
+    fn markdown_preview_visible_rows(editor: &Editor) -> usize {
+        Self::markdown_preview_rect(editor).height.saturating_sub(3) as usize
+    }
+
     /// Render the diagnostic floating popup (like vim.diagnostic.open_float())
     fn render_diagnostic_float(&mut self, editor: &Editor) -> anyhow::Result<()> {
         let diagnostics = editor.diagnostics_for_line(editor.cursor.line);
@@ -3779,6 +3804,170 @@ impl Terminal {
         print!("╯");
 
         execute!(self.stdout, ResetColor)?;
+        Ok(())
+    }
+
+    fn render_markdown_preview(&mut self, editor: &Editor) -> anyhow::Result<()> {
+        let Some(preview) = &editor.markdown_preview else {
+            return Ok(());
+        };
+
+        let rect = Self::markdown_preview_rect(editor);
+        let visible_rows = rect.height.saturating_sub(3) as usize;
+        let inner_width = rect.width.saturating_sub(2) as usize;
+        let theme = editor.theme();
+
+        execute!(
+            self.stdout,
+            SetForegroundColor(theme.ui.popup_border),
+            SetBackgroundColor(theme.ui.popup_bg),
+            cursor::MoveTo(rect.x, rect.y)
+        )?;
+        print!("╭");
+        let title = " Markdown Preview ";
+        let title_start = (rect.width as usize).saturating_sub(title.len()) / 2;
+        for i in 1..rect.width.saturating_sub(1) {
+            if i as usize == title_start {
+                print!("{title}");
+            } else if i as usize > title_start && (i as usize) < title_start + title.len() {
+                continue;
+            } else {
+                print!("─");
+            }
+        }
+        print!("╮");
+
+        for row in 0..visible_rows {
+            execute!(
+                self.stdout,
+                cursor::MoveTo(rect.x, rect.y + 1 + row as u16),
+                SetForegroundColor(theme.ui.popup_border),
+                SetBackgroundColor(theme.ui.popup_bg)
+            )?;
+            print!("│");
+
+            if let Some(line) = preview.lines.get(preview.scroll + row) {
+                Self::render_markdown_preview_line(&mut self.stdout, line, inner_width, editor)?;
+            } else {
+                print!("{:width$}", "", width = inner_width);
+            }
+
+            execute!(
+                self.stdout,
+                SetForegroundColor(theme.ui.popup_border),
+                SetBackgroundColor(theme.ui.popup_bg)
+            )?;
+            print!("│");
+        }
+
+        execute!(
+            self.stdout,
+            cursor::MoveTo(rect.x, rect.y + rect.height.saturating_sub(2)),
+            SetForegroundColor(theme.ui.line_number),
+            SetBackgroundColor(theme.ui.popup_bg)
+        )?;
+        print!("│");
+        let footer = " j/k scroll • Ctrl-d/u page • q close ";
+        print!("{:^width$}", footer, width = inner_width);
+        execute!(self.stdout, SetForegroundColor(theme.ui.popup_border))?;
+        print!("│");
+
+        execute!(
+            self.stdout,
+            cursor::MoveTo(rect.x, rect.y + rect.height.saturating_sub(1)),
+            SetForegroundColor(theme.ui.popup_border),
+            SetBackgroundColor(theme.ui.popup_bg)
+        )?;
+        print!("╰");
+        for _ in 1..rect.width.saturating_sub(1) {
+            print!("─");
+        }
+        print!("╯");
+
+        execute!(self.stdout, ResetColor)?;
+        Ok(())
+    }
+
+    fn render_markdown_preview_line<W: Write>(
+        output: &mut W,
+        line: &crate::markdown_preview::PreviewLine,
+        width: usize,
+        editor: &Editor,
+    ) -> anyhow::Result<()> {
+        use crate::markdown_preview::{PreviewLineKind, PreviewSpanStyle};
+
+        let theme = editor.theme();
+        let mut written = 0usize;
+
+        if line.kind == PreviewLineKind::Rule {
+            execute!(output, SetForegroundColor(theme.ui.line_number))?;
+            write!(output, "{}", "─".repeat(width))?;
+            return Ok(());
+        }
+
+        for span in &line.spans {
+            let remaining = width.saturating_sub(written);
+            if remaining == 0 {
+                break;
+            }
+            let display: String = span.text.chars().take(remaining).collect();
+            let char_count = display.chars().count();
+
+            match span.style {
+                PreviewSpanStyle::Plain => {
+                    let fg = match line.kind {
+                        PreviewLineKind::Heading(_) => theme.syntax.function.fg,
+                        PreviewLineKind::Quote => theme.syntax.comment.fg,
+                        PreviewLineKind::CodeBlock => theme.syntax.string.fg,
+                        PreviewLineKind::Placeholder => theme.ui.line_number,
+                        _ => theme.ui.foreground,
+                    };
+                    execute!(
+                        output,
+                        SetForegroundColor(fg),
+                        SetAttribute(Attribute::Reset)
+                    )?;
+                }
+                PreviewSpanStyle::Emphasis => {
+                    execute!(
+                        output,
+                        SetForegroundColor(theme.ui.foreground),
+                        SetAttribute(Attribute::Italic)
+                    )?;
+                }
+                PreviewSpanStyle::Strong => {
+                    execute!(
+                        output,
+                        SetForegroundColor(theme.ui.foreground),
+                        SetAttribute(Attribute::Bold)
+                    )?;
+                }
+                PreviewSpanStyle::InlineCode => {
+                    execute!(
+                        output,
+                        SetForegroundColor(theme.syntax.string.fg),
+                        SetAttribute(Attribute::Reset)
+                    )?;
+                }
+                PreviewSpanStyle::Link => {
+                    execute!(
+                        output,
+                        SetForegroundColor(theme.syntax.function.fg),
+                        SetAttribute(Attribute::Underlined)
+                    )?;
+                }
+            }
+
+            write!(output, "{display}")?;
+            written += char_count;
+        }
+
+        execute!(
+            output,
+            SetAttribute(Attribute::Reset),
+            SetForegroundColor(theme.ui.foreground)
+        )?;
+        write!(output, "{:width$}", "", width = width.saturating_sub(written))?;
         Ok(())
     }
 
@@ -5755,6 +5944,30 @@ fn handle_theme_picker_key(editor: &mut Editor, key: KeyEvent) {
     }
 }
 
+fn handle_markdown_preview_key(editor: &mut Editor, key: KeyEvent) {
+    let visible_rows = Terminal::markdown_preview_visible_rows(editor).max(1);
+    let half_page = (visible_rows / 2).max(1) as isize;
+
+    match (key.modifiers, key.code) {
+        (KeyModifiers::NONE, KeyCode::Esc)
+        | (KeyModifiers::NONE, KeyCode::Char('q'))
+        | (KeyModifiers::CONTROL, KeyCode::Char('[')) => editor.close_markdown_preview(),
+        (KeyModifiers::NONE, KeyCode::Char('j')) | (KeyModifiers::NONE, KeyCode::Down) => {
+            editor.scroll_markdown_preview(1, visible_rows)
+        }
+        (KeyModifiers::NONE, KeyCode::Char('k')) | (KeyModifiers::NONE, KeyCode::Up) => {
+            editor.scroll_markdown_preview(-1, visible_rows)
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+            editor.scroll_markdown_preview(half_page, visible_rows)
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            editor.scroll_markdown_preview(-half_page, visible_rows)
+        }
+        _ => {}
+    }
+}
+
 /// Play a macro from a register
 fn play_macro(editor: &mut Editor, register: char, count: usize) {
     // Get the macro keys (clone to avoid borrow issues)
@@ -5814,6 +6027,12 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
 
         // Terminal apps need Escape; Ctrl-\ is the dedicated toggle key.
         editor.floating_terminal.send_key(key);
+        return;
+    }
+
+    // If Markdown preview is visible, it owns input until closed.
+    if editor.markdown_preview.is_some() {
+        handle_markdown_preview_key(editor, key);
         return;
     }
 
@@ -9109,6 +9328,46 @@ mod tests {
             rust.status_message.as_deref(),
             Some("Markdown preview is only available for Markdown buffers")
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_rect_is_centered_and_sized_for_reading() {
+        let mut editor = Editor::default();
+        editor.set_size(140, 50);
+
+        let rect = Terminal::markdown_preview_rect(&editor);
+
+        assert_eq!(rect.width, 100);
+        assert_eq!(rect.height, 46);
+        assert_eq!(rect.x, 20);
+        assert_eq!(rect.y, 2);
+    }
+
+    #[test]
+    fn markdown_preview_keys_scroll_and_close_the_overlay() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_keys");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.open_file(markdown_path).expect("open markdown");
+        editor.replace_buffer_content(&(0..30).map(|i| format!("line {i}\n")).collect::<String>());
+        editor.open_markdown_preview().expect("open preview");
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 1);
+
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+        );
+        assert!(editor.markdown_preview.as_ref().unwrap().scroll > 1);
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        assert!(editor.markdown_preview.is_none());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -594,7 +594,7 @@ impl Terminal {
 
     /// Render the editor state to the terminal
     pub fn render(&mut self, editor: &Editor) -> anyhow::Result<()> {
-        self.set_mouse_capture(editor.floating_terminal.is_visible())?;
+        self.set_mouse_capture(Self::should_capture_mouse(editor))?;
         execute!(self.stdout, cursor::MoveTo(0, 0))?;
 
         // Skip rendering background when finder is open - it's a large overlay
@@ -3673,6 +3673,10 @@ impl Terminal {
         Self::markdown_preview_rect(editor).height.saturating_sub(3) as usize
     }
 
+    fn should_capture_mouse(editor: &Editor) -> bool {
+        editor.floating_terminal.is_visible() || editor.markdown_preview.is_some()
+    }
+
     /// Render the diagnostic floating popup (like vim.diagnostic.open_float())
     fn render_diagnostic_float(&mut self, editor: &Editor) -> anyhow::Result<()> {
         let diagnostics = editor.diagnostics_for_line(editor.cursor.line);
@@ -5965,6 +5969,36 @@ fn handle_markdown_preview_key(editor: &mut Editor, key: KeyEvent) {
             editor.scroll_markdown_preview(-half_page, visible_rows)
         }
         _ => {}
+    }
+}
+
+pub fn handle_markdown_preview_mouse(editor: &mut Editor, mouse: MouseEvent) -> bool {
+    use crossterm::event::MouseEventKind;
+
+    if editor.markdown_preview.is_none() {
+        return false;
+    }
+
+    let rect = Terminal::markdown_preview_rect(editor);
+    let inside_preview = mouse.column >= rect.x
+        && mouse.column < rect.x.saturating_add(rect.width)
+        && mouse.row >= rect.y
+        && mouse.row < rect.y.saturating_add(rect.height);
+    if !inside_preview {
+        return false;
+    }
+
+    let visible_rows = Terminal::markdown_preview_visible_rows(editor).max(1);
+    match mouse.kind {
+        MouseEventKind::ScrollUp => {
+            editor.scroll_markdown_preview(-3, visible_rows);
+            true
+        }
+        MouseEventKind::ScrollDown => {
+            editor.scroll_markdown_preview(3, visible_rows);
+            true
+        }
+        _ => false,
     }
 }
 
@@ -9122,15 +9156,15 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 mod tests {
     use super::{
         apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
-        Terminal,
+        finder_preview_match_ranges, handle_insert_mode, handle_key,
+        handle_markdown_preview_mouse, replace_completion_text, Terminal,
     };
     use crate::commands::Command;
     use crate::config::{KeymapEntry, Settings};
     use crate::editor::{Editor, Mode, RegisterContent};
     use crate::input::Motion;
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
-    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
     use crossterm::style::Color;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -9368,6 +9402,66 @@ mod tests {
 
         handle_key(&mut editor, KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
         assert!(editor.markdown_preview.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_mouse_capture_is_enabled_while_overlay_is_open() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_mouse_capture");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.open_file(markdown_path).expect("open markdown");
+        assert!(!Terminal::should_capture_mouse(&editor));
+
+        editor.open_markdown_preview().expect("open preview");
+        assert!(Terminal::should_capture_mouse(&editor));
+
+        editor.close_markdown_preview();
+        assert!(!Terminal::should_capture_mouse(&editor));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn markdown_preview_mouse_wheel_scrolls_only_inside_the_overlay() {
+        let tmp = unique_temp_dir("nevi_markdown_preview_mouse_wheel");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let markdown_path = tmp.join("notes.md");
+        std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.set_size(120, 40);
+        editor.open_file(markdown_path).expect("open markdown");
+        editor.replace_buffer_content(&(0..40).map(|i| format!("line {i}\n")).collect::<String>());
+        editor.open_markdown_preview().expect("open preview");
+
+        let rect = Terminal::markdown_preview_rect(&editor);
+        let inside = MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: rect.x + 1,
+            row: rect.y + 1,
+            modifiers: KeyModifiers::NONE,
+        };
+        let outside = MouseEvent {
+            kind: crossterm::event::MouseEventKind::ScrollDown,
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        assert!(handle_markdown_preview_mouse(&mut editor, inside));
+        assert!(editor.markdown_preview.as_ref().unwrap().scroll > 0);
+
+        let scroll_after_inside = editor.markdown_preview.as_ref().unwrap().scroll;
+        assert!(!handle_markdown_preview_mouse(&mut editor, outside));
+        assert_eq!(
+            editor.markdown_preview.as_ref().unwrap().scroll,
+            scroll_after_inside
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
PR covers:
Add a floating Markdown preview for `.md` buffers with dependency-free rendering, keyboard navigation, cached word wrapping, wider reader layout, native terminal text selection, and footer position hints.
<img width="1255" height="1371" alt="Screenshot 2026-05-16 at 3 45 25 PM" src="https://github.com/user-attachments/assets/99ff4f4a-29e6-42fb-b75b-6ceb520a131e" />
