### PR TITLE
feat: git changes picker

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -594,6 +594,7 @@ The leader key is `Space` by default. Press `Space` followed by these keys:
 | Key | Action |
 |-----|--------|
 | `<leader>gg` | Open lazygit |
+| `<leader>gc` | Open Git changes picker |
 
 ### Harpoon-like Quick Files
 
@@ -723,6 +724,7 @@ Type `:` to enter command mode. Implemented commands include:
 | `:FindBuffers` / `:fb` / `:buffers` | Open buffer finder |
 | `:FindDiagnostics` / `:diag` / `:fd` | Open diagnostics finder |
 | `:DiagnosticFloat` / `:df` | Show diagnostics for cursor line |
+| `:GitChanges` / `:gitchanges` / `:changes` / `:gc` | Open changed Git files picker with diff preview; `Enter` opens the selected file |
 | `:Explorer` / `:ex` | Toggle file explorer |
 | `:Explore` / `:Ex` | Open file explorer |
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ nevi file1.rs file2.rs
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
+- `<Space>gc` - Git changes picker
 - `<Space>e` - File explorer
 - `<Space>tt` - Terminal picker
 
@@ -206,6 +207,7 @@ Nevi aims for full vim/neovim keybind compatibility. Most common keybindings are
 | `w` | Save file |
 | `q` | Quit |
 | `gg` | Open lazygit |
+| `gc` | Git changes picker |
 | `m` | Add to harpoon |
 | `h` | Harpoon menu |
 | `1-4` | Jump to harpoon slot |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -57,6 +57,8 @@ pub enum Command {
     SearchWord,
     /// :FindDiagnostics - Open fuzzy finder for LSP diagnostics
     FindDiagnostics,
+    /// :GitChanges - Open fuzzy finder for changed Git files
+    GitChanges,
     /// :DiagnosticFloat - Show diagnostic floating popup at cursor line
     DiagnosticFloat,
     /// :MarkdownPreview - Open a rendered floating Markdown preview
@@ -332,6 +334,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         command: "FindDiagnostics",
         aliases: &["finddiagnostics", "diagnostics", "diag", "fd"],
         description: "Open diagnostics finder",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "GitChanges",
+        aliases: &["gitchanges", "changes", "gc"],
+        description: "Open Git changes finder",
         takes_args: false,
     },
     CommandSpec {
@@ -831,10 +839,9 @@ pub fn parse_command(input: &str) -> Command {
         "FindDiagnostics" | "finddiagnostics" | "diagnostics" | "diag" | "fd" => {
             Command::FindDiagnostics
         }
+        "GitChanges" | "gitchanges" | "changes" | "gc" => Command::GitChanges,
         "DiagnosticFloat" | "diagnosticfloat" | "df" | "linediag" => Command::DiagnosticFloat,
-        "MarkdownPreview" | "markdownpreview" | "mdpreview" | "mdp" => {
-            Command::MarkdownPreview
-        }
+        "MarkdownPreview" | "markdownpreview" | "mdpreview" | "mdp" => Command::MarkdownPreview,
 
         // Clear search highlight
         "noh" | "nohlsearch" => Command::NoHighlight,
@@ -1482,6 +1489,22 @@ mod tests {
                 .any(|item| item.command == "FindFiles" || item.matched_alias == "ff"),
             "expected FindFiles to match alias 'ff'"
         );
+    }
+
+    #[test]
+    fn git_changes_command_suggestions_match_aliases() {
+        let suggestions = command_suggestions_for_token("gc", 10);
+
+        assert!(
+            suggestions
+                .iter()
+                .any(|item| item.command == "GitChanges" && item.matched_alias == "gc"),
+            "expected GitChanges to match alias 'gc'"
+        );
+
+        assert!(matches!(parse_command("GitChanges"), Command::GitChanges));
+        assert!(matches!(parse_command("changes"), Command::GitChanges));
+        assert!(matches!(parse_command("gc"), Command::GitChanges));
     }
 
     #[test]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -538,6 +538,7 @@ mod tests {
             ("d", "FindDiagnostics"),
             ("D", "DiagnosticFloat"),
             ("gg", "LazyGit"),
+            ("gc", "GitChanges"),
             ("m", "HarpoonAdd"),
             ("h", "HarpoonMenu"),
             ("1", "Harpoon1"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -295,6 +295,11 @@ impl Default for KeymapSettings {
                     action: ":LazyGit".to_string(),
                     desc: Some("Open lazygit".to_string()),
                 },
+                LeaderMapping {
+                    key: "gc".to_string(),
+                    action: ":GitChanges".to_string(),
+                    desc: Some("Git changes picker".to_string()),
+                },
                 // Harpoon
                 LeaderMapping {
                     key: "m".to_string(),
@@ -999,6 +1004,7 @@ fn default_config_template() -> &'static str {
 # <leader>d        - Search diagnostics
 # <leader>D        - Show line diagnostic
 # <leader>gg       - Open lazygit
+# <leader>gc       - Git changes picker
 # <leader>m        - Add to harpoon
 # <leader>h        - Harpoon menu
 # <leader>1-4      - Jump to harpoon slot 1-4

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -6799,6 +6799,53 @@ impl Editor {
         self.update_finder_preview();
     }
 
+    /// Open the fuzzy finder in git changes mode
+    pub fn open_finder_git_changes(&mut self) {
+        use crate::finder::FinderItem;
+
+        let Some(repo) = &self.git_repo else {
+            self.set_status("Not in a Git repository");
+            return;
+        };
+
+        let Some(workdir) = repo.workdir() else {
+            self.set_status("Not in a Git repository");
+            return;
+        };
+
+        let mut statuses: Vec<_> = repo.file_statuses().into_iter().collect();
+        statuses.sort_by(|(left_path, left_status), (right_path, right_status)| {
+            left_status
+                .picker_sort_rank()
+                .cmp(&right_status.picker_sort_rank())
+                .then_with(|| left_path.cmp(right_path))
+        });
+
+        let items: Vec<_> = statuses
+            .into_iter()
+            .map(|(path, status)| {
+                let relative_path = path.strip_prefix(workdir).unwrap_or(&path);
+                let display = format!(
+                    "{} {}",
+                    status.picker_prefix(),
+                    relative_path.to_string_lossy()
+                );
+                FinderItem::new(display, path)
+                    .with_git_status(status)
+                    .with_icon("GT")
+            })
+            .collect();
+
+        if items.is_empty() {
+            self.set_status("No Git changes");
+            return;
+        }
+
+        self.finder.open_git_changes(items);
+        self.mode = Mode::Finder;
+        self.update_finder_preview();
+    }
+
     /// Open the fuzzy finder in buffer mode
     pub fn open_finder_buffers(&mut self) {
         let buffer_info: Vec<(usize, String, std::path::PathBuf)> = self
@@ -7014,13 +7061,12 @@ impl Editor {
 
     /// Update the preview syntax highlighting for the currently selected finder item
     pub fn update_finder_preview(&mut self) {
-        // Only for Files, Grep, Harpoon, and Marks modes with preview enabled
-        if !self.finder.preview_enabled
-            || (self.finder.mode != crate::finder::FinderMode::Files
-                && self.finder.mode != crate::finder::FinderMode::Grep
-                && self.finder.mode != crate::finder::FinderMode::Harpoon
-                && self.finder.mode != crate::finder::FinderMode::Marks)
-        {
+        if !self.finder.preview_enabled || !self.finder.mode_supports_preview() {
+            return;
+        }
+
+        if self.finder.mode == crate::finder::FinderMode::GitChanges {
+            self.update_git_changes_preview();
             return;
         }
 
@@ -7060,6 +7106,39 @@ impl Editor {
         // Parse the content
         let content = self.finder.preview_content.join("\n");
         self.preview_syntax.parse_string(&content);
+    }
+
+    fn update_git_changes_preview(&mut self) {
+        let Some(item) = self.finder.selected_item().cloned() else {
+            self.finder.clear_preview_cache();
+            self.reset_preview_syntax();
+            return;
+        };
+        let Some(status) = item.git_status else {
+            self.finder.clear_preview_cache();
+            self.reset_preview_syntax();
+            return;
+        };
+
+        if self.finder.preview_path.as_ref() == Some(&item.path) {
+            return;
+        }
+
+        self.reset_preview_syntax();
+
+        const GIT_CHANGES_PREVIEW_LINES: usize = 150;
+        let content = self
+            .git_repo
+            .as_ref()
+            .map(|repo| repo.diff_preview(&item.path, status, GIT_CHANGES_PREVIEW_LINES))
+            .unwrap_or_else(|| vec!["Not in a Git repository".to_string()]);
+
+        self.finder.set_preview_content(item.path, content);
+    }
+
+    fn reset_preview_syntax(&mut self) {
+        self.preview_syntax = SyntaxManager::new();
+        self.preview_syntax.sync_theme(self.theme_manager.theme());
     }
 
     // === File Explorer Methods ===
@@ -7669,6 +7748,134 @@ mod tests {
         editor.update_all_git_diffs();
 
         assert_eq!(editor.git_status_for_line(0), None);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_picker_reports_missing_repository() {
+        let tmp = unique_temp_dir("nevi_git_changes_no_repo");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(tmp.clone());
+        editor.init_git();
+        editor.open_finder_git_changes();
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Not in a Git repository")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_picker_reports_clean_repository() {
+        let tmp = unique_temp_dir("nevi_git_changes_clean");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        let path = root.join("tracked.rs");
+        std::fs::write(&path, "clean\n").expect("write tracked");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, Path::new("tracked.rs"), "initial");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.init_git();
+        editor.open_finder_git_changes();
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.status_message.as_deref(), Some("No Git changes"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_picker_lists_modified_files_and_loads_diff_preview() {
+        let tmp = unique_temp_dir("nevi_git_changes_modified");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        let path = root.join("tracked.rs");
+        std::fs::write(&path, "old\n").expect("write original");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, Path::new("tracked.rs"), "initial");
+        std::fs::write(&path, "new\n").expect("write modified");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.init_git();
+        editor.open_finder_git_changes();
+
+        assert_eq!(editor.mode, Mode::Finder);
+        assert_eq!(editor.finder.mode, crate::finder::FinderMode::GitChanges);
+        assert!(editor.finder.preview_enabled);
+        assert_eq!(editor.finder.items.len(), 1);
+        assert!(editor.finder.items[0].display.contains("M tracked.rs"));
+
+        editor.update_finder_preview();
+        let preview = editor.finder.preview_content.join("\n");
+        assert!(preview.contains("diff --git"));
+        assert!(preview.contains("-old"));
+        assert!(preview.contains("+new"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_picker_clears_diff_preview_when_filter_has_no_selection() {
+        let tmp = unique_temp_dir("nevi_git_changes_filter_empty");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        let path = root.join("tracked.rs");
+        std::fs::write(&path, "old\n").expect("write original");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, Path::new("tracked.rs"), "initial");
+        std::fs::write(&path, "new\n").expect("write modified");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.init_git();
+        editor.open_finder_git_changes();
+
+        assert!(!editor.finder.preview_content.is_empty());
+        assert_eq!(editor.finder.preview_path.as_deref(), Some(path.as_path()));
+
+        for ch in "ZZZZZZZZ".chars() {
+            editor.finder.insert_char(ch);
+        }
+        assert!(editor.finder.selected_item().is_none());
+
+        editor.update_finder_preview();
+
+        assert!(editor.finder.preview_content.is_empty());
+        assert_eq!(editor.finder.preview_path, None);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_picker_resets_stale_preview_syntax_for_diff_preview() {
+        let tmp = unique_temp_dir("nevi_git_changes_preview_syntax");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        let path = root.join("tracked.rs");
+        std::fs::write(&path, "old\n").expect("write original");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, Path::new("tracked.rs"), "initial");
+        std::fs::write(&path, "new\n").expect("write modified");
+
+        let mut editor = Editor::default();
+        editor.preview_syntax.set_language_from_path(&path);
+        editor.preview_syntax.parse_string("fn main() {}\n");
+        assert!(editor.preview_syntax.has_highlighting());
+
+        editor.set_project_root(root.clone());
+        editor.init_git();
+        editor.open_finder_git_changes();
+
+        assert!(!editor.preview_syntax.has_highlighting());
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -33,6 +33,7 @@ pub enum FinderMode {
     Diagnostics,
     Harpoon,
     Marks,
+    GitChanges,
     Terminals,
 }
 
@@ -63,6 +64,8 @@ pub struct FinderItem {
     pub terminal_session_position: Option<usize>,
     /// Optional 2-character icon override
     pub icon: Option<&'static str>,
+    /// Git status metadata for git changes finder results
+    pub git_status: Option<crate::git::GitFileStatus>,
     /// Match score for sorting
     pub score: u32,
     /// Indices of matched characters (for highlighting)
@@ -79,6 +82,7 @@ impl FinderItem {
             buffer_idx: None,
             terminal_session_position: None,
             icon: None,
+            git_status: None,
             score: 0,
             match_indices: Vec::new(),
         }
@@ -106,6 +110,11 @@ impl FinderItem {
 
     pub fn with_icon(mut self, icon: &'static str) -> Self {
         self.icon = Some(icon);
+        self
+    }
+
+    pub fn with_git_status(mut self, status: crate::git::GitFileStatus) -> Self {
+        self.git_status = Some(status);
         self
     }
 
@@ -392,6 +401,23 @@ impl FuzzyFinder {
         self.cancel_grep_search();
 
         self.items = terminal_items;
+        self.filtered = (0..self.items.len()).collect();
+        self.populated = true;
+    }
+
+    /// Open the finder in git changes mode
+    pub fn open_git_changes(&mut self, items: Vec<FinderItem>) {
+        self.mode = FinderMode::GitChanges;
+        self.input_mode = FinderInputMode::Insert;
+        self.query.clear();
+        self.cursor = 0;
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.clear_preview_cache();
+        self.cancel_grep_search();
+        self.preview_enabled = true;
+
+        self.items = items;
         self.filtered = (0..self.items.len()).collect();
         self.populated = true;
     }
@@ -686,11 +712,19 @@ impl FuzzyFinder {
                         .iter()
                         .enumerate()
                         .filter_map(|(idx, item)| {
+                            let match_text = if self.mode == FinderMode::GitChanges {
+                                item.path.to_string_lossy()
+                            } else {
+                                std::borrow::Cow::Borrowed(item.display.as_str())
+                            };
                             self.matcher
-                                .match_score(&self.query, &item.display)
+                                .match_score(&self.query, &match_text)
                                 .map(|score| {
-                                    let indices =
-                                        self.matcher.match_indices(&self.query, &item.display);
+                                    let indices = if self.mode == FinderMode::GitChanges {
+                                        Vec::new()
+                                    } else {
+                                        self.matcher.match_indices(&self.query, &item.display)
+                                    };
                                     (idx, score, indices)
                                 })
                         })
@@ -853,6 +887,26 @@ impl FuzzyFinder {
         self.preview_update_pending = false;
     }
 
+    pub fn mode_supports_preview(&self) -> bool {
+        matches!(
+            self.mode,
+            FinderMode::Files
+                | FinderMode::Grep
+                | FinderMode::Harpoon
+                | FinderMode::Marks
+                | FinderMode::GitChanges
+        )
+    }
+
+    pub fn set_preview_content(&mut self, path: PathBuf, content: Vec<String>) {
+        self.preview_content = content;
+        self.preview_scroll = 0;
+        self.preview_line_offset = 0;
+        self.preview_path = Some(path);
+        self.preview_line = None;
+        self.preview_update_pending = false;
+    }
+
     /// Update preview content if the selected file changed
     /// Returns the current preview path and content for rendering
     pub fn update_preview_content(&mut self) -> Option<(PathBuf, &[String])> {
@@ -860,12 +914,7 @@ impl FuzzyFinder {
             return None;
         }
 
-        // Only show preview for Files, Grep, Harpoon, and Marks modes
-        if self.mode != FinderMode::Files
-            && self.mode != FinderMode::Grep
-            && self.mode != FinderMode::Harpoon
-            && self.mode != FinderMode::Marks
-        {
+        if !self.mode_supports_preview() || self.mode == FinderMode::GitChanges {
             return None;
         }
 
@@ -1049,7 +1098,7 @@ impl Default for FuzzyFinder {
 mod tests {
     use super::{FinderInputMode, FinderItem, FinderMode, FuzzyFinder, GrepSearchMessage};
     use std::fs;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::mpsc;
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -1081,6 +1130,93 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         panic!("async grep search did not finish");
+    }
+
+    #[test]
+    fn git_changes_finder_opens_with_preview_and_status_metadata() {
+        let mut finder = FuzzyFinder::new();
+        let item = FinderItem::new("M src/main.rs".to_string(), PathBuf::from("src/main.rs"))
+            .with_git_status(crate::git::GitFileStatus::Modified);
+
+        finder.open_git_changes(vec![item]);
+
+        assert_eq!(finder.mode, FinderMode::GitChanges);
+        assert!(finder.preview_enabled);
+        assert!(finder.mode_supports_preview());
+        assert_eq!(finder.items.len(), 1);
+        assert_eq!(
+            finder.selected_item().and_then(|item| item.git_status),
+            Some(crate::git::GitFileStatus::Modified)
+        );
+    }
+
+    #[test]
+    fn git_changes_finder_fuzzy_filters_paths() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_git_changes(vec![
+            FinderItem::new("M src/main.rs".to_string(), PathBuf::from("src/main.rs"))
+                .with_git_status(crate::git::GitFileStatus::Modified),
+            FinderItem::new("A README.md".to_string(), PathBuf::from("README.md"))
+                .with_git_status(crate::git::GitFileStatus::Added),
+        ]);
+
+        finder.insert_char('r');
+        finder.insert_char('e');
+        finder.insert_char('a');
+        finder.insert_char('d');
+
+        assert_eq!(finder.filtered.len(), 1);
+        assert_eq!(
+            finder.selected_item().map(|item| item.path.as_path()),
+            Some(Path::new("README.md"))
+        );
+    }
+
+    #[test]
+    fn git_changes_finder_does_not_filter_by_status_prefix() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_git_changes(vec![
+            FinderItem::new("! src/main.rs".to_string(), PathBuf::from("src/main.rs"))
+                .with_git_status(crate::git::GitFileStatus::Conflicted),
+            FinderItem::new("? README.md".to_string(), PathBuf::from("README.md"))
+                .with_git_status(crate::git::GitFileStatus::Untracked),
+        ]);
+
+        finder.insert_char('!');
+
+        assert!(finder.filtered.is_empty());
+    }
+
+    #[test]
+    fn git_changes_update_preview_waits_for_injected_content() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_git_changes(vec![FinderItem::new(
+            "M src/main.rs".to_string(),
+            PathBuf::from("src/main.rs"),
+        )
+        .with_git_status(crate::git::GitFileStatus::Modified)]);
+
+        assert_eq!(finder.update_preview_content(), None);
+    }
+
+    #[test]
+    fn set_preview_content_replaces_pending_preview_state() {
+        let mut finder = FuzzyFinder::new();
+        finder.preview_content = vec!["old".to_string()];
+        finder.preview_scroll = 3;
+        finder.preview_line_offset = 9;
+        finder.preview_path = Some(PathBuf::from("old.rs"));
+        finder.preview_line = Some(12);
+        finder.preview_update_pending = true;
+
+        finder.set_preview_content(PathBuf::from("src/main.rs"), vec!["diff".to_string()]);
+
+        assert_eq!(finder.preview_content, vec!["diff"]);
+        assert_eq!(finder.preview_scroll, 0);
+        assert_eq!(finder.preview_line_offset, 0);
+        assert_eq!(finder.preview_path, Some(PathBuf::from("src/main.rs")));
+        assert_eq!(finder.preview_line, None);
+        assert!(!finder.preview_update_pending);
     }
 
     #[test]

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -139,6 +139,27 @@ pub struct MarkInfo {
     pub file_name: String,
 }
 
+fn git_changes_display_path(display: &str) -> (usize, &str) {
+    if let Some((prefix, path)) = display.split_once(' ') {
+        (prefix.chars().count() + 1, path)
+    } else {
+        (0, display)
+    }
+}
+
+fn offset_match_indices(
+    matcher: &mut FuzzyMatcher,
+    query: &str,
+    match_text: &str,
+    char_start: usize,
+) -> Vec<usize> {
+    matcher
+        .match_indices(query, match_text)
+        .into_iter()
+        .map(|idx| char_start + idx)
+        .collect()
+}
+
 /// Floating window dimensions
 #[derive(Debug, Clone, Copy)]
 pub struct FloatingWindow {
@@ -707,26 +728,28 @@ impl FuzzyFinder {
                     self.filtered = (0..self.items.len()).collect();
                 } else {
                     // Filter and sort by match score, and get match indices
+                    let mode = self.mode;
+                    let query = self.query.clone();
+                    let matcher = &mut self.matcher;
                     let mut scored: Vec<(usize, u32, Vec<usize>)> = self
                         .items
                         .iter()
                         .enumerate()
                         .filter_map(|(idx, item)| {
-                            let match_text = if self.mode == FinderMode::GitChanges {
-                                item.path.to_string_lossy()
+                            let (match_start, match_text) = if mode == FinderMode::GitChanges {
+                                git_changes_display_path(&item.display)
                             } else {
-                                std::borrow::Cow::Borrowed(item.display.as_str())
+                                (0, item.display.as_str())
                             };
-                            self.matcher
-                                .match_score(&self.query, &match_text)
-                                .map(|score| {
-                                    let indices = if self.mode == FinderMode::GitChanges {
-                                        Vec::new()
-                                    } else {
-                                        self.matcher.match_indices(&self.query, &item.display)
-                                    };
-                                    (idx, score, indices)
-                                })
+                            matcher.match_score(&query, match_text).map(|score| {
+                                let indices = offset_match_indices(
+                                    matcher,
+                                    &query,
+                                    match_text,
+                                    match_start,
+                                );
+                                (idx, score, indices)
+                            })
                         })
                         .collect();
 
@@ -1170,6 +1193,30 @@ mod tests {
             finder.selected_item().map(|item| item.path.as_path()),
             Some(Path::new("README.md"))
         );
+    }
+
+    #[test]
+    fn git_changes_finder_highlights_path_matches_in_display_text() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_git_changes(vec![
+            FinderItem::new(
+                "M src/lib/types.ts".to_string(),
+                PathBuf::from("/repo/src/lib/types.ts"),
+            )
+            .with_git_status(crate::git::GitFileStatus::Modified),
+        ]);
+
+        for ch in "type".chars() {
+            finder.insert_char(ch);
+        }
+
+        let item = finder.selected_item().expect("matching item");
+        let highlighted: String = item
+            .match_indices
+            .iter()
+            .map(|&idx| item.display.chars().nth(idx).expect("matched char"))
+            .collect();
+        assert_eq!(highlighted, "type");
     }
 
     #[test]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -2,7 +2,11 @@
 
 use similar::{ChangeTag, TextDiff};
 use std::collections::HashMap;
+use std::io::Read;
 use std::path::{Path, PathBuf};
+
+const TEXT_SAMPLE_LIMIT: usize = 8 * 1024;
+const PREVIEW_BYTE_LIMIT: usize = 16 * 1024;
 
 /// Status of a line compared to the HEAD version
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,6 +52,30 @@ impl GitFileStatus {
             self
         }
     }
+
+    pub fn picker_prefix(self) -> &'static str {
+        match self {
+            GitFileStatus::Modified => "M",
+            GitFileStatus::Added => "A",
+            GitFileStatus::Deleted => "D",
+            GitFileStatus::Untracked => "?",
+            GitFileStatus::Conflicted => "!",
+        }
+    }
+
+    pub fn picker_sort_rank(self) -> u8 {
+        match self {
+            GitFileStatus::Conflicted => 0,
+            GitFileStatus::Modified => 1,
+            GitFileStatus::Deleted => 2,
+            GitFileStatus::Added => 3,
+            GitFileStatus::Untracked => 4,
+        }
+    }
+
+    pub fn is_deleted(self) -> bool {
+        self == GitFileStatus::Deleted
+    }
 }
 
 /// A single hunk representing a change at a specific line
@@ -69,10 +97,7 @@ pub struct GitDiff {
 impl GitDiff {
     /// Get the status for a specific line
     pub fn status_for_line(&self, line: usize) -> Option<GitLineStatus> {
-        self.hunks
-            .iter()
-            .find(|h| h.line == line)
-            .map(|h| h.status)
+        self.hunks.iter().find(|h| h.line == line).map(|h| h.status)
     }
 }
 
@@ -158,10 +183,10 @@ impl GitRepo {
         };
 
         for entry in repo_statuses.iter() {
-            let Some(relative) = entry.path() else {
+            let Some(status) = git_file_status_from_git2(entry.status()) else {
                 continue;
             };
-            let Some(status) = git_file_status_from_git2(entry.status()) else {
+            let Some(relative) = git_status_entry_path(&entry) else {
                 continue;
             };
 
@@ -170,6 +195,315 @@ impl GitRepo {
 
         statuses
     }
+
+    pub fn diff_preview(
+        &self,
+        file_path: &Path,
+        status: GitFileStatus,
+        max_lines: usize,
+    ) -> Vec<String> {
+        if max_lines == 0 {
+            return Vec::new();
+        }
+
+        let Some(workdir) = self.repo.workdir() else {
+            return vec!["No git worktree available".to_string()];
+        };
+
+        let Some(relative) = relative_to_workdir(workdir, file_path) else {
+            return vec!["File is outside the git worktree".to_string()];
+        };
+
+        if status == GitFileStatus::Untracked {
+            if !is_text_previewable(file_path) {
+                return vec!["File is binary or unreadable".to_string()];
+            }
+            return untracked_diff_preview(&relative, file_path, max_lines);
+        }
+
+        if !status.is_deleted() && !is_text_previewable(file_path) {
+            return vec!["File is binary or unreadable".to_string()];
+        }
+
+        let mut lines = Vec::new();
+        let mut options = git2::DiffOptions::new();
+        options.pathspec(&relative);
+
+        let index = self.repo.index().ok();
+        let head_tree = self
+            .repo
+            .head()
+            .ok()
+            .and_then(|head| head.peel_to_tree().ok());
+
+        if let Some(index) = index.as_ref() {
+            if let Ok(diff) =
+                self.repo
+                    .diff_tree_to_index(head_tree.as_ref(), Some(index), Some(&mut options))
+            {
+                if !collect_diff_lines(&diff, &mut lines, max_lines) {
+                    return vec!["File is binary or unreadable".to_string()];
+                }
+            }
+
+            if !preview_is_truncated(&lines) {
+                let mut options = git2::DiffOptions::new();
+                options.pathspec(&relative);
+                if let Ok(diff) = self
+                    .repo
+                    .diff_index_to_workdir(Some(index), Some(&mut options))
+                {
+                    if !collect_diff_lines(&diff, &mut lines, max_lines) {
+                        return vec!["File is binary or unreadable".to_string()];
+                    }
+                }
+            }
+        }
+
+        if lines.is_empty() {
+            if let Some(rename_preview) = self.worktree_rename_preview(&relative, max_lines) {
+                return rename_preview;
+            }
+            lines.push("No diff available".to_string());
+        }
+
+        lines
+    }
+
+    fn worktree_rename_preview(&self, relative: &Path, max_lines: usize) -> Option<Vec<String>> {
+        let mut options = git2::StatusOptions::new();
+        options
+            .include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .renames_index_to_workdir(true);
+
+        let repo_statuses = self.repo.statuses(Some(&mut options)).ok()?;
+        for entry in repo_statuses.iter() {
+            if !entry.status().contains(git2::Status::WT_RENAMED) {
+                continue;
+            }
+
+            let delta = entry.index_to_workdir()?;
+            let old_path = delta.old_file().path()?;
+            let new_path = delta.new_file().path()?;
+            if new_path != relative {
+                continue;
+            }
+
+            return Some(rename_diff_preview(old_path, new_path, max_lines));
+        }
+
+        None
+    }
+}
+
+fn git_status_entry_path(entry: &git2::StatusEntry<'_>) -> Option<PathBuf> {
+    if entry.status().contains(git2::Status::INDEX_RENAMED) {
+        return entry
+            .head_to_index()
+            .and_then(|delta| delta.new_file().path().map(Path::to_path_buf));
+    }
+
+    if entry.status().contains(git2::Status::WT_RENAMED) {
+        return entry
+            .index_to_workdir()
+            .and_then(|delta| delta.new_file().path().map(Path::to_path_buf));
+    }
+
+    entry.path().map(PathBuf::from)
+}
+
+fn is_text_previewable(file_path: &Path) -> bool {
+    let Ok(file) = std::fs::File::open(file_path) else {
+        return false;
+    };
+    let mut sample = Vec::with_capacity(TEXT_SAMPLE_LIMIT);
+    let Ok(_) = file.take(TEXT_SAMPLE_LIMIT as u64).read_to_end(&mut sample) else {
+        return false;
+    };
+
+    bytes_are_previewable_text(&sample)
+}
+
+fn bytes_are_previewable_text(bytes: &[u8]) -> bool {
+    if bytes.contains(&0) {
+        return false;
+    }
+
+    let Ok(text) = std::str::from_utf8(bytes) else {
+        return false;
+    };
+
+    for ch in text.chars() {
+        if ch.is_control() && !matches!(ch, '\n' | '\r' | '\t') {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn relative_to_workdir(workdir: &Path, file_path: &Path) -> Option<PathBuf> {
+    if let Ok(relative) = file_path.strip_prefix(workdir) {
+        return Some(relative.to_path_buf());
+    }
+
+    let canonical_workdir = workdir.canonicalize().ok()?;
+    let canonical_file = file_path.canonicalize().ok()?;
+    canonical_file
+        .strip_prefix(canonical_workdir)
+        .ok()
+        .map(Path::to_path_buf)
+}
+
+fn collect_diff_lines(diff: &git2::Diff<'_>, lines: &mut Vec<String>, max_lines: usize) -> bool {
+    let mut safe = true;
+    let _ = diff.print(git2::DiffFormat::Patch, |_delta, _hunk, line| {
+        if preview_is_truncated(lines) {
+            return false;
+        }
+
+        let mut content = line.content();
+        if content.ends_with(b"\n") {
+            content = &content[..content.len() - 1];
+        }
+
+        if line.origin() == 'B' || content.starts_with(b"Binary files ") {
+            safe = false;
+            return false;
+        }
+
+        let truncated_by_bytes = content.len() > PREVIEW_BYTE_LIMIT;
+        let mut content = content[..content.len().min(PREVIEW_BYTE_LIMIT)].to_vec();
+        while !std::str::from_utf8(&content).is_ok() {
+            content.pop();
+        }
+        if !bytes_are_previewable_text(&content) {
+            safe = false;
+            return false;
+        }
+
+        let content = String::from_utf8(content).expect("validated utf-8");
+        let content = sanitize_preview_text(&content);
+        let origin = line.origin();
+        let rendered = match origin {
+            '+' | '-' | ' ' => format!("{origin}{content}"),
+            _ => content,
+        };
+        if !push_preview_line(lines, max_lines, rendered) {
+            return false;
+        }
+        if truncated_by_bytes {
+            let _ = push_preview_line(lines, max_lines, "... (truncated)".to_string());
+            return false;
+        }
+        true
+    });
+    safe
+}
+
+fn rename_diff_preview(old_path: &Path, new_path: &Path, max_lines: usize) -> Vec<String> {
+    let old_display = sanitize_path_display(old_path);
+    let new_display = sanitize_path_display(new_path);
+    let mut lines = Vec::new();
+    for line in [
+        format!("diff --git a/{old_display} b/{new_display}"),
+        format!("rename from {old_display}"),
+        format!("rename to {new_display}"),
+    ] {
+        if !push_preview_line(&mut lines, max_lines, line) {
+            break;
+        }
+    }
+    lines
+}
+
+fn untracked_diff_preview(relative_path: &Path, file_path: &Path, max_lines: usize) -> Vec<String> {
+    let Ok(mut file) = std::fs::File::open(file_path) else {
+        return vec!["File is binary or unreadable".to_string()];
+    };
+
+    let display_path = sanitize_path_display(relative_path);
+    let mut lines = Vec::new();
+    for line in [
+        format!("diff --git a/{display_path} b/{display_path}"),
+        "new file mode 100644".to_string(),
+        "--- /dev/null".to_string(),
+        format!("+++ b/{display_path}"),
+    ] {
+        if !push_preview_line(&mut lines, max_lines, line) {
+            return lines;
+        }
+    }
+
+    let mut content = Vec::new();
+    let Ok(_) = file
+        .by_ref()
+        .take((PREVIEW_BYTE_LIMIT + 1) as u64)
+        .read_to_end(&mut content)
+    else {
+        return vec!["File is binary or unreadable".to_string()];
+    };
+    let truncated_by_bytes = content.len() > PREVIEW_BYTE_LIMIT;
+    if truncated_by_bytes {
+        content.truncate(PREVIEW_BYTE_LIMIT);
+        while !std::str::from_utf8(&content).is_ok() {
+            content.pop();
+        }
+    }
+    if !bytes_are_previewable_text(&content) {
+        return vec!["File is binary or unreadable".to_string()];
+    }
+    let content = String::from_utf8(content).expect("validated utf-8");
+
+    for line in content.split('\n') {
+        let line = sanitize_preview_text(line);
+        if !push_preview_line(&mut lines, max_lines, format!("+{line}")) {
+            return lines;
+        }
+    }
+
+    if truncated_by_bytes {
+        let _ = push_preview_line(&mut lines, max_lines, "... (truncated)".to_string());
+    }
+
+    lines
+}
+
+fn sanitize_path_display(path: &Path) -> String {
+    sanitize_preview_text(&path.to_string_lossy().replace('\\', "/"))
+}
+
+fn sanitize_preview_text(text: &str) -> String {
+    text.chars()
+        .map(|ch| {
+            if ch.is_control() && !matches!(ch, '\t') {
+                '?'
+            } else {
+                ch
+            }
+        })
+        .collect()
+}
+
+fn preview_is_truncated(lines: &[String]) -> bool {
+    lines.last().is_some_and(|line| line == "... (truncated)")
+}
+
+fn push_preview_line(lines: &mut Vec<String>, max_lines: usize, line: String) -> bool {
+    if max_lines == 0 {
+        return false;
+    }
+
+    if lines.len() < max_lines {
+        lines.push(line);
+        return true;
+    }
+
+    if let Some(last) = lines.last_mut() {
+        *last = "... (truncated)".to_string();
+    }
+    false
 }
 
 fn git_file_status_from_git2(status: git2::Status) -> Option<GitFileStatus> {
@@ -267,7 +601,11 @@ pub fn compute_diff(head_content: &str, current_content: &str) -> GitDiff {
     // Handle any remaining deletes at end of file
     if pending_deletes > 0 {
         // Mark delete at end of file (use last line index)
-        let delete_marker_line = if new_line_idx > 0 { new_line_idx - 1 } else { 0 };
+        let delete_marker_line = if new_line_idx > 0 {
+            new_line_idx - 1
+        } else {
+            0
+        };
         hunks.push(GitHunk {
             line: delete_marker_line,
             status: GitLineStatus::Deleted,
@@ -280,6 +618,439 @@ pub fn compute_diff(head_content: &str, current_content: &str) -> GitDiff {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::{Path, PathBuf};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    fn commit_file(repo: &git2::Repository, relative_path: &Path, message: &str) {
+        let signature =
+            git2::Signature::now("Nevi Test", "nevi-test@example.com").expect("signature");
+        let mut index = repo.index().expect("index");
+        index.add_path(relative_path).expect("add file");
+        index.write().expect("write index");
+        let tree_id = index.write_tree().expect("write tree");
+        let tree = repo.find_tree(tree_id).expect("find tree");
+
+        if let Some(parent_id) = repo.head().ok().and_then(|head| head.target()) {
+            let parent = repo.find_commit(parent_id).expect("find parent");
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                message,
+                &tree,
+                &[&parent],
+            )
+            .expect("commit");
+        } else {
+            repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[])
+                .expect("initial commit");
+        }
+    }
+
+    #[test]
+    fn git_changes_status_metadata_matches_picker_order() {
+        assert_eq!(GitFileStatus::Modified.picker_prefix(), "M");
+        assert_eq!(GitFileStatus::Added.picker_prefix(), "A");
+        assert_eq!(GitFileStatus::Deleted.picker_prefix(), "D");
+        assert_eq!(GitFileStatus::Untracked.picker_prefix(), "?");
+        assert_eq!(GitFileStatus::Conflicted.picker_prefix(), "!");
+        assert!(GitFileStatus::Deleted.is_deleted());
+        assert!(!GitFileStatus::Modified.is_deleted());
+
+        let mut statuses = vec![
+            GitFileStatus::Untracked,
+            GitFileStatus::Added,
+            GitFileStatus::Deleted,
+            GitFileStatus::Modified,
+            GitFileStatus::Conflicted,
+        ];
+        statuses.sort_by_key(|status| status.picker_sort_rank());
+
+        assert_eq!(
+            statuses,
+            vec![
+                GitFileStatus::Conflicted,
+                GitFileStatus::Modified,
+                GitFileStatus::Deleted,
+                GitFileStatus::Added,
+                GitFileStatus::Untracked,
+            ]
+        );
+    }
+
+    #[test]
+    fn git_changes_diff_preview_includes_modified_file_patch() {
+        let root = unique_temp_dir("nevi_git_changes_diff_modified");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("tracked.rs");
+        std::fs::write(&path, "old\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("tracked.rs"), "initial");
+        std::fs::write(&path, "new\n").expect("write modified");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Modified, 50);
+        let joined = preview.join("\n");
+
+        assert!(joined.contains("diff --git"));
+        assert!(joined.contains("-old"));
+        assert!(joined.contains("+new"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_formats_untracked_text_file_as_added() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("new.rs");
+        std::fs::write(&path, "fn main() {}\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 50);
+        let joined = preview.join("\n");
+
+        assert!(joined.contains("new file mode"));
+        assert!(joined.contains("--- /dev/null"));
+        assert!(joined.contains("+++ b/new.rs"));
+        assert!(joined.contains("+fn main() {}"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_untracked_nul_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_nul");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("nul.txt");
+        std::fs::write(&path, b"hello\0world\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_control_heavy_untracked_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_control");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("ansi.txt");
+        let content = "\x1b[31m\x1b[0m".repeat(256);
+        std::fs::write(&path, content).expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_single_control_untracked_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_single_control");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("bell.txt");
+        std::fs::write(&path, "mostly normal text with bell \x07\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_untracked_diff_preview_bounds_large_line_and_truncates() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_large_line");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("large.txt");
+        std::fs::write(&path, "a".repeat(TEXT_SAMPLE_LIMIT * 4)).expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 5);
+
+        assert_eq!(preview.len(), 5);
+        assert_eq!(preview.last().map(String::as_str), Some("... (truncated)"));
+        assert!(preview
+            .iter()
+            .all(|line| line.len() <= PREVIEW_BYTE_LIMIT + 1));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_tracked_binary_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_binary");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("image.bin");
+        std::fs::write(&path, [0, 159, 146, 150]).expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("image.bin"), "initial");
+        std::fs::write(&path, [0, 255, 146, 150]).expect("write modified");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Modified, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_deleted_tracked_binary_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_deleted_binary");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("image.bin");
+        std::fs::write(&path, [0, 159, 146, 150]).expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("image.bin"), "initial");
+        std::fs::remove_file(&path).expect("delete tracked file");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let statuses = repo.file_statuses();
+        let (path, status) = statuses
+            .iter()
+            .find(|(path, _status)| path.ends_with("image.bin"))
+            .expect("deleted file status");
+        let preview = repo.diff_preview(path, *status, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_tracked_diff_preview_strips_raw_carriage_returns() {
+        let root = unique_temp_dir("nevi_git_changes_diff_tracked_cr");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("crlf.txt");
+        std::fs::write(&path, "old\r\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("crlf.txt"), "initial");
+        std::fs::write(&path, "new\r\n").expect("write modified");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Modified, 50);
+
+        assert!(preview.iter().all(|line| !line.contains('\r')));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_untracked_diff_preview_strips_raw_carriage_returns() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_cr");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("crlf.txt");
+        std::fs::write(&path, "new\r\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 50);
+
+        assert!(preview.iter().all(|line| !line.contains('\r')));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_preview_path_display_replaces_control_chars() {
+        let old_path = Path::new("old\x1b\r\nname.rs");
+        let new_path = Path::new("new\x1b\r\nname.rs");
+        let preview = rename_diff_preview(old_path, new_path, 10);
+
+        assert!(preview.iter().all(|line| !line.contains('\x1b')));
+        assert!(preview.iter().all(|line| !line.contains('\r')));
+        assert!(preview.iter().all(|line| !line.contains('\n')));
+        assert!(preview.iter().any(|line| line.contains('?')));
+    }
+
+    #[test]
+    fn git_changes_diff_preview_returns_empty_for_zero_line_budget() {
+        let root = unique_temp_dir("nevi_git_changes_diff_zero_budget");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let tracked_path = root.join("tracked.rs");
+        std::fs::write(&tracked_path, "old\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("tracked.rs"), "initial");
+        std::fs::write(&tracked_path, "new\n").expect("write modified");
+        let untracked_path = root.join("new.rs");
+        std::fs::write(&untracked_path, "fn main() {}\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+
+        assert!(repo
+            .diff_preview(&tracked_path, GitFileStatus::Modified, 0)
+            .is_empty());
+        assert!(repo
+            .diff_preview(&untracked_path, GitFileStatus::Untracked, 0)
+            .is_empty());
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_uses_placeholder_for_tracked_deleted_control_file() {
+        let root = unique_temp_dir("nevi_git_changes_diff_deleted_control");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("control.txt");
+        std::fs::write(&path, "safe\nbad \x1b\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("control.txt"), "initial");
+        std::fs::remove_file(&path).expect("delete tracked file");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let statuses = repo.file_statuses();
+        let (path, status) = statuses
+            .iter()
+            .find(|(path, _status)| path.ends_with("control.txt"))
+            .expect("deleted file status");
+        let preview = repo.diff_preview(path, *status, 50);
+
+        assert_eq!(preview, vec!["File is binary or unreadable"]);
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_tracked_diff_preview_bounds_large_line_and_truncates() {
+        let root = unique_temp_dir("nevi_git_changes_diff_tracked_large_line");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("large.txt");
+        std::fs::write(&path, "old\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("large.txt"), "initial");
+        std::fs::write(&path, "a".repeat(PREVIEW_BYTE_LIMIT * 4)).expect("write modified");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Modified, 50);
+
+        assert!(preview
+            .iter()
+            .all(|line| line.len() <= PREVIEW_BYTE_LIMIT + 1));
+        assert_eq!(preview.last().map(String::as_str), Some("... (truncated)"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_handles_worktree_rename_destination_path() {
+        let root = unique_temp_dir("nevi_git_changes_diff_rename_preview");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let old_path = root.join("old.rs");
+        std::fs::write(&old_path, "fn old() {}\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("old.rs"), "initial");
+        let new_path = root.join("new.rs");
+        std::fs::rename(&old_path, &new_path).expect("rename file");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let statuses = repo.file_statuses();
+        let (path, status) = statuses
+            .iter()
+            .find(|(path, _status)| path.ends_with("new.rs"))
+            .expect("renamed destination status");
+        let preview = repo.diff_preview(path, *status, 50);
+        let joined = preview.join("\n");
+
+        assert_ne!(preview, vec!["No diff available"]);
+        assert!(joined.contains("diff --git"));
+        assert!(joined.contains("old.rs"));
+        assert!(joined.contains("new.rs"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_diff_preview_handles_nested_worktree_rename_destination_path() {
+        let root = unique_temp_dir("nevi_git_changes_diff_nested_rename_preview");
+        let old_dir = root.join("old");
+        let new_dir = root.join("new");
+        std::fs::create_dir_all(&old_dir).expect("create old dir");
+        let old_path = old_dir.join("file.rs");
+        std::fs::write(&old_path, "fn old() {}\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("old/file.rs"), "initial");
+        std::fs::create_dir_all(&new_dir).expect("create new dir");
+        let new_path = new_dir.join("file.rs");
+        std::fs::rename(&old_path, &new_path).expect("rename file");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let statuses = repo.file_statuses();
+        let (path, status) = statuses
+            .iter()
+            .find(|(path, _status)| path.ends_with("new/file.rs"))
+            .expect("renamed destination status");
+        let preview = repo.diff_preview(path, *status, 50);
+        let joined = preview.join("\n");
+
+        assert_ne!(preview, vec!["No diff available"]);
+        assert!(joined.contains("old/file.rs"));
+        assert!(joined.contains("new/file.rs"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_file_statuses_use_rename_destination_path() {
+        let root = unique_temp_dir("nevi_git_changes_status_rename");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let old_path = root.join("old.rs");
+        let new_path = root.join("new.rs");
+        std::fs::write(&old_path, "fn old() {}\n").expect("write original");
+        let raw_repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&raw_repo, Path::new("old.rs"), "initial");
+        std::fs::rename(&old_path, &new_path).expect("rename file");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let statuses = repo.file_statuses();
+
+        assert_eq!(
+            statuses
+                .iter()
+                .find(|(path, _status)| path.ends_with("new.rs"))
+                .map(|(_path, status)| status),
+            Some(&GitFileStatus::Modified)
+        );
+        assert!(!statuses.keys().any(|path| path.ends_with("old.rs")));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_changes_untracked_diff_preview_truncates_at_line_limit() {
+        let root = unique_temp_dir("nevi_git_changes_diff_untracked_truncated");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        git2::Repository::init(&root).expect("init repo");
+        let path = root.join("large.rs");
+        std::fs::write(&path, "one\ntwo\nthree\nfour\nfive\n").expect("write untracked");
+
+        let repo = GitRepo::open(&root).expect("open repo");
+        let preview = repo.diff_preview(&path, GitFileStatus::Untracked, 5);
+
+        assert_eq!(preview.len(), 5);
+        assert_eq!(preview.last().map(String::as_str), Some("... (truncated)"));
+
+        let _ = std::fs::remove_dir_all(&root);
+    }
 
     #[test]
     fn test_compute_diff_added_lines() {
@@ -314,7 +1085,10 @@ mod tests {
 
         // Should have a delete marker
         assert!(!diff.hunks.is_empty());
-        assert!(diff.hunks.iter().any(|h| h.status == GitLineStatus::Deleted));
+        assert!(diff
+            .hunks
+            .iter()
+            .any(|h| h.status == GitLineStatus::Deleted));
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4888,6 +4888,7 @@ impl Terminal {
             crate::finder::FinderMode::Diagnostics => " Diagnostics ",
             crate::finder::FinderMode::Harpoon => " Harpoon ",
             crate::finder::FinderMode::Marks => " Marks ",
+            crate::finder::FinderMode::GitChanges => " Git Changes ",
             crate::finder::FinderMode::Terminals => " Terminals ",
         };
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4952,11 +4952,9 @@ impl Terminal {
         let show_scroll_indicator = total_items > list_height;
         let scroll_indicator_color = Color::DarkGrey;
 
-        // Draw items with scrolling (starts at row 1, after top border)
-        // Telescope-style: best matches at BOTTOM (closest to input)
-        let visible_count = list_height.min(total_items.saturating_sub(scroll_offset));
-        let first_item_row = list_height - visible_count; // Empty rows above items
-
+        // Draw items with scrolling (starts at row 1, after top border).
+        // Fuzzy search modes keep best matches near the input; fixed Git changes
+        // results are top-aligned so short lists do not leave a large blank pane.
         for row in 0..list_height {
             let y = win.y + 1 + row as u16;
             queue!(
@@ -4967,15 +4965,13 @@ impl Terminal {
             )?;
             write!(self.stdout, "\u{2502}")?; // │
 
-            // Reverse display: row 0 = least relevant, bottom row = best match
-            let list_idx = if row >= first_item_row {
-                // Map row to item index (reversed)
-                scroll_offset + (list_height - 1 - row)
-            } else {
-                usize::MAX // Empty row marker
-            };
-
-            if list_idx < total_items {
+            if let Some(list_idx) = finder_list_index_for_row(
+                editor.finder.mode,
+                row,
+                list_height,
+                total_items,
+                scroll_offset,
+            ) {
                 let item_idx = editor.finder.filtered[list_idx];
                 let item = &editor.finder.items[item_idx];
                 let is_selected = list_idx == editor.finder.selected;
@@ -5822,6 +5818,38 @@ impl Terminal {
     #[allow(dead_code)]
     pub fn poll_key(&self, timeout: std::time::Duration) -> anyhow::Result<bool> {
         Ok(event::poll(timeout)?)
+    }
+}
+
+fn finder_mode_top_aligns_results(mode: crate::finder::FinderMode) -> bool {
+    matches!(mode, crate::finder::FinderMode::GitChanges)
+}
+
+fn finder_list_index_for_row(
+    mode: crate::finder::FinderMode,
+    row: usize,
+    list_height: usize,
+    total_items: usize,
+    scroll_offset: usize,
+) -> Option<usize> {
+    if row >= list_height {
+        return None;
+    }
+
+    let visible_count = list_height.min(total_items.saturating_sub(scroll_offset));
+    if finder_mode_top_aligns_results(mode) {
+        if row < visible_count {
+            Some(scroll_offset + row)
+        } else {
+            None
+        }
+    } else {
+        let first_item_row = list_height.saturating_sub(visible_count);
+        if row >= first_item_row {
+            Some(scroll_offset + (list_height - 1 - row))
+        } else {
+            None
+        }
     }
 }
 
@@ -7762,36 +7790,49 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
         }
 
         // Navigate up - works in both modes
-        // Note: List is rendered Telescope-style (best match at bottom)
-        // Visual UP means going toward higher indices (at visual top)
         (KeyModifiers::NONE, KeyCode::Up)
         | (KeyModifiers::CONTROL, KeyCode::Char('k'))
         | (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
-            editor.finder.select_next(); // Visually goes UP
+            if finder_mode_top_aligns_results(editor.finder.mode) {
+                editor.finder.select_prev();
+            } else {
+                // Telescope-style modes render index 0 at the visual bottom.
+                editor.finder.select_next();
+            }
             adjust_scroll(editor);
             selection_changed = true;
         }
 
         // Navigate down - works in both modes
-        // Visual DOWN means going toward lower indices (at visual bottom)
         (KeyModifiers::NONE, KeyCode::Down)
         | (KeyModifiers::CONTROL, KeyCode::Char('j'))
         | (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
-            editor.finder.select_prev(); // Visually goes DOWN
+            if finder_mode_top_aligns_results(editor.finder.mode) {
+                editor.finder.select_next();
+            } else {
+                // Telescope-style modes render index 0 at the visual bottom.
+                editor.finder.select_prev();
+            }
             adjust_scroll(editor);
             selection_changed = true;
         }
 
         // Normal mode specific: j/k for navigation
-        // Note: List is rendered Telescope-style (best match at bottom, index 0)
-        // So j (down visually) = decrement index, k (up visually) = increment index
         (KeyModifiers::NONE, KeyCode::Char('j')) if is_normal_mode => {
-            editor.finder.select_prev(); // Visually goes DOWN (toward index 0 at bottom)
+            if finder_mode_top_aligns_results(editor.finder.mode) {
+                editor.finder.select_next();
+            } else {
+                editor.finder.select_prev();
+            }
             adjust_scroll(editor);
             selection_changed = true;
         }
         (KeyModifiers::NONE, KeyCode::Char('k')) if is_normal_mode => {
-            editor.finder.select_next(); // Visually goes UP (toward higher indices at top)
+            if finder_mode_top_aligns_results(editor.finder.mode) {
+                editor.finder.select_prev();
+            } else {
+                editor.finder.select_next();
+            }
             adjust_scroll(editor);
             selection_changed = true;
         }
@@ -9195,8 +9236,8 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 mod tests {
     use super::{
         apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
-        Terminal,
+        finder_list_index_for_row, finder_preview_match_ranges, handle_insert_mode, handle_key,
+        replace_completion_text, Terminal,
     };
     use crate::commands::Command;
     use crate::config::{KeymapEntry, Settings};
@@ -9792,6 +9833,71 @@ mod tests {
         assert_eq!(editor.buffer().path.as_ref(), Some(&path));
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_results_render_from_top_of_short_list() {
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 0, 10, 3, 0),
+            Some(0)
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 1, 10, 3, 0),
+            Some(1)
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 2, 10, 3, 0),
+            Some(2)
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 3, 10, 3, 0),
+            None
+        );
+    }
+
+    #[test]
+    fn fuzzy_finder_results_keep_bottom_aligned_short_list() {
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::Files, 6, 10, 3, 0),
+            None
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::Files, 7, 10, 3, 0),
+            Some(2)
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::Files, 8, 10, 3, 0),
+            Some(1)
+        );
+        assert_eq!(
+            finder_list_index_for_row(crate::finder::FinderMode::Files, 9, 10, 3, 0),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn git_changes_navigation_moves_down_through_top_aligned_list() {
+        let mut editor = Editor::default();
+        editor.finder.open_git_changes(vec![
+            crate::finder::FinderItem::new("M alpha.rs".to_string(), PathBuf::from("alpha.rs"))
+                .with_git_status(crate::git::GitFileStatus::Modified),
+            crate::finder::FinderItem::new("M beta.rs".to_string(), PathBuf::from("beta.rs"))
+                .with_git_status(crate::git::GitFileStatus::Modified),
+            crate::finder::FinderItem::new("M gamma.rs".to_string(), PathBuf::from("gamma.rs"))
+                .with_git_status(crate::git::GitFileStatus::Modified),
+        ]);
+        editor.mode = Mode::Finder;
+        editor.finder.enter_normal_mode();
+
+        assert_eq!(editor.finder.selected, 0);
+        handle_key(&mut editor, key('j'));
+        assert_eq!(editor.finder.selected, 1);
+        handle_key(&mut editor, key('k'));
+        assert_eq!(editor.finder.selected, 0);
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        assert_eq!(editor.finder.selected, 1);
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
+        assert_eq!(editor.finder.selected, 0);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4952,9 +4952,11 @@ impl Terminal {
         let show_scroll_indicator = total_items > list_height;
         let scroll_indicator_color = Color::DarkGrey;
 
-        // Draw items with scrolling (starts at row 1, after top border).
-        // Fuzzy search modes keep best matches near the input; fixed Git changes
-        // results are top-aligned so short lists do not leave a large blank pane.
+        // Draw items with scrolling (starts at row 1, after top border)
+        // Telescope-style: best matches at BOTTOM (closest to input)
+        let visible_count = list_height.min(total_items.saturating_sub(scroll_offset));
+        let first_item_row = list_height - visible_count; // Empty rows above items
+
         for row in 0..list_height {
             let y = win.y + 1 + row as u16;
             queue!(
@@ -4965,13 +4967,15 @@ impl Terminal {
             )?;
             write!(self.stdout, "\u{2502}")?; // │
 
-            if let Some(list_idx) = finder_list_index_for_row(
-                editor.finder.mode,
-                row,
-                list_height,
-                total_items,
-                scroll_offset,
-            ) {
+            // Reverse display: row 0 = least relevant, bottom row = best match
+            let list_idx = if row >= first_item_row {
+                // Map row to item index (reversed)
+                scroll_offset + (list_height - 1 - row)
+            } else {
+                usize::MAX // Empty row marker
+            };
+
+            if list_idx < total_items {
                 let item_idx = editor.finder.filtered[list_idx];
                 let item = &editor.finder.items[item_idx];
                 let is_selected = list_idx == editor.finder.selected;
@@ -5818,38 +5822,6 @@ impl Terminal {
     #[allow(dead_code)]
     pub fn poll_key(&self, timeout: std::time::Duration) -> anyhow::Result<bool> {
         Ok(event::poll(timeout)?)
-    }
-}
-
-fn finder_mode_top_aligns_results(mode: crate::finder::FinderMode) -> bool {
-    matches!(mode, crate::finder::FinderMode::GitChanges)
-}
-
-fn finder_list_index_for_row(
-    mode: crate::finder::FinderMode,
-    row: usize,
-    list_height: usize,
-    total_items: usize,
-    scroll_offset: usize,
-) -> Option<usize> {
-    if row >= list_height {
-        return None;
-    }
-
-    let visible_count = list_height.min(total_items.saturating_sub(scroll_offset));
-    if finder_mode_top_aligns_results(mode) {
-        if row < visible_count {
-            Some(scroll_offset + row)
-        } else {
-            None
-        }
-    } else {
-        let first_item_row = list_height.saturating_sub(visible_count);
-        if row >= first_item_row {
-            Some(scroll_offset + (list_height - 1 - row))
-        } else {
-            None
-        }
     }
 }
 
@@ -7790,49 +7762,36 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
         }
 
         // Navigate up - works in both modes
+        // Note: List is rendered Telescope-style (best match at bottom)
+        // Visual UP means going toward higher indices (at visual top)
         (KeyModifiers::NONE, KeyCode::Up)
         | (KeyModifiers::CONTROL, KeyCode::Char('k'))
         | (KeyModifiers::CONTROL, KeyCode::Char('p')) => {
-            if finder_mode_top_aligns_results(editor.finder.mode) {
-                editor.finder.select_prev();
-            } else {
-                // Telescope-style modes render index 0 at the visual bottom.
-                editor.finder.select_next();
-            }
+            editor.finder.select_next(); // Visually goes UP
             adjust_scroll(editor);
             selection_changed = true;
         }
 
         // Navigate down - works in both modes
+        // Visual DOWN means going toward lower indices (at visual bottom)
         (KeyModifiers::NONE, KeyCode::Down)
         | (KeyModifiers::CONTROL, KeyCode::Char('j'))
         | (KeyModifiers::CONTROL, KeyCode::Char('n')) => {
-            if finder_mode_top_aligns_results(editor.finder.mode) {
-                editor.finder.select_next();
-            } else {
-                // Telescope-style modes render index 0 at the visual bottom.
-                editor.finder.select_prev();
-            }
+            editor.finder.select_prev(); // Visually goes DOWN
             adjust_scroll(editor);
             selection_changed = true;
         }
 
         // Normal mode specific: j/k for navigation
+        // Note: List is rendered Telescope-style (best match at bottom, index 0)
+        // So j (down visually) = decrement index, k (up visually) = increment index
         (KeyModifiers::NONE, KeyCode::Char('j')) if is_normal_mode => {
-            if finder_mode_top_aligns_results(editor.finder.mode) {
-                editor.finder.select_next();
-            } else {
-                editor.finder.select_prev();
-            }
+            editor.finder.select_prev(); // Visually goes DOWN (toward index 0 at bottom)
             adjust_scroll(editor);
             selection_changed = true;
         }
         (KeyModifiers::NONE, KeyCode::Char('k')) if is_normal_mode => {
-            if finder_mode_top_aligns_results(editor.finder.mode) {
-                editor.finder.select_prev();
-            } else {
-                editor.finder.select_next();
-            }
+            editor.finder.select_next(); // Visually goes UP (toward higher indices at top)
             adjust_scroll(editor);
             selection_changed = true;
         }
@@ -9236,8 +9195,8 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 mod tests {
     use super::{
         apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        finder_list_index_for_row, finder_preview_match_ranges, handle_insert_mode, handle_key,
-        replace_completion_text, Terminal,
+        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
+        Terminal,
     };
     use crate::commands::Command;
     use crate::config::{KeymapEntry, Settings};
@@ -9833,71 +9792,6 @@ mod tests {
         assert_eq!(editor.buffer().path.as_ref(), Some(&path));
 
         let _ = std::fs::remove_dir_all(&tmp);
-    }
-
-    #[test]
-    fn git_changes_results_render_from_top_of_short_list() {
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 0, 10, 3, 0),
-            Some(0)
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 1, 10, 3, 0),
-            Some(1)
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 2, 10, 3, 0),
-            Some(2)
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::GitChanges, 3, 10, 3, 0),
-            None
-        );
-    }
-
-    #[test]
-    fn fuzzy_finder_results_keep_bottom_aligned_short_list() {
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::Files, 6, 10, 3, 0),
-            None
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::Files, 7, 10, 3, 0),
-            Some(2)
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::Files, 8, 10, 3, 0),
-            Some(1)
-        );
-        assert_eq!(
-            finder_list_index_for_row(crate::finder::FinderMode::Files, 9, 10, 3, 0),
-            Some(0)
-        );
-    }
-
-    #[test]
-    fn git_changes_navigation_moves_down_through_top_aligned_list() {
-        let mut editor = Editor::default();
-        editor.finder.open_git_changes(vec![
-            crate::finder::FinderItem::new("M alpha.rs".to_string(), PathBuf::from("alpha.rs"))
-                .with_git_status(crate::git::GitFileStatus::Modified),
-            crate::finder::FinderItem::new("M beta.rs".to_string(), PathBuf::from("beta.rs"))
-                .with_git_status(crate::git::GitFileStatus::Modified),
-            crate::finder::FinderItem::new("M gamma.rs".to_string(), PathBuf::from("gamma.rs"))
-                .with_git_status(crate::git::GitFileStatus::Modified),
-        ]);
-        editor.mode = Mode::Finder;
-        editor.finder.enter_normal_mode();
-
-        assert_eq!(editor.finder.selected, 0);
-        handle_key(&mut editor, key('j'));
-        assert_eq!(editor.finder.selected, 1);
-        handle_key(&mut editor, key('k'));
-        assert_eq!(editor.finder.selected, 0);
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
-        assert_eq!(editor.finder.selected, 1);
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Up, KeyModifiers::NONE));
-        assert_eq!(editor.finder.selected, 0);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2154,11 +2154,8 @@ impl Terminal {
                 } else {
                     // Cursor in finder input line (at bottom of finder window)
                     // Must use same window calculation as render_finder
-                    let preview_enabled = editor.finder.preview_enabled
-                        && (editor.finder.mode == crate::finder::FinderMode::Files
-                            || editor.finder.mode == crate::finder::FinderMode::Grep
-                            || editor.finder.mode == crate::finder::FinderMode::Harpoon
-                            || editor.finder.mode == crate::finder::FinderMode::Marks);
+                    let preview_enabled =
+                        editor.finder.preview_enabled && editor.finder.mode_supports_preview();
                     let win = crate::finder::FloatingWindow::centered_with_preview(
                         editor.term_width,
                         editor.term_height,
@@ -4833,11 +4830,8 @@ impl Terminal {
         let t_start = Instant::now();
         use crate::finder::FuzzyFinder;
 
-        let preview_enabled = editor.finder.preview_enabled
-            && (editor.finder.mode == crate::finder::FinderMode::Files
-                || editor.finder.mode == crate::finder::FinderMode::Grep
-                || editor.finder.mode == crate::finder::FinderMode::Harpoon
-                || editor.finder.mode == crate::finder::FinderMode::Marks);
+        let preview_enabled =
+            editor.finder.preview_enabled && editor.finder.mode_supports_preview();
         let win = crate::finder::FloatingWindow::centered_with_preview(
             editor.term_width,
             editor.term_height,
@@ -7695,11 +7689,8 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
 
     // Helper to adjust scroll after navigation
     let adjust_scroll = |editor: &mut Editor| {
-        let preview_enabled = editor.finder.preview_enabled
-            && (editor.finder.mode == crate::finder::FinderMode::Files
-                || editor.finder.mode == crate::finder::FinderMode::Grep
-                || editor.finder.mode == crate::finder::FinderMode::Harpoon
-                || editor.finder.mode == crate::finder::FinderMode::Marks);
+        let preview_enabled =
+            editor.finder.preview_enabled && editor.finder.mode_supports_preview();
         let win = crate::finder::FloatingWindow::centered_with_preview(
             editor.term_width,
             editor.term_height,
@@ -7713,7 +7704,7 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
         // Toggle preview panel - Ctrl+t (works in both modes)
         (KeyModifiers::CONTROL, KeyCode::Char('t')) => {
             editor.finder.toggle_preview();
-            if editor.finder.preview_enabled {
+            if editor.finder.preview_enabled && editor.finder.mode_supports_preview() {
                 // Mark preview as needing immediate update (skip debounce on toggle)
                 editor.update_finder_preview();
             }
@@ -7747,6 +7738,12 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
                     if !editor.switch_to_buffer(buf_idx) {
                         editor.set_status("Buffer not found");
                     }
+                } else if item
+                    .git_status
+                    .map(|status| status.is_deleted())
+                    .unwrap_or(false)
+                {
+                    editor.set_status("File was deleted");
                 } else {
                     // Open the selected file
                     let target_line = item.line;
@@ -7807,7 +7804,7 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
         // Normal mode: 'p' to toggle preview
         (KeyModifiers::NONE, KeyCode::Char('p')) if is_normal_mode => {
             editor.finder.toggle_preview();
-            if editor.finder.preview_enabled {
+            if editor.finder.preview_enabled && editor.finder.mode_supports_preview() {
                 editor.update_finder_preview();
             }
         }
@@ -8006,7 +8003,7 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
 
     // Mark preview as needing update (debounced in main loop)
     // This avoids the 10-40ms tree-sitter parsing on every keystroke
-    if selection_changed && editor.finder.preview_enabled {
+    if selection_changed && editor.finder.preview_enabled && editor.finder.mode_supports_preview() {
         editor.finder.preview_update_pending = true;
     }
 
@@ -8829,6 +8826,11 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
 
         Command::FindDiagnostics => {
             editor.open_finder_diagnostics();
+            CommandResult::Ok
+        }
+
+        Command::GitChanges => {
+            editor.open_finder_git_changes();
             CommandResult::Ok
         }
 
@@ -9766,6 +9768,49 @@ mod tests {
 
         assert_eq!(editor.mode, Mode::Normal);
         assert_eq!(editor.current_buffer_index(), 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_enter_opens_existing_file() {
+        let tmp = unique_temp_dir("nevi_git_changes_enter_open");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("changed.rs");
+        std::fs::write(&path, "fn changed() {}\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.finder.open_git_changes(vec![
+            crate::finder::FinderItem::new("M changed.rs".to_string(), path.clone())
+                .with_git_status(crate::git::GitFileStatus::Modified),
+        ]);
+        editor.mode = Mode::Finder;
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.buffer().path.as_ref(), Some(&path));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn git_changes_enter_refuses_deleted_file() {
+        let tmp = unique_temp_dir("nevi_git_changes_enter_deleted");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("deleted.rs");
+
+        let mut editor = Editor::default();
+        editor.finder.open_git_changes(vec![
+            crate::finder::FinderItem::new("D deleted.rs".to_string(), path)
+                .with_git_status(crate::git::GitFileStatus::Deleted),
+        ]);
+        editor.mode = Mode::Finder;
+
+        handle_key(&mut editor, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.status_message.as_deref(), Some("File was deleted"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
PR covers:

Add a finder-style Git changes picker with diff preview, status-prefixed results, path filtering with match highlighting, and editor navigation for selected files.

Also add :GitChanges with aliases and the default <leader>gc mapping.