### PR TITLE
fix: Rust LSP bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -677,6 +686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +727,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -884,11 +933,13 @@ dependencies = [
  "crossterm",
  "dirs",
  "git2",
+ "globset",
  "grep-matcher",
  "grep-regex",
  "grep-searcher",
  "ignore",
  "lsp-types",
+ "notify",
  "nucleo",
  "portable-pty",
  "regex",
@@ -928,6 +979,30 @@ dependencies = [
  "memoffset",
  "pin-utils",
 ]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nucleo"
@@ -1922,6 +1997,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1953,11 +2037,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1973,6 +2074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2090,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1997,10 +2110,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2015,6 +2140,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,6 +2156,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2039,6 +2176,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2049,6 +2192,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bda177466b9524d59f1b12f0dd30b68696788e9992a7e959021c4a0ed96fcf59"
 dependencies = [
  "base64",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "home",
  "libc",
  "log",
@@ -99,9 +99,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bstr"
@@ -202,7 +202,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -260,7 +260,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -399,6 +399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,7 +452,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
  "libgit2-sys",
  "log",
@@ -677,6 +686,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533e68a5842e734946fe159fb03fc9bbbb254f590dd0d8ad321ae5ff7beca2c1"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +727,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -733,7 +782,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "libc",
 ]
 
@@ -890,6 +939,7 @@ dependencies = [
  "grep-searcher",
  "ignore",
  "lsp-types",
+ "notify",
  "nucleo",
  "portable-pty",
  "regex",
@@ -928,6 +978,33 @@ dependencies = [
  "libc",
  "memoffset",
  "pin-utils",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -975,7 +1052,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -987,7 +1064,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -998,7 +1075,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -1017,7 +1094,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1028,7 +1105,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -1121,7 +1198,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -1237,7 +1314,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -1296,7 +1373,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -1309,7 +1386,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
@@ -1829,7 +1906,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5924018406ce0063cd67f8e008104968b74b563ee1b85dde3ed1f7cb87d3dbd"
 dependencies = [
  "arrayvec",
- "bitflags 2.10.0",
+ "bitflags 2.13.0",
  "cursor-icon",
  "log",
  "memchr",
@@ -1923,6 +2000,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -1954,11 +2040,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -1974,6 +2077,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2093,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1998,10 +2113,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2016,6 +2143,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2026,6 +2159,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2040,6 +2179,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2050,6 +2195,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,15 +399,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,26 +677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
-dependencies = [
- "bitflags 2.10.0",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -727,26 +698,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
 dependencies = [
  "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
  "libc",
 ]
 
@@ -939,7 +890,6 @@ dependencies = [
  "grep-searcher",
  "ignore",
  "lsp-types",
- "notify",
  "nucleo",
  "portable-pty",
  "regex",
@@ -979,30 +929,6 @@ dependencies = [
  "memoffset",
  "pin-utils",
 ]
-
-[[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.10.0",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nucleo"
@@ -1997,15 +1923,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -2037,28 +1954,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -2074,12 +1974,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,12 +1984,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2110,22 +1998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2140,12 +2016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,12 +2026,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2176,12 +2040,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2192,12 +2050,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,8 @@ nucleo = "0.5"            # Fast fuzzy matching
 # LSP support
 lsp-types = "0.95"        # LSP protocol types
 serde_json = "1.0"        # JSON serialization for LSP messages
+notify = "8"              # Filesystem notifications for LSP watched files
+globset = "0.4"           # LSP glob pattern matching
 
 # Floating terminal
 portable-pty = "0.8"      # Cross-platform PTY support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ nucleo = "0.5"            # Fast fuzzy matching
 lsp-types = "0.95"        # LSP protocol types
 serde_json = "1.0"        # JSON serialization for LSP messages
 globset = "0.4"           # LSP glob pattern matching
+notify = "8"              # Filesystem watching for LSP watched files
 
 # Floating terminal
 portable-pty = "0.8"      # Cross-platform PTY support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ nucleo = "0.5"            # Fast fuzzy matching
 # LSP support
 lsp-types = "0.95"        # LSP protocol types
 serde_json = "1.0"        # JSON serialization for LSP messages
-notify = "8"              # Filesystem notifications for LSP watched files
 globset = "0.4"           # LSP glob pattern matching
 
 # Floating terminal

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -176,6 +176,11 @@ fn client_capabilities() -> ClientCapabilities {
             work_done_progress: Some(true),
             ..Default::default()
         }),
+        // Opt in to rust-analyzer's experimental/serverStatus notification so we
+        // know when analysis is actually quiescent (vs. just initialized).
+        experimental: Some(serde_json::json!({
+            "serverStatusNotification": true,
+        })),
         ..Default::default()
     }
 }
@@ -1211,6 +1216,18 @@ fn handle_notification(method: &str, params: Option<Value>) -> Option<LspNotific
                 done: kind == "end",
             })
         }
+        "experimental/serverStatus" => {
+            let params = params?;
+            let quiescent = params
+                .get("quiescent")
+                .and_then(|quiescent| quiescent.as_bool())
+                .unwrap_or(false);
+            let message = params
+                .get("message")
+                .and_then(|message| message.as_str())
+                .map(|message| message.to_string());
+            Some(LspNotification::ServerStatus { quiescent, message })
+        }
         _ => None,
     }
 }
@@ -1913,6 +1930,44 @@ mod tests {
                 assert!(!done);
             }
             other => panic!("expected progress notification, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn client_capabilities_advertise_server_status_notification() {
+        let capabilities = client_capabilities();
+
+        let experimental = capabilities
+            .experimental
+            .expect("experimental capabilities");
+        assert_eq!(
+            experimental
+                .get("serverStatusNotification")
+                .and_then(|value| value.as_bool()),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn server_status_notifications_are_parsed() {
+        let quiescent = handle_notification(
+            "experimental/serverStatus",
+            Some(json!({ "quiescent": true, "health": "ok" })),
+        )
+        .expect("server status notification");
+        match quiescent {
+            LspNotification::ServerStatus { quiescent, .. } => assert!(quiescent),
+            other => panic!("expected server status notification, got {other:?}"),
+        }
+
+        let indexing = handle_notification(
+            "experimental/serverStatus",
+            Some(json!({ "quiescent": false })),
+        )
+        .expect("server status notification");
+        match indexing {
+            LspNotification::ServerStatus { quiescent, .. } => assert!(!quiescent),
+            other => panic!("expected server status notification, got {other:?}"),
         }
     }
 }

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -172,15 +172,6 @@ fn client_capabilities() -> ClientCapabilities {
             }),
             ..Default::default()
         }),
-        workspace: Some(lsp_types::WorkspaceClientCapabilities {
-            did_change_watched_files: Some(
-                lsp_types::DidChangeWatchedFilesClientCapabilities {
-                    dynamic_registration: Some(true),
-                    relative_pattern_support: Some(true),
-                },
-            ),
-            ..Default::default()
-        }),
         window: Some(lsp_types::WindowClientCapabilities {
             work_done_progress: Some(true),
             ..Default::default()
@@ -1908,19 +1899,6 @@ mod tests {
                 .and_then(|window| window.work_done_progress),
             Some(true)
         );
-    }
-
-    #[test]
-    fn client_capabilities_delegate_file_watching_to_the_client() {
-        let capabilities = client_capabilities();
-
-        let watched_files = capabilities
-            .workspace
-            .and_then(|workspace| workspace.did_change_watched_files)
-            .expect("watched-file capabilities");
-
-        assert_eq!(watched_files.dynamic_registration, Some(true));
-        assert_eq!(watched_files.relative_pattern_support, Some(true));
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -6,7 +6,7 @@ use std::hash::{Hash, Hasher};
 use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{self, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
 
 use anyhow::{anyhow, Result};
@@ -22,6 +22,11 @@ use serde_json::{json, Value};
 use super::types::{
     CodeActionItem, CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity, Location,
     LspNotification, ParameterInfo, RequestKind, SignatureHelpResult, SignatureInfo, TextEdit,
+};
+#[cfg(test)]
+use super::watched_files::WATCHED_FILES_METHOD;
+use super::watched_files::{
+    parse_register_params, parse_unregister_params, WatcherCommand, WatcherRequestError,
 };
 
 /// Shared pending requests map - maps request ID to request kind
@@ -169,6 +174,13 @@ fn client_capabilities() -> ClientCapabilities {
                     },
                 }),
                 ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        workspace: Some(lsp_types::WorkspaceClientCapabilities {
+            did_change_watched_files: Some(lsp_types::DidChangeWatchedFilesClientCapabilities {
+                dynamic_registration: Some(true),
+                relative_pattern_support: Some(true),
             }),
             ..Default::default()
         }),
@@ -720,6 +732,7 @@ pub fn read_messages(
     tx: Sender<LspNotification>,
     pending: PendingRequests,
     stdin: SharedStdin,
+    watcher_tx: Sender<WatcherCommand>,
 ) {
     let mut reader = BufReader::new(stdout);
     let mut headers = String::new();
@@ -769,7 +782,8 @@ pub fn read_messages(
         };
 
         // Handle the message using the shared pending map
-        let (notification, response_to_server) = handle_message(response, &pending);
+        let (notification, response_to_server) =
+            handle_message(response, &pending, Some(&watcher_tx));
 
         // Send response to server if needed (for server-initiated requests)
         if let Some(response_msg) = response_to_server {
@@ -803,6 +817,7 @@ pub fn read_messages(
 fn handle_message(
     msg: JsonRpcResponse,
     pending: &PendingRequests,
+    watcher_tx: Option<&Sender<WatcherCommand>>,
 ) -> (Option<LspNotification>, Option<String>) {
     // Check if it's a notification (no id) - these are server-initiated notifications
     if msg.id.is_none() {
@@ -817,7 +832,7 @@ fn handle_message(
     // Check if it's a server-initiated REQUEST (has both id AND method)
     // These require us to send a response back
     if let Some(method) = &msg.method {
-        let response = handle_server_request(id, method, msg.params);
+        let response = handle_server_request(id, method, msg.params, watcher_tx);
         return (None, response);
     }
 
@@ -996,7 +1011,48 @@ fn handle_message(
 
 /// Handle a server-initiated request (server is asking us something)
 /// Returns a JSON-RPC response string to send back
-fn handle_server_request(id: JsonRpcId, method: &str, params: Option<Value>) -> Option<String> {
+fn success_response(id: JsonRpcId) -> Option<String> {
+    build_response(JsonRpcResponseOut {
+        jsonrpc: "2.0",
+        id,
+        result: Some(Value::Null),
+        error: None,
+    })
+}
+
+fn error_response(id: JsonRpcId, code: i64, message: impl Into<String>) -> Option<String> {
+    build_response(JsonRpcResponseOut {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(JsonRpcErrorOut {
+            code,
+            message: message.into(),
+        }),
+    })
+}
+
+fn send_watcher_command(
+    watcher_tx: Option<&Sender<WatcherCommand>>,
+    build: impl FnOnce(SyncSender<std::result::Result<(), WatcherRequestError>>) -> WatcherCommand,
+) -> std::result::Result<(), WatcherRequestError> {
+    let watcher_tx = watcher_tx
+        .ok_or_else(|| WatcherRequestError::Setup("watched-file worker unavailable".to_string()))?;
+    let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+    watcher_tx.send(build(reply_tx)).map_err(|error| {
+        WatcherRequestError::Setup(format!("failed to send watched-file command: {error}"))
+    })?;
+    reply_rx.recv().map_err(|error| {
+        WatcherRequestError::Setup(format!("watched-file worker did not reply: {error}"))
+    })?
+}
+
+fn handle_server_request(
+    id: JsonRpcId,
+    method: &str,
+    params: Option<Value>,
+    watcher_tx: Option<&Sender<WatcherCommand>>,
+) -> Option<String> {
     match method {
         "workspace/configuration" => {
             // Server is asking for configuration
@@ -1019,14 +1075,29 @@ fn handle_server_request(id: JsonRpcId, method: &str, params: Option<Value>) -> 
             })
         }
         "client/registerCapability" => {
-            // Server wants to register dynamic capabilities
-            // Acknowledge with null result
-            build_response(JsonRpcResponseOut {
-                jsonrpc: "2.0",
-                id,
-                result: Some(Value::Null),
-                error: None,
-            })
+            let registrations = match parse_register_params(params) {
+                Ok(registrations) => registrations,
+                Err(WatcherRequestError::InvalidParams(message)) => {
+                    return error_response(id, -32602, message);
+                }
+                Err(WatcherRequestError::Setup(message)) => {
+                    return error_response(id, -32603, message);
+                }
+            };
+            if registrations.is_empty() {
+                return success_response(id);
+            }
+
+            match send_watcher_command(watcher_tx, |reply| WatcherCommand::Register {
+                registrations,
+                reply,
+            }) {
+                Ok(()) => success_response(id),
+                Err(WatcherRequestError::InvalidParams(message)) => {
+                    error_response(id, -32602, message)
+                }
+                Err(WatcherRequestError::Setup(message)) => error_response(id, -32603, message),
+            }
         }
         "window/workDoneProgress/create" => {
             // Server wants to create a progress indicator
@@ -1057,13 +1128,29 @@ fn handle_server_request(id: JsonRpcId, method: &str, params: Option<Value>) -> 
             })
         }
         "client/unregisterCapability" => {
-            // Accept unregister requests
-            build_response(JsonRpcResponseOut {
-                jsonrpc: "2.0",
-                id,
-                result: Some(Value::Null),
-                error: None,
-            })
+            let registration_ids = match parse_unregister_params(params) {
+                Ok(registration_ids) => registration_ids,
+                Err(WatcherRequestError::InvalidParams(message)) => {
+                    return error_response(id, -32602, message);
+                }
+                Err(WatcherRequestError::Setup(message)) => {
+                    return error_response(id, -32603, message);
+                }
+            };
+            if registration_ids.is_empty() {
+                return success_response(id);
+            }
+
+            match send_watcher_command(watcher_tx, |reply| WatcherCommand::Unregister {
+                registration_ids,
+                reply,
+            }) {
+                Ok(()) => success_response(id),
+                Err(WatcherRequestError::InvalidParams(message)) => {
+                    error_response(id, -32602, message)
+                }
+                Err(WatcherRequestError::Setup(message)) => error_response(id, -32603, message),
+            }
         }
         "workspace/applyEdit" => {
             // We don't support workspace edits yet; explicitly reject.
@@ -1838,6 +1925,8 @@ fn handle_completion_resolve_response(
 mod tests {
     use super::*;
     use crate::lsp::types::{DiagnosticCode, DiagnosticSeverity};
+    use lsp_types::Url;
+    use std::thread;
 
     #[test]
     fn code_action_diagnostic_conversion_preserves_multiline_end_line() {
@@ -1899,6 +1988,80 @@ mod tests {
                 .and_then(|window| window.work_done_progress),
             Some(true)
         );
+    }
+
+    #[test]
+    fn client_capabilities_delegate_file_watching_to_the_client() {
+        let capabilities = client_capabilities();
+
+        let watched_files = capabilities
+            .workspace
+            .and_then(|workspace| workspace.did_change_watched_files)
+            .expect("watched-file capabilities");
+
+        assert_eq!(watched_files.dynamic_registration, Some(true));
+        assert_eq!(watched_files.relative_pattern_support, Some(true));
+    }
+
+    #[test]
+    fn watched_file_registration_is_forwarded_before_success_response() {
+        let root = std::env::temp_dir();
+        let (command_tx, command_rx) = mpsc::channel();
+        let worker = thread::spawn(move || match command_rx.recv().expect("watcher command") {
+            WatcherCommand::Register {
+                registrations,
+                reply,
+            } => {
+                assert_eq!(registrations.len(), 1);
+                assert_eq!(registrations[0].id, "rust-files");
+                reply.send(Ok(())).unwrap();
+            }
+            other => panic!("unexpected command: {other:?}"),
+        });
+
+        let response = handle_server_request(
+            JsonRpcId::Num(7),
+            "client/registerCapability",
+            Some(json!({
+                "registrations": [{
+                    "id": "rust-files",
+                    "method": WATCHED_FILES_METHOD,
+                    "registerOptions": {
+                        "watchers": [{
+                            "globPattern": {
+                                "baseUri": Url::from_file_path(&root).unwrap(),
+                                "pattern": "**/*.rs"
+                            }
+                        }]
+                    }
+                }]
+            })),
+            Some(&command_tx),
+        )
+        .expect("response");
+
+        worker.join().unwrap();
+        assert!(response.contains("\"result\":null"));
+    }
+
+    #[test]
+    fn malformed_watched_file_registration_returns_invalid_params() {
+        let (command_tx, _command_rx) = mpsc::channel();
+        let response = handle_server_request(
+            JsonRpcId::Num(8),
+            "client/registerCapability",
+            Some(json!({
+                "registrations": [{
+                    "id": "broken",
+                    "method": WATCHED_FILES_METHOD,
+                    "registerOptions": { "watchers": "not-an-array" }
+                }]
+            })),
+            Some(&command_tx),
+        )
+        .expect("response");
+
+        assert!(response.contains("\"code\":-32602"));
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -172,6 +172,15 @@ fn client_capabilities() -> ClientCapabilities {
             }),
             ..Default::default()
         }),
+        workspace: Some(lsp_types::WorkspaceClientCapabilities {
+            did_change_watched_files: Some(
+                lsp_types::DidChangeWatchedFilesClientCapabilities {
+                    dynamic_registration: Some(true),
+                    relative_pattern_support: Some(true),
+                },
+            ),
+            ..Default::default()
+        }),
         window: Some(lsp_types::WindowClientCapabilities {
             work_done_progress: Some(true),
             ..Default::default()
@@ -1899,6 +1908,19 @@ mod tests {
                 .and_then(|window| window.work_done_progress),
             Some(true)
         );
+    }
+
+    #[test]
+    fn client_capabilities_delegate_file_watching_to_the_client() {
+        let capabilities = client_capabilities();
+
+        let watched_files = capabilities
+            .workspace
+            .and_then(|workspace| workspace.did_change_watched_files)
+            .expect("watched-file capabilities");
+
+        assert_eq!(watched_files.dynamic_registration, Some(true));
+        assert_eq!(watched_files.relative_pattern_support, Some(true));
     }
 
     #[test]

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -8,6 +8,7 @@ use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc::{self, Sender, SyncSender};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 use anyhow::{anyhow, Result};
 use lsp_types::{
@@ -33,6 +34,11 @@ use super::watched_files::{
 /// This is shared between the request sender and response reader threads
 pub type PendingRequests = Arc<Mutex<HashMap<u64, RequestKind>>>;
 pub type SharedStdin = Arc<Mutex<ChildStdin>>;
+
+#[cfg(not(test))]
+const WATCHER_COMMAND_REPLY_TIMEOUT: Duration = Duration::from_secs(2);
+#[cfg(test)]
+const WATCHER_COMMAND_REPLY_TIMEOUT: Duration = Duration::from_millis(50);
 
 /// JSON-RPC request message
 #[derive(Debug, Serialize)]
@@ -1042,9 +1048,15 @@ fn send_watcher_command(
     watcher_tx.send(build(reply_tx)).map_err(|error| {
         WatcherRequestError::Setup(format!("failed to send watched-file command: {error}"))
     })?;
-    reply_rx.recv().map_err(|error| {
-        WatcherRequestError::Setup(format!("watched-file worker did not reply: {error}"))
-    })?
+    match reply_rx.recv_timeout(WATCHER_COMMAND_REPLY_TIMEOUT) {
+        Ok(result) => result,
+        Err(mpsc::RecvTimeoutError::Timeout) => Err(WatcherRequestError::Setup(
+            "watched-file worker reply timed out".to_string(),
+        )),
+        Err(mpsc::RecvTimeoutError::Disconnected) => Err(WatcherRequestError::Setup(
+            "watched-file worker reply channel closed".to_string(),
+        )),
+    }
 }
 
 fn handle_server_request(
@@ -1926,7 +1938,35 @@ mod tests {
     use super::*;
     use crate::lsp::types::{DiagnosticCode, DiagnosticSeverity};
     use lsp_types::Url;
+    use std::path::Path;
     use std::thread;
+    use std::time::Duration;
+
+    fn watched_file_register_params(root: &Path) -> Option<Value> {
+        Some(json!({
+            "registrations": [{
+                "id": "rust-files",
+                "method": WATCHED_FILES_METHOD,
+                "registerOptions": {
+                    "watchers": [{
+                        "globPattern": {
+                            "baseUri": Url::from_file_path(root).unwrap(),
+                            "pattern": "**/*.rs"
+                        }
+                    }]
+                }
+            }]
+        }))
+    }
+
+    fn watched_file_unregister_params() -> Option<Value> {
+        Some(json!({
+            "unregisterations": [{
+                "id": "rust-files",
+                "method": WATCHED_FILES_METHOD
+            }]
+        }))
+    }
 
     #[test]
     fn code_action_diagnostic_conversion_preserves_multiline_end_line() {
@@ -2022,26 +2062,160 @@ mod tests {
         let response = handle_server_request(
             JsonRpcId::Num(7),
             "client/registerCapability",
-            Some(json!({
-                "registrations": [{
-                    "id": "rust-files",
-                    "method": WATCHED_FILES_METHOD,
-                    "registerOptions": {
-                        "watchers": [{
-                            "globPattern": {
-                                "baseUri": Url::from_file_path(&root).unwrap(),
-                                "pattern": "**/*.rs"
-                            }
-                        }]
-                    }
-                }]
-            })),
+            watched_file_register_params(&root),
             Some(&command_tx),
         )
         .expect("response");
 
         worker.join().unwrap();
         assert!(response.contains("\"result\":null"));
+    }
+
+    #[test]
+    fn watched_file_unregistration_is_forwarded_before_success_response() {
+        let (command_tx, command_rx) = mpsc::channel();
+        let worker = thread::spawn(move || match command_rx.recv().expect("watcher command") {
+            WatcherCommand::Unregister {
+                registration_ids,
+                reply,
+            } => {
+                assert_eq!(registration_ids, vec!["rust-files".to_string()]);
+                reply.send(Ok(())).unwrap();
+            }
+            other => panic!("unexpected command: {other:?}"),
+        });
+
+        let response = handle_server_request(
+            JsonRpcId::Num(9),
+            "client/unregisterCapability",
+            watched_file_unregister_params(),
+            Some(&command_tx),
+        )
+        .expect("response");
+
+        worker.join().unwrap();
+        assert!(response.contains("\"result\":null"));
+    }
+
+    #[test]
+    fn unrelated_dynamic_registration_requests_do_not_touch_watcher() {
+        let (command_tx, command_rx) = mpsc::channel();
+
+        let register_response = handle_server_request(
+            JsonRpcId::Num(10),
+            "client/registerCapability",
+            Some(json!({
+                "registrations": [{
+                    "id": "configuration",
+                    "method": "workspace/didChangeConfiguration"
+                }]
+            })),
+            Some(&command_tx),
+        )
+        .expect("register response");
+
+        let unregister_response = handle_server_request(
+            JsonRpcId::Num(11),
+            "client/unregisterCapability",
+            Some(json!({
+                "unregisterations": [{
+                    "id": "configuration",
+                    "method": "workspace/didChangeConfiguration"
+                }]
+            })),
+            Some(&command_tx),
+        )
+        .expect("unregister response");
+
+        assert!(register_response.contains("\"result\":null"));
+        assert!(unregister_response.contains("\"result\":null"));
+        assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn watcher_setup_error_returns_internal_error() {
+        let root = std::env::temp_dir();
+        let (command_tx, command_rx) = mpsc::channel();
+        let worker = thread::spawn(move || match command_rx.recv().expect("watcher command") {
+            WatcherCommand::Register { reply, .. } => {
+                reply
+                    .send(Err(WatcherRequestError::Setup(
+                        "watch setup failed".to_string(),
+                    )))
+                    .unwrap();
+            }
+            other => panic!("unexpected command: {other:?}"),
+        });
+
+        let response = handle_server_request(
+            JsonRpcId::Num(12),
+            "client/registerCapability",
+            watched_file_register_params(&root),
+            Some(&command_tx),
+        )
+        .expect("response");
+
+        worker.join().unwrap();
+        assert!(response.contains("\"code\":-32603"));
+    }
+
+    #[test]
+    fn missing_or_closed_watcher_sender_returns_internal_error() {
+        let root = std::env::temp_dir();
+        let missing_response = handle_server_request(
+            JsonRpcId::Num(13),
+            "client/registerCapability",
+            watched_file_register_params(&root),
+            None,
+        )
+        .expect("missing watcher response");
+
+        let (command_tx, command_rx) = mpsc::channel();
+        drop(command_rx);
+        let closed_response = handle_server_request(
+            JsonRpcId::Num(14),
+            "client/registerCapability",
+            watched_file_register_params(&root),
+            Some(&command_tx),
+        )
+        .expect("closed watcher response");
+
+        assert!(missing_response.contains("\"code\":-32603"));
+        assert!(closed_response.contains("\"code\":-32603"));
+    }
+
+    #[test]
+    fn watcher_reply_timeout_returns_internal_error() {
+        let root = std::env::temp_dir();
+        let (command_tx, command_rx) = mpsc::channel();
+        let (release_tx, release_rx) = mpsc::channel();
+        let worker = thread::spawn(move || match command_rx.recv().expect("watcher command") {
+            WatcherCommand::Register { reply, .. } => {
+                let _reply = reply;
+                let _ = release_rx.recv();
+            }
+            other => panic!("unexpected command: {other:?}"),
+        });
+        let (done_tx, done_rx) = mpsc::channel();
+        let request_tx = command_tx.clone();
+        let requester = thread::spawn(move || {
+            let response = handle_server_request(
+                JsonRpcId::Num(15),
+                "client/registerCapability",
+                watched_file_register_params(&root),
+                Some(&request_tx),
+            )
+            .expect("response");
+            done_tx.send(response).unwrap();
+        });
+
+        let result = done_rx.recv_timeout(Duration::from_millis(200));
+        let _ = release_tx.send(());
+        worker.join().unwrap();
+        requester.join().unwrap();
+        let response = result.expect("watcher routing should time out");
+
+        assert!(response.contains("\"code\":-32603"));
     }
 
     #[test]

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -13,6 +13,7 @@ pub mod types;
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};
 use std::thread::{self, JoinHandle};
+use std::time::Duration;
 
 use lsp_types::Url;
 
@@ -86,11 +87,25 @@ impl LspManager {
         self.status == LspStatus::Ready
     }
 
-    /// Shutdown the LSP manager
+    /// Shutdown the LSP manager.
+    ///
+    /// Sends a graceful shutdown, then waits only *briefly* for the worker thread to
+    /// exit. The worker can be blocked writing to a busy server's stdin, and an
+    /// unbounded `join()` here would hang the editor on quit (this is why `:wq` could
+    /// freeze and leave orphaned `nevi` processes). We bound the wait and move on:
+    /// - common case: the worker exits in ms and its `LspClient` drop kills the server;
+    /// - stuck case: we give up quickly and let the process exit — the server
+    ///   self-terminates because we passed our processId in `initialize`.
     pub fn shutdown(&mut self) {
         let _ = self.request_tx.send(LspRequest::Shutdown);
         if let Some(handle) = self.thread_handle.take() {
-            let _ = handle.join();
+            let (done_tx, done_rx) = mpsc::channel();
+            thread::spawn(move || {
+                let _ = handle.join();
+                let _ = done_tx.send(());
+            });
+            // Bounded: graceful shutdown is fast when the server isn't wedged.
+            let _ = done_rx.recv_timeout(Duration::from_millis(300));
         }
         self.status = LspStatus::Stopped;
     }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -9,6 +9,7 @@
 mod client;
 pub mod multi;
 pub mod types;
+mod watched_files;
 
 use std::path::PathBuf;
 use std::sync::mpsc::{self, Receiver, Sender};

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -295,6 +295,21 @@ fn run_lsp_thread(
         }
     };
 
+    let mut watched_files = match watched_files::WatchedFilesHandle::start(
+        root_path.clone(),
+        stdin.clone(),
+        notification_tx.clone(),
+    ) {
+        Ok(handle) => handle,
+        Err(error) => {
+            let _ = notification_tx.send(LspNotification::Error {
+                message: format!("Failed to start LSP file watcher: {error}"),
+            });
+            return;
+        }
+    };
+    let watcher_tx = watched_files.command_sender();
+
     // Start stdout reader thread
     let stdout = match client.take_stdout() {
         Some(s) => s,
@@ -311,7 +326,7 @@ fn run_lsp_thread(
     // so responses are guaranteed to find their request kinds
     let notification_tx_clone = notification_tx.clone();
     let reader_handle = thread::spawn(move || {
-        client::read_messages(stdout, notification_tx_clone, pending, stdin);
+        client::read_messages(stdout, notification_tx_clone, pending, stdin, watcher_tx);
     });
 
     // Spawn stderr reader thread to capture LSP server errors
@@ -506,6 +521,8 @@ fn run_lsp_thread(
             }
         }
     }
+
+    watched_files.shutdown();
 
     // Wait for reader thread to finish (it will exit when stdout closes)
     let _ = reader_handle.join();

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -22,6 +22,8 @@ pub use client::LspClient;
 pub use multi::{LanguageId, MultiLspManager};
 pub use types::*;
 
+const READER_JOIN_TIMEOUT: Duration = Duration::from_millis(300);
+
 /// Manager for the LSP client thread
 pub struct LspManager {
     /// Channel to send requests to the LSP thread
@@ -276,6 +278,15 @@ impl Drop for LspManager {
     }
 }
 
+fn join_thread_with_timeout(handle: JoinHandle<()>, timeout: Duration) -> bool {
+    let (done_tx, done_rx) = mpsc::channel();
+    thread::spawn(move || {
+        let _ = handle.join();
+        let _ = done_tx.send(());
+    });
+    done_rx.recv_timeout(timeout).is_ok()
+}
+
 /// Run the LSP client thread
 fn run_lsp_thread(
     command: &str,
@@ -524,8 +535,8 @@ fn run_lsp_thread(
 
     watched_files.shutdown();
 
-    // Wait for reader thread to finish (it will exit when stdout closes)
-    let _ = reader_handle.join();
+    // Bounded: stdout readers can wedge if the server ignores shutdown.
+    let _ = join_thread_with_timeout(reader_handle, READER_JOIN_TIMEOUT);
 }
 
 /// Convert a file path to a file:// URI
@@ -583,8 +594,24 @@ fn detect_language(path: &PathBuf) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::detect_language;
+    use super::{detect_language, join_thread_with_timeout};
     use std::path::PathBuf;
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn reader_thread_join_helper_returns_without_waiting_forever() {
+        let (release_tx, release_rx) = mpsc::channel::<()>();
+        let handle = thread::spawn(move || {
+            let _ = release_rx.recv();
+        });
+
+        let started = Instant::now();
+        assert!(!join_thread_with_timeout(handle, Duration::from_millis(20)));
+        assert!(started.elapsed() < Duration::from_millis(200));
+        drop(release_tx);
+    }
 
     #[test]
     fn detect_language_maps_all_routed_lsp_extensions() {

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -70,6 +70,11 @@ impl LanguageId {
 struct LspInstance {
     manager: LspManager,
     ready: bool,
+    /// Analysis readiness reported via `experimental/serverStatus`:
+    /// `None`  — server doesn't report status; treat as ready once initialized.
+    /// `Some(false)` — initialized but still indexing/analyzing.
+    /// `Some(true)`  — quiescent; requests can be answered reliably.
+    analysis_ready: Option<bool>,
     last_error: Option<String>,
     progress: Option<LspProgressState>,
     current_file: Option<PathBuf>,
@@ -277,6 +282,17 @@ impl MultiLspManager {
         now.duration_since(started_at) >= PROGRESS_DISPLAY_DELAY
     }
 
+    /// Statusline label once the handshake is done: "ready" when the server is
+    /// quiescent, "indexing…" while it is still analyzing (rust-analyzer reports
+    /// this via `experimental/serverStatus`).
+    fn lifecycle_label(server_name: &str, lang: LanguageId, indexing: bool) -> String {
+        if indexing {
+            format!("LSP: {} indexing… ({})", server_name, lang.as_lsp_id())
+        } else {
+            format!("LSP: {} ready ({})", server_name, lang.as_lsp_id())
+        }
+    }
+
     /// Create a new multi-LSP manager with the given configurations
     pub fn new(
         workspace_root: PathBuf,
@@ -351,6 +367,7 @@ impl MultiLspManager {
                     LspInstance {
                         manager,
                         ready: false,
+                        analysis_ready: None,
                         last_error: None,
                         progress: None,
                         current_file: None,
@@ -420,6 +437,13 @@ impl MultiLspManager {
                 if let LspNotification::Initialized = &notification {
                     instance.ready = true;
                     instance.last_error = None;
+                    // Handshake done, but analysis hasn't started yet. Wait for a
+                    // serverStatus notification (if the server sends them) before
+                    // reporting "ready" rather than "indexing".
+                    instance.analysis_ready = None;
+                }
+                if let LspNotification::ServerStatus { quiescent, .. } = &notification {
+                    instance.analysis_ready = Some(*quiescent);
                 }
                 if let LspNotification::Progress {
                     title,
@@ -447,6 +471,7 @@ impl MultiLspManager {
                     // Keep the server ready unless we detect a transport/startup failure.
                     if Self::is_fatal_error(message) {
                         instance.ready = false;
+                        instance.analysis_ready = None;
                         let command = self
                             .configs
                             .get(&lang)
@@ -720,6 +745,10 @@ impl MultiLspManager {
                         .map(|c| c.effective_command())
                         .unwrap_or("unknown");
 
+                    // `ready` (handshake) gates requests; `analysis_ready == Some(false)`
+                    // means the server is up but still indexing, so don't claim "ready".
+                    let indexing = instance.analysis_ready == Some(false);
+
                     if let Some(error) = &instance.last_error {
                         return format!("LSP: {error}");
                     } else if let Some(progress) = &instance.progress {
@@ -732,11 +761,11 @@ impl MultiLspManager {
                             );
                         }
                     } else if instance.ready {
-                        return format!("LSP: {} ready ({})", server_name, lang.as_lsp_id());
+                        return Self::lifecycle_label(server_name, lang, indexing);
                     }
 
                     if instance.ready {
-                        return format!("LSP: {} ready ({})", server_name, lang.as_lsp_id());
+                        return Self::lifecycle_label(server_name, lang, indexing);
                     }
 
                     return format!("LSP: starting {} ({})...", server_name, lang.as_lsp_id());
@@ -963,5 +992,16 @@ mod tests {
             now - PROGRESS_DISPLAY_DELAY,
             now
         ));
+    }
+
+    #[test]
+    fn lifecycle_label_distinguishes_indexing_from_ready() {
+        let ready = MultiLspManager::lifecycle_label("rust-analyzer", LanguageId::Rust, false);
+        assert!(ready.contains("ready"), "got: {ready}");
+        assert!(!ready.contains("indexing"), "got: {ready}");
+
+        let indexing = MultiLspManager::lifecycle_label("rust-analyzer", LanguageId::Rust, true);
+        assert!(indexing.contains("indexing"), "got: {indexing}");
+        assert!(!indexing.contains("ready"), "got: {indexing}");
     }
 }

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -232,6 +232,14 @@ pub enum LspNotification {
     /// Server status update
     Status { message: String },
 
+    /// Analysis-readiness status (e.g. rust-analyzer `experimental/serverStatus`).
+    /// `quiescent` is false while the server is still indexing/analyzing and true
+    /// once it can answer requests reliably.
+    ServerStatus {
+        quiescent: bool,
+        message: Option<String>,
+    },
+
     /// Formatting result with text edits to apply
     Formatting {
         edits: Vec<TextEdit>,

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -1,0 +1,324 @@
+use std::collections::{HashMap, HashSet};
+use std::io::Write;
+use std::path::{Component, Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use globset::{GlobBuilder, GlobMatcher};
+use lsp_types::{
+    DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileChangeType,
+    FileEvent, GlobPattern, OneOf, RegistrationParams, RelativePattern, UnregistrationParams, Url,
+    WatchKind,
+};
+use notify::event::{ModifyKind, RenameMode};
+use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use serde_json::json;
+
+use super::client::SharedStdin;
+use super::types::LspNotification;
+
+pub(crate) const WATCHED_FILES_METHOD: &str = "workspace/didChangeWatchedFiles";
+
+#[derive(Debug)]
+pub(crate) enum WatcherRequestError {
+    InvalidParams(String),
+    Setup(String),
+}
+
+impl std::fmt::Display for WatcherRequestError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::InvalidParams(message) | Self::Setup(message) => formatter.write_str(message),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WatchedFileRegistration {
+    pub(crate) id: String,
+    pub(crate) options: DidChangeWatchedFilesRegistrationOptions,
+}
+
+#[derive(Debug)]
+pub(crate) enum WatcherCommand {
+    Register {
+        registrations: Vec<WatchedFileRegistration>,
+        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
+    },
+    Unregister {
+        registration_ids: Vec<String>,
+        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
+    },
+    Event(notify::Result<Event>),
+    Shutdown,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MatchInput {
+    Relative,
+    Absolute,
+}
+
+#[derive(Clone)]
+struct CompiledWatcher {
+    base: PathBuf,
+    root: PathBuf,
+    matcher: GlobMatcher,
+    input: MatchInput,
+    kind: WatchKind,
+}
+
+#[derive(Clone, Default)]
+struct RegistrationState {
+    registrations: HashMap<String, Vec<CompiledWatcher>>,
+}
+
+fn normalized_match_path(path: &Path) -> String {
+    path.components()
+        .filter_map(|component| match component {
+            Component::Prefix(prefix) => Some(prefix.as_os_str().to_string_lossy().into_owned()),
+            Component::RootDir => Some(String::new()),
+            Component::CurDir => None,
+            Component::ParentDir => Some("..".to_string()),
+            Component::Normal(part) => Some(part.to_string_lossy().into_owned()),
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn watch_kind_allows(kind: WatchKind, change: FileChangeType) -> bool {
+    match change {
+        FileChangeType::CREATED => kind.contains(WatchKind::Create),
+        FileChangeType::CHANGED => kind.contains(WatchKind::Change),
+        FileChangeType::DELETED => kind.contains(WatchKind::Delete),
+        _ => false,
+    }
+}
+
+fn contains_glob_meta(segment: &str) -> bool {
+    segment
+        .bytes()
+        .any(|byte| matches!(byte, b'*' | b'?' | b'[' | b'{'))
+}
+
+fn absolute_pattern_root(pattern: &str) -> PathBuf {
+    let path = Path::new(pattern);
+    let mut prefix = PathBuf::new();
+
+    for component in path.components() {
+        let text = component.as_os_str().to_string_lossy();
+        if contains_glob_meta(&text) {
+            break;
+        }
+        prefix.push(component.as_os_str());
+    }
+
+    if prefix == path {
+        prefix.parent().unwrap_or(Path::new("/")).to_path_buf()
+    } else if prefix.as_os_str().is_empty() {
+        PathBuf::from("/")
+    } else {
+        prefix
+    }
+}
+
+fn compile_glob(pattern: &str) -> Result<GlobMatcher> {
+    Ok(GlobBuilder::new(pattern)
+        .literal_separator(true)
+        .backslash_escape(false)
+        .build()
+        .with_context(|| format!("invalid LSP glob pattern: {pattern}"))?
+        .compile_matcher())
+}
+
+fn relative_pattern_base(pattern: &RelativePattern) -> Result<PathBuf> {
+    let uri = match &pattern.base_uri {
+        OneOf::Left(folder) => &folder.uri,
+        OneOf::Right(uri) => uri,
+    };
+    uri.to_file_path()
+        .map_err(|_| anyhow!("watched-file base URI is not a file URI: {uri}"))
+}
+
+pub(crate) fn parse_register_params(
+    params: Option<serde_json::Value>,
+) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> {
+    let params: RegistrationParams = serde_json::from_value(params.ok_or_else(|| {
+        WatcherRequestError::InvalidParams("missing registration params".to_string())
+    })?)
+    .map_err(|error| WatcherRequestError::InvalidParams(error.to_string()))?;
+
+    params
+        .registrations
+        .into_iter()
+        .filter(|registration| registration.method == WATCHED_FILES_METHOD)
+        .map(|registration| {
+            let options = serde_json::from_value(registration.register_options.ok_or_else(
+                || {
+                    WatcherRequestError::InvalidParams(format!(
+                        "watched-file registration {} has no options",
+                        registration.id
+                    ))
+                },
+            )?)
+            .map_err(|error| WatcherRequestError::InvalidParams(error.to_string()))?;
+            Ok(WatchedFileRegistration {
+                id: registration.id,
+                options,
+            })
+        })
+        .collect()
+}
+
+pub(crate) fn parse_unregister_params(
+    params: Option<serde_json::Value>,
+) -> std::result::Result<Vec<String>, WatcherRequestError> {
+    let params: UnregistrationParams = serde_json::from_value(params.ok_or_else(|| {
+        WatcherRequestError::InvalidParams("missing unregistration params".to_string())
+    })?)
+    .map_err(|error| WatcherRequestError::InvalidParams(error.to_string()))?;
+
+    Ok(params
+        .unregisterations
+        .into_iter()
+        .filter(|registration| registration.method == WATCHED_FILES_METHOD)
+        .map(|registration| registration.id)
+        .collect())
+}
+
+fn compile_watcher(
+    watcher: &lsp_types::FileSystemWatcher,
+    workspace_root: &Path,
+) -> Result<CompiledWatcher> {
+    let kind = watcher
+        .kind
+        .unwrap_or(WatchKind::Create | WatchKind::Change | WatchKind::Delete);
+
+    match &watcher.glob_pattern {
+        GlobPattern::Relative(pattern) => {
+            let base = relative_pattern_base(pattern)?;
+            Ok(CompiledWatcher {
+                root: base.clone(),
+                base,
+                matcher: compile_glob(&pattern.pattern)?,
+                input: MatchInput::Relative,
+                kind,
+            })
+        }
+        GlobPattern::String(pattern) if Path::new(pattern).is_absolute() => Ok(CompiledWatcher {
+            base: PathBuf::from("/"),
+            root: absolute_pattern_root(pattern),
+            matcher: compile_glob(pattern)?,
+            input: MatchInput::Absolute,
+            kind,
+        }),
+        GlobPattern::String(pattern) => Ok(CompiledWatcher {
+            base: workspace_root.to_path_buf(),
+            root: workspace_root.to_path_buf(),
+            matcher: compile_glob(pattern)?,
+            input: MatchInput::Relative,
+            kind,
+        }),
+    }
+}
+
+impl CompiledWatcher {
+    fn matches(&self, path: &Path, change: FileChangeType) -> bool {
+        if !watch_kind_allows(self.kind, change) {
+            return false;
+        }
+
+        let candidate = match self.input {
+            MatchInput::Relative => match path.strip_prefix(&self.base) {
+                Ok(relative) => normalized_match_path(relative),
+                Err(_) => return false,
+            },
+            MatchInput::Absolute => normalized_match_path(path),
+        };
+
+        self.matcher.is_match(candidate)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lsp_types::{FileSystemWatcher, WorkspaceFolder};
+
+    fn workspace_folder(path: &Path) -> WorkspaceFolder {
+        WorkspaceFolder {
+            uri: Url::from_file_path(path).expect("workspace URI"),
+            name: "workspace".to_string(),
+        }
+    }
+
+    #[test]
+    fn relative_pattern_matches_only_under_its_base_uri() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::Relative(RelativePattern {
+                base_uri: OneOf::Left(workspace_folder(&root)),
+                pattern: "**/*.rs".to_string(),
+            }),
+            kind: None,
+        };
+
+        let compiled = compile_watcher(&watcher, &root).expect("compiled watcher");
+
+        assert!(compiled.matches(&root.join("src/main.rs"), FileChangeType::CHANGED));
+        assert!(!compiled.matches(&root.join("README.md"), FileChangeType::CHANGED));
+        assert!(!compiled.matches(
+            Path::new("/tmp/other/src/main.rs"),
+            FileChangeType::CHANGED
+        ));
+    }
+
+    #[test]
+    fn string_pattern_uses_workspace_root_when_relative() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/Cargo.{toml,lock}".to_string()),
+            kind: None,
+        };
+
+        let compiled = compile_watcher(&watcher, &root).expect("compiled watcher");
+
+        assert!(compiled.matches(&root.join("crates/app/Cargo.toml"), FileChangeType::CREATED));
+        assert!(compiled.matches(&root.join("Cargo.lock"), FileChangeType::CHANGED));
+        assert!(!compiled.matches(&root.join("src/main.rs"), FileChangeType::CHANGED));
+    }
+
+    #[test]
+    fn absolute_string_pattern_watches_parent_and_matches_exact_file() {
+        let root = std::env::temp_dir().join("nevi-watch-root");
+        let manifest = root.join("Cargo.toml");
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::String(normalized_match_path(&manifest)),
+            kind: None,
+        };
+
+        let compiled = compile_watcher(&watcher, &root).expect("compiled watcher");
+
+        assert_eq!(compiled.root, root);
+        assert!(compiled.matches(&manifest, FileChangeType::CHANGED));
+        assert!(!compiled.matches(&root.join("Cargo.lock"), FileChangeType::CHANGED));
+    }
+
+    #[test]
+    fn watcher_kind_filters_unrequested_events() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::String("**/*.rs".to_string()),
+            kind: Some(WatchKind::Create | WatchKind::Delete),
+        };
+
+        let compiled = compile_watcher(&watcher, &root).expect("compiled watcher");
+        let path = root.join("src/lib.rs");
+
+        assert!(compiled.matches(&path, FileChangeType::CREATED));
+        assert!(!compiled.matches(&path, FileChangeType::CHANGED));
+        assert!(compiled.matches(&path, FileChangeType::DELETED));
+    }
+}

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -1,20 +1,27 @@
+use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Component, Path, PathBuf};
+use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
+use std::thread::{self, JoinHandle};
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use globset::{GlobBuilder, GlobMatcher};
 use lsp_types::{
     DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileChangeType,
-    FileEvent, GlobPattern, OneOf,
-    RegistrationParams, RelativePattern, UnregistrationParams, WatchKind,
+    FileEvent, GlobPattern, OneOf, RegistrationParams, RelativePattern, UnregistrationParams, Url,
+    WatchKind,
 };
-#[cfg(test)]
-use lsp_types::Url;
 use notify::event::{ModifyKind, RenameMode};
-use notify::{Event, EventKind};
+#[cfg(not(test))]
+use notify::RecommendedWatcher;
+#[cfg(test)]
+use notify::{Config, PollWatcher};
+use notify::{Event, EventKind, RecursiveMode, Watcher};
 use serde_json::json;
 
 use super::client::SharedStdin;
+use super::types::LspNotification;
 
 pub(crate) const WATCHED_FILES_METHOD: &str = "workspace/didChangeWatchedFiles";
 
@@ -35,9 +42,7 @@ impl std::fmt::Display for WatcherRequestError {
 
 #[derive(Debug)]
 pub(crate) struct WatchedFileRegistration {
-    #[allow(dead_code)] // Read by later unregister/register lifecycle routing.
     pub(crate) id: String,
-    #[allow(dead_code)] // Compiled into watchers when registration lifecycle lands.
     pub(crate) options: DidChangeWatchedFilesRegistrationOptions,
 }
 
@@ -50,11 +55,127 @@ enum MatchInput {
 #[derive(Clone)]
 struct CompiledWatcher {
     base: PathBuf,
-    #[allow(dead_code)] // Read by registration lifecycle when syncing watch roots.
     root: PathBuf,
     matcher: GlobMatcher,
     input: MatchInput,
     kind: WatchKind,
+}
+
+#[derive(Clone, Default)]
+struct RegistrationState {
+    registrations: HashMap<String, Vec<CompiledWatcher>>,
+}
+
+impl RegistrationState {
+    fn register(
+        &mut self,
+        registrations: Vec<WatchedFileRegistration>,
+        workspace_root: &Path,
+    ) -> Result<()> {
+        let mut compiled = Vec::new();
+
+        for registration in registrations {
+            let watchers = registration
+                .options
+                .watchers
+                .iter()
+                .map(|watcher| compile_watcher(watcher, workspace_root))
+                .collect::<Result<Vec<_>>>()?;
+            compiled.push((registration.id, watchers));
+        }
+
+        for (id, watchers) in compiled {
+            self.registrations.insert(id, watchers);
+        }
+        Ok(())
+    }
+
+    fn unregister(&mut self, registration_ids: &[String]) {
+        for registration_id in registration_ids {
+            self.registrations.remove(registration_id);
+        }
+    }
+
+    fn desired_roots(&self) -> HashSet<PathBuf> {
+        self.registrations
+            .values()
+            .flatten()
+            .map(|watcher| watcher.root.clone())
+            .collect()
+    }
+
+    fn matching_events(&self, event: &Event) -> Vec<FileEvent> {
+        let mut deduplicated = HashMap::<(String, u32), FileEvent>::new();
+
+        for (path, change) in event_changes(event) {
+            if !self
+                .registrations
+                .values()
+                .flatten()
+                .any(|watcher| watcher.matches(&path, change))
+            {
+                continue;
+            }
+            let Ok(uri) = Url::from_file_path(&path) else {
+                continue;
+            };
+            deduplicated.insert(
+                (uri.to_string(), file_change_code(change)),
+                FileEvent::new(uri, change),
+            );
+        }
+
+        deduplicated.into_values().collect()
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum WatcherCommand {
+    Register {
+        registrations: Vec<WatchedFileRegistration>,
+        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
+    },
+    #[allow(dead_code)] // Constructed by dynamic-registration routing in Task 5.
+    Unregister {
+        registration_ids: Vec<String>,
+        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
+    },
+    Shutdown,
+    Event(notify::Result<Event>),
+}
+
+#[cfg(test)]
+type RuntimeWatcher = PollWatcher;
+#[cfg(not(test))]
+type RuntimeWatcher = RecommendedWatcher;
+
+#[cfg(test)]
+fn create_runtime_watcher(event_tx: Sender<WatcherCommand>) -> Result<RuntimeWatcher> {
+    // Native filesystem backends can be unavailable inside sandboxed test
+    // runners; polling keeps the real-filesystem worker test deterministic.
+    Ok(PollWatcher::new(
+        move |event| {
+            let _ = event_tx.send(WatcherCommand::Event(event));
+        },
+        Config::default().with_poll_interval(Duration::from_millis(100)),
+    )?)
+}
+
+#[cfg(not(test))]
+fn create_runtime_watcher(event_tx: Sender<WatcherCommand>) -> Result<RuntimeWatcher> {
+    Ok(notify::recommended_watcher(move |event| {
+        let _ = event_tx.send(WatcherCommand::Event(event));
+    })?)
+}
+
+fn file_change_code(change: FileChangeType) -> u32 {
+    if change == FileChangeType::CREATED {
+        1
+    } else if change == FileChangeType::CHANGED {
+        2
+    } else {
+        3
+    }
 }
 
 fn normalized_match_path(path: &Path) -> String {
@@ -137,15 +258,14 @@ pub(crate) fn parse_register_params(
         .into_iter()
         .filter(|registration| registration.method == WATCHED_FILES_METHOD)
         .map(|registration| {
-            let options = serde_json::from_value(registration.register_options.ok_or_else(
-                || {
+            let options =
+                serde_json::from_value(registration.register_options.ok_or_else(|| {
                     WatcherRequestError::InvalidParams(format!(
                         "watched-file registration {} has no options",
                         registration.id
                     ))
-                },
-            )?)
-            .map_err(|error| WatcherRequestError::InvalidParams(error.to_string()))?;
+                })?)
+                .map_err(|error| WatcherRequestError::InvalidParams(error.to_string()))?;
             Ok(WatchedFileRegistration {
                 id: registration.id,
                 options,
@@ -286,13 +406,211 @@ fn write_notification(stdin: &SharedStdin, changes: Vec<FileEvent>) -> Result<()
     Ok(())
 }
 
-// Tasks 2 and 3 intentionally stage parser/matcher and event-conversion
-// foundations before Tasks 4 and 5 wire them into the runtime watcher and
-// dynamic-registration routing.
+type EventSink = Box<dyn Fn(Vec<FileEvent>) -> Result<()> + Send>;
+type ErrorSink = Box<dyn Fn(String) + Send>;
+
+#[allow(dead_code)] // Started by the LSP client wiring in Task 5.
+pub(crate) struct WatchedFilesHandle {
+    tx: Sender<WatcherCommand>,
+    join: Option<JoinHandle<()>>,
+}
+
+#[allow(dead_code)] // Methods are wired into the LSP client in Task 5.
+impl WatchedFilesHandle {
+    #[allow(dead_code)] // Started by the LSP client wiring in Task 5.
+    pub(crate) fn start(
+        workspace_root: PathBuf,
+        stdin: SharedStdin,
+        notification_tx: Sender<LspNotification>,
+    ) -> Result<Self> {
+        let notification_tx_for_write = notification_tx.clone();
+        Self::start_with_sink(
+            workspace_root,
+            Box::new(move |changes| {
+                write_notification(&stdin, changes).map_err(|error| {
+                    let _ = notification_tx_for_write.send(LspNotification::Error {
+                        message: format!("Failed to send watched-file notification: {error}"),
+                    });
+                    error
+                })
+            }),
+            Box::new(move |message| {
+                let _ = notification_tx.send(LspNotification::Error { message });
+            }),
+        )
+    }
+
+    fn start_with_sink(
+        workspace_root: PathBuf,
+        sink: EventSink,
+        error_sink: ErrorSink,
+    ) -> Result<Self> {
+        let (tx, rx) = mpsc::channel();
+        let event_tx = tx.clone();
+        let watcher = create_runtime_watcher(event_tx)?;
+        let join = thread::spawn(move || {
+            run_worker(workspace_root, rx, watcher, sink, error_sink);
+        });
+        Ok(Self {
+            tx,
+            join: Some(join),
+        })
+    }
+
+    #[allow(dead_code)] // Used by dynamic-registration routing in Task 5.
+    pub(crate) fn command_sender(&self) -> Sender<WatcherCommand> {
+        self.tx.clone()
+    }
+
+    fn request(
+        &self,
+        build: impl FnOnce(SyncSender<std::result::Result<(), WatcherRequestError>>) -> WatcherCommand,
+    ) -> Result<()> {
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        self.tx.send(build(reply_tx))?;
+        reply_rx
+            .recv_timeout(Duration::from_secs(2))
+            .map_err(|error| anyhow!("watcher worker did not reply: {error}"))?
+            .map_err(|error| anyhow!(error.to_string()))
+    }
+
+    fn register(&self, registrations: Vec<WatchedFileRegistration>) -> Result<()> {
+        self.request(|reply| WatcherCommand::Register {
+            registrations,
+            reply,
+        })
+    }
+
+    pub(crate) fn shutdown(&mut self) {
+        let _ = self.tx.send(WatcherCommand::Shutdown);
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
+    }
+}
+
+fn run_worker(
+    workspace_root: PathBuf,
+    rx: Receiver<WatcherCommand>,
+    mut watcher: RuntimeWatcher,
+    sink: EventSink,
+    error_sink: ErrorSink,
+) {
+    let mut state = RegistrationState::default();
+    let mut watched_roots = HashSet::new();
+    let mut pending = HashMap::<(String, u32), FileEvent>::new();
+    let mut flush_at: Option<Instant> = None;
+
+    loop {
+        let timeout = flush_at
+            .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+            .unwrap_or(Duration::from_secs(3600));
+
+        match rx.recv_timeout(timeout) {
+            Ok(WatcherCommand::Register {
+                registrations,
+                reply,
+            }) => {
+                let mut next_state = state.clone();
+                let result = next_state
+                    .register(registrations, &workspace_root)
+                    .and_then(|_| {
+                        sync_roots(&mut watcher, &mut watched_roots, next_state.desired_roots())
+                    })
+                    .map_err(|error| WatcherRequestError::Setup(error.to_string()));
+                if result.is_ok() {
+                    state = next_state;
+                }
+                let _ = reply.send(result);
+            }
+            Ok(WatcherCommand::Unregister {
+                registration_ids,
+                reply,
+            }) => {
+                let mut next_state = state.clone();
+                next_state.unregister(&registration_ids);
+                let result =
+                    sync_roots(&mut watcher, &mut watched_roots, next_state.desired_roots())
+                        .map_err(|error| WatcherRequestError::Setup(error.to_string()));
+                if result.is_ok() {
+                    state = next_state;
+                }
+                let _ = reply.send(result);
+            }
+            Ok(WatcherCommand::Shutdown) => break,
+            Ok(WatcherCommand::Event(Ok(event))) => {
+                for change in state.matching_events(&event) {
+                    pending.insert(
+                        (change.uri.to_string(), file_change_code(change.typ)),
+                        change,
+                    );
+                }
+                if !pending.is_empty() && flush_at.is_none() {
+                    flush_at = Some(Instant::now() + Duration::from_millis(50));
+                }
+            }
+            Ok(WatcherCommand::Event(Err(error))) => {
+                error_sink(format!("LSP file watcher error: {error}"));
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if !pending.is_empty() {
+                    let changes = pending.drain().map(|(_, event)| event).collect();
+                    let _ = sink(changes);
+                }
+                flush_at = None;
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+    }
+}
+
+fn sync_roots(
+    watcher: &mut RuntimeWatcher,
+    watched_roots: &mut HashSet<PathBuf>,
+    desired_roots: HashSet<PathBuf>,
+) -> Result<()> {
+    let additions = desired_roots
+        .difference(watched_roots)
+        .cloned()
+        .collect::<Vec<_>>();
+    let removals = watched_roots
+        .difference(&desired_roots)
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut added: Vec<PathBuf> = Vec::new();
+
+    for root in &additions {
+        if let Err(error) = watcher.watch(root, RecursiveMode::Recursive) {
+            for added_root in &added {
+                let _ = watcher.unwatch(added_root);
+            }
+            return Err(anyhow!("failed to watch {}: {error}", root.display()));
+        }
+        added.push(root.clone());
+    }
+
+    let mut removed: Vec<PathBuf> = Vec::new();
+    for root in &removals {
+        if let Err(error) = watcher.unwatch(root) {
+            for removed_root in &removed {
+                let _ = watcher.watch(removed_root, RecursiveMode::Recursive);
+            }
+            for added_root in &added {
+                let _ = watcher.unwatch(added_root);
+            }
+            return Err(anyhow!("failed to unwatch {}: {error}", root.display()));
+        }
+        removed.push(root.clone());
+    }
+
+    *watched_roots = desired_roots;
+    Ok(())
+}
+
+// Task 5 wires these staged APIs into the LSP client and request router.
 const _: fn(
     Option<serde_json::Value>,
-) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> =
-    parse_register_params;
+) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> = parse_register_params;
 const _: fn(Option<serde_json::Value>) -> std::result::Result<Vec<String>, WatcherRequestError> =
     parse_unregister_params;
 const _: fn(&lsp_types::FileSystemWatcher, &Path) -> Result<CompiledWatcher> = compile_watcher;
@@ -331,6 +649,84 @@ mod tests {
             method: WATCHED_FILES_METHOD.to_string(),
             register_options: Some(register_options),
         }
+    }
+
+    fn watched_registration(id: &str, root: &Path, pattern: &str) -> WatchedFileRegistration {
+        WatchedFileRegistration {
+            id: id.to_string(),
+            options: DidChangeWatchedFilesRegistrationOptions {
+                watchers: vec![lsp_types::FileSystemWatcher {
+                    glob_pattern: GlobPattern::Relative(RelativePattern {
+                        base_uri: OneOf::Right(Url::from_file_path(root).expect("root URI")),
+                        pattern: pattern.to_string(),
+                    }),
+                    kind: None,
+                }],
+            },
+        }
+    }
+
+    #[test]
+    fn registration_state_adds_and_removes_registration_by_id() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let mut state = RegistrationState::default();
+
+        state
+            .register(
+                vec![watched_registration("rust-files", &root, "**/*.rs")],
+                &root,
+            )
+            .expect("register");
+        assert!(state.registrations.contains_key("rust-files"));
+        assert_eq!(state.desired_roots(), HashSet::from([root.clone()]));
+
+        state.unregister(&["rust-files".to_string()]);
+        assert!(!state.registrations.contains_key("rust-files"));
+        assert!(state.desired_roots().is_empty());
+    }
+
+    #[test]
+    fn worker_emits_matching_changes_and_ignores_unrelated_files() {
+        static NEXT_DIR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+        let root = std::env::temp_dir().join(format!(
+            "nevi-watched-files-{}-{}",
+            std::process::id(),
+            NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        std::fs::create_dir_all(root.join("src")).unwrap();
+
+        let (events_tx, events_rx) = mpsc::channel();
+        let mut handle = WatchedFilesHandle::start_with_sink(
+            root.clone(),
+            Box::new(move |changes| {
+                events_tx
+                    .send(changes)
+                    .map_err(|error| anyhow!(error.to_string()))
+            }),
+            Box::new(|_| {}),
+        )
+        .expect("watcher");
+
+        handle
+            .register(vec![watched_registration("rust-files", &root, "**/*.rs")])
+            .expect("register");
+
+        std::fs::write(root.join("README.md"), "ignored").unwrap();
+        std::fs::write(root.join("src/main.rs"), "fn main() {}").unwrap();
+
+        let changes = events_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("matching filesystem notification");
+        assert!(changes.iter().any(|event| {
+            event.uri.to_file_path().ok().as_deref() == Some(root.join("src/main.rs").as_path())
+        }));
+        assert!(!changes.iter().any(|event| {
+            event.uri.to_file_path().ok().as_deref() == Some(root.join("README.md").as_path())
+        }));
+
+        handle.shutdown();
+        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]
@@ -427,10 +823,7 @@ mod tests {
 
         assert!(compiled.matches(&root.join("src/main.rs"), FileChangeType::CHANGED));
         assert!(!compiled.matches(&root.join("README.md"), FileChangeType::CHANGED));
-        assert!(!compiled.matches(
-            Path::new("/tmp/other/src/main.rs"),
-            FileChangeType::CHANGED
-        ));
+        assert!(!compiled.matches(Path::new("/tmp/other/src/main.rs"), FileChangeType::CHANGED));
     }
 
     #[test]

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -1,11 +1,20 @@
+use std::io::Write;
 use std::path::{Component, Path, PathBuf};
 
 use anyhow::{anyhow, Context, Result};
 use globset::{GlobBuilder, GlobMatcher};
 use lsp_types::{
-    DidChangeWatchedFilesRegistrationOptions, FileChangeType, GlobPattern, OneOf,
+    DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileChangeType,
+    FileEvent, GlobPattern, OneOf,
     RegistrationParams, RelativePattern, UnregistrationParams, WatchKind,
 };
+#[cfg(test)]
+use lsp_types::Url;
+use notify::event::{ModifyKind, RenameMode};
+use notify::{Event, EventKind};
+use serde_json::json;
+
+use super::client::SharedStdin;
 
 pub(crate) const WATCHED_FILES_METHOD: &str = "workspace/didChangeWatchedFiles";
 
@@ -215,6 +224,67 @@ impl CompiledWatcher {
     }
 }
 
+fn event_changes(event: &Event) -> Vec<(PathBuf, FileChangeType)> {
+    match &event.kind {
+        EventKind::Create(_) => event
+            .paths
+            .iter()
+            .cloned()
+            .map(|path| (path, FileChangeType::CREATED))
+            .collect(),
+        EventKind::Remove(_) => event
+            .paths
+            .iter()
+            .cloned()
+            .map(|path| (path, FileChangeType::DELETED))
+            .collect(),
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) if event.paths.len() >= 2 => {
+            vec![
+                (event.paths[0].clone(), FileChangeType::DELETED),
+                (event.paths[1].clone(), FileChangeType::CREATED),
+            ]
+        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::From)) => event
+            .paths
+            .iter()
+            .cloned()
+            .map(|path| (path, FileChangeType::DELETED))
+            .collect(),
+        EventKind::Modify(ModifyKind::Name(RenameMode::To)) => event
+            .paths
+            .iter()
+            .cloned()
+            .map(|path| (path, FileChangeType::CREATED))
+            .collect(),
+        EventKind::Modify(_) => event
+            .paths
+            .iter()
+            .cloned()
+            .map(|path| (path, FileChangeType::CHANGED))
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+fn build_notification(changes: Vec<FileEvent>) -> Result<String> {
+    let body = serde_json::to_string(&json!({
+        "jsonrpc": "2.0",
+        "method": WATCHED_FILES_METHOD,
+        "params": DidChangeWatchedFilesParams { changes },
+    }))?;
+    Ok(format!("Content-Length: {}\r\n\r\n{}", body.len(), body))
+}
+
+fn write_notification(stdin: &SharedStdin, changes: Vec<FileEvent>) -> Result<()> {
+    let message = build_notification(changes)?;
+    let mut stdin = stdin
+        .lock()
+        .map_err(|_| anyhow!("failed to lock LSP stdin"))?;
+    stdin.write_all(message.as_bytes())?;
+    stdin.flush()?;
+    Ok(())
+}
+
 // Task 2 intentionally lands parser/matcher foundations before Tasks 4 and 5
 // wire them into the runtime watcher and dynamic-registration routing.
 const _: fn(
@@ -225,13 +295,16 @@ const _: fn(Option<serde_json::Value>) -> std::result::Result<Vec<String>, Watch
     parse_unregister_params;
 const _: fn(&lsp_types::FileSystemWatcher, &Path) -> Result<CompiledWatcher> = compile_watcher;
 const _: fn(&CompiledWatcher, &Path, FileChangeType) -> bool = CompiledWatcher::matches;
+const _: fn(&Event) -> Vec<(PathBuf, FileChangeType)> = event_changes;
+const _: fn(Vec<FileEvent>) -> Result<String> = build_notification;
+const _: fn(&SharedStdin, Vec<FileEvent>) -> Result<()> = write_notification;
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use lsp_types::{
         FileSystemWatcher, Registration, RegistrationParams, Unregistration, UnregistrationParams,
-        Url, WorkspaceFolder,
+        WorkspaceFolder,
     };
     use serde_json::json;
 
@@ -446,5 +519,46 @@ mod tests {
         assert!(compiled.matches(&path, FileChangeType::CREATED));
         assert!(!compiled.matches(&path, FileChangeType::CHANGED));
         assert!(compiled.matches(&path, FileChangeType::DELETED));
+    }
+
+    #[test]
+    fn rename_event_becomes_delete_then_create() {
+        let event = Event {
+            kind: EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            paths: vec![
+                PathBuf::from("/tmp/nevi-watch-root/src/old.rs"),
+                PathBuf::from("/tmp/nevi-watch-root/src/new.rs"),
+            ],
+            attrs: Default::default(),
+        };
+
+        assert_eq!(
+            event_changes(&event),
+            vec![
+                (
+                    PathBuf::from("/tmp/nevi-watch-root/src/old.rs"),
+                    FileChangeType::DELETED,
+                ),
+                (
+                    PathBuf::from("/tmp/nevi-watch-root/src/new.rs"),
+                    FileChangeType::CREATED,
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn did_change_watched_files_message_is_valid_json_rpc() {
+        let changes = vec![FileEvent::new(
+            Url::parse("file:///tmp/nevi-watch-root/src/main.rs").unwrap(),
+            FileChangeType::CHANGED,
+        )];
+
+        let message = build_notification(changes).expect("notification");
+        let (_, body) = message.split_once("\r\n\r\n").expect("framed message");
+        let body: serde_json::Value = serde_json::from_str(body).expect("JSON body");
+
+        assert_eq!(body["method"], WATCHED_FILES_METHOD);
+        assert_eq!(body["params"]["changes"][0]["type"], 2);
     }
 }

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -29,7 +29,6 @@ const WATCHER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
 #[derive(Debug)]
 pub(crate) enum WatcherRequestError {
     InvalidParams(String),
-    #[allow(dead_code)] // Used by later registration routing when watcher setup can fail.
     Setup(String),
 }
 
@@ -136,7 +135,6 @@ pub(crate) enum WatcherCommand {
         registrations: Vec<WatchedFileRegistration>,
         reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
     },
-    #[allow(dead_code)] // Constructed by dynamic-registration routing in Task 5.
     Unregister {
         registration_ids: Vec<String>,
         reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
@@ -434,15 +432,12 @@ fn write_notification(stdin: &SharedStdin, changes: Vec<FileEvent>) -> Result<()
 type EventSink = Box<dyn Fn(Vec<FileEvent>) -> Result<()> + Send>;
 type ErrorSink = Box<dyn Fn(String) + Send>;
 
-#[allow(dead_code)] // Started by the LSP client wiring in Task 5.
 pub(crate) struct WatchedFilesHandle {
     tx: Sender<WatcherCommand>,
     join: Option<JoinHandle<()>>,
 }
 
-#[allow(dead_code)] // Methods are wired into the LSP client in Task 5.
 impl WatchedFilesHandle {
-    #[allow(dead_code)] // Started by the LSP client wiring in Task 5.
     pub(crate) fn start(
         workspace_root: PathBuf,
         stdin: SharedStdin,
@@ -482,11 +477,11 @@ impl WatchedFilesHandle {
         })
     }
 
-    #[allow(dead_code)] // Used by dynamic-registration routing in Task 5.
     pub(crate) fn command_sender(&self) -> Sender<WatcherCommand> {
         self.tx.clone()
     }
 
+    #[cfg(test)]
     fn request(
         &self,
         build: impl FnOnce(SyncSender<std::result::Result<(), WatcherRequestError>>) -> WatcherCommand,
@@ -499,6 +494,7 @@ impl WatchedFilesHandle {
             .map_err(|error| anyhow!(error.to_string()))
     }
 
+    #[cfg(test)]
     fn register(&self, registrations: Vec<WatchedFileRegistration>) -> Result<()> {
         self.request(|reply| WatcherCommand::Register {
             registrations,
@@ -668,7 +664,6 @@ fn sync_roots(
     Ok(())
 }
 
-// Task 5 wires these staged APIs into the LSP client and request router.
 const _: fn(
     Option<serde_json::Value>,
 ) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> = parse_register_params;

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -535,6 +535,12 @@ fn run_worker(
     sink: EventSink,
     error_sink: ErrorSink,
 ) {
+    let (sink_tx, sink_rx) = mpsc::channel::<Vec<FileEvent>>();
+    thread::spawn(move || {
+        for changes in sink_rx {
+            let _ = sink(changes);
+        }
+    });
     let mut state = RegistrationState::default();
     let mut watched_roots = HashSet::new();
     let mut pending = PendingFileEvents::default();
@@ -543,7 +549,7 @@ fn run_worker(
     loop {
         if flush_at.is_some_and(|deadline| Instant::now() >= deadline) {
             if !pending.is_empty() {
-                let _ = sink(pending.drain());
+                deliver_pending(&mut pending, &sink_tx, &error_sink);
             }
             flush_at = None;
             continue;
@@ -598,12 +604,24 @@ fn run_worker(
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 if !pending.is_empty() {
-                    let _ = sink(pending.drain());
+                    deliver_pending(&mut pending, &sink_tx, &error_sink);
                 }
                 flush_at = None;
             }
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
+    }
+}
+
+fn deliver_pending(
+    pending: &mut PendingFileEvents,
+    sink_tx: &Sender<Vec<FileEvent>>,
+    error_sink: &ErrorSink,
+) {
+    if let Err(error) = sink_tx.send(pending.drain()) {
+        error_sink(format!(
+            "LSP file watcher notification worker stopped: {error}"
+        ));
     }
 }
 
@@ -874,6 +892,51 @@ mod tests {
             result.is_ok(),
             "worker did not flush while events continued"
         );
+    }
+
+    #[test]
+    fn worker_processes_commands_while_notification_sink_is_blocked() {
+        let temp_root = TempWatchRoot::create();
+        let root = temp_root.path.clone();
+        let (sink_started_tx, sink_started_rx) = mpsc::channel();
+        let (release_sink_tx, release_sink_rx) = mpsc::channel::<()>();
+        let mut handle = WatchedFilesHandle::start_with_sink(
+            root.clone(),
+            Box::new(move |_changes| {
+                let _ = sink_started_tx.send(());
+                let _ = release_sink_rx.recv();
+                Ok(())
+            }),
+            Box::new(|_| {}),
+        )
+        .expect("watcher");
+        handle
+            .register(vec![watched_registration("rust-files", &root, "**/*.rs")])
+            .expect("register");
+
+        let command_tx = handle.command_sender();
+        command_tx
+            .send(WatcherCommand::Event(Ok(file_event(
+                root.join("src/main.rs"),
+                EventKind::Create(notify::event::CreateKind::File),
+            ))))
+            .expect("event command");
+        sink_started_rx
+            .recv_timeout(Duration::from_millis(250))
+            .expect("sink started");
+
+        let (reply_tx, reply_rx) = mpsc::sync_channel(1);
+        command_tx
+            .send(WatcherCommand::Unregister {
+                registration_ids: vec!["rust-files".to_string()],
+                reply: reply_tx,
+            })
+            .expect("unregister command");
+        let result = reply_rx.recv_timeout(Duration::from_millis(100));
+
+        let _ = release_sink_tx.send(());
+        handle.shutdown();
+        assert!(matches!(result, Ok(Ok(()))));
     }
 
     #[test]

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -238,12 +238,13 @@ fn event_changes(event: &Event) -> Vec<(PathBuf, FileChangeType)> {
             .cloned()
             .map(|path| (path, FileChangeType::DELETED))
             .collect(),
-        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) if event.paths.len() >= 2 => {
-            vec![
-                (event.paths[0].clone(), FileChangeType::DELETED),
-                (event.paths[1].clone(), FileChangeType::CREATED),
-            ]
-        }
+        EventKind::Modify(ModifyKind::Name(RenameMode::Both)) => match event.paths.as_slice() {
+            [from, to] => vec![
+                (from.clone(), FileChangeType::DELETED),
+                (to.clone(), FileChangeType::CREATED),
+            ],
+            _ => Vec::new(),
+        },
         EventKind::Modify(ModifyKind::Name(RenameMode::From)) => event
             .paths
             .iter()
@@ -285,8 +286,9 @@ fn write_notification(stdin: &SharedStdin, changes: Vec<FileEvent>) -> Result<()
     Ok(())
 }
 
-// Task 2 intentionally lands parser/matcher foundations before Tasks 4 and 5
-// wire them into the runtime watcher and dynamic-registration routing.
+// Tasks 2 and 3 intentionally stage parser/matcher and event-conversion
+// foundations before Tasks 4 and 5 wire them into the runtime watcher and
+// dynamic-registration routing.
 const _: fn(
     Option<serde_json::Value>,
 ) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> =
@@ -545,6 +547,29 @@ mod tests {
                 ),
             ]
         );
+    }
+
+    #[test]
+    fn rename_both_with_unexpected_path_count_is_ignored() {
+        let malformed_paths = [
+            vec![],
+            vec![PathBuf::from("/tmp/nevi-watch-root/src/only.rs")],
+            vec![
+                PathBuf::from("/tmp/nevi-watch-root/src/old.rs"),
+                PathBuf::from("/tmp/nevi-watch-root/src/new.rs"),
+                PathBuf::from("/tmp/nevi-watch-root/src/extra.rs"),
+            ],
+        ];
+
+        for paths in malformed_paths {
+            let event = Event {
+                kind: EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+                paths,
+                attrs: Default::default(),
+            };
+
+            assert_eq!(event_changes(&event), Vec::new());
+        }
     }
 
     #[test]

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -24,6 +24,7 @@ use super::client::SharedStdin;
 use super::types::LspNotification;
 
 pub(crate) const WATCHED_FILES_METHOD: &str = "workspace/didChangeWatchedFiles";
+const WATCHER_SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Debug)]
 pub(crate) enum WatcherRequestError {
@@ -105,7 +106,8 @@ impl RegistrationState {
     }
 
     fn matching_events(&self, event: &Event) -> Vec<FileEvent> {
-        let mut deduplicated = HashMap::<(String, u32), FileEvent>::new();
+        let mut changes = Vec::new();
+        let mut seen = HashSet::new();
 
         for (path, change) in event_changes(event) {
             if !self
@@ -119,13 +121,12 @@ impl RegistrationState {
             let Ok(uri) = Url::from_file_path(&path) else {
                 continue;
             };
-            deduplicated.insert(
-                (uri.to_string(), file_change_code(change)),
-                FileEvent::new(uri, change),
-            );
+            if seen.insert((uri.to_string(), file_change_code(change))) {
+                changes.push(FileEvent::new(uri, change));
+            }
         }
 
-        deduplicated.into_values().collect()
+        changes
     }
 }
 
@@ -175,6 +176,30 @@ fn file_change_code(change: FileChangeType) -> u32 {
         2
     } else {
         3
+    }
+}
+
+#[derive(Default)]
+struct PendingFileEvents {
+    events: Vec<FileEvent>,
+    seen: HashSet<(String, u32)>,
+}
+
+impl PendingFileEvents {
+    fn insert(&mut self, event: FileEvent) {
+        let key = (event.uri.to_string(), file_change_code(event.typ));
+        if self.seen.insert(key) {
+            self.events.push(event);
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
+    fn drain(&mut self) -> Vec<FileEvent> {
+        self.seen.clear();
+        self.events.drain(..).collect()
     }
 }
 
@@ -469,8 +494,8 @@ impl WatchedFilesHandle {
         let (reply_tx, reply_rx) = mpsc::sync_channel(1);
         self.tx.send(build(reply_tx))?;
         reply_rx
-            .recv_timeout(Duration::from_secs(2))
-            .map_err(|error| anyhow!("watcher worker did not reply: {error}"))?
+            .recv()
+            .map_err(|error| anyhow!("watcher worker reply channel closed: {error}"))?
             .map_err(|error| anyhow!(error.to_string()))
     }
 
@@ -482,10 +507,24 @@ impl WatchedFilesHandle {
     }
 
     pub(crate) fn shutdown(&mut self) {
+        if self.join.is_none() {
+            return;
+        }
         let _ = self.tx.send(WatcherCommand::Shutdown);
         if let Some(join) = self.join.take() {
-            let _ = join.join();
+            let (done_tx, done_rx) = mpsc::sync_channel(1);
+            thread::spawn(move || {
+                let _ = join.join();
+                let _ = done_tx.send(());
+            });
+            let _ = done_rx.recv_timeout(WATCHER_SHUTDOWN_TIMEOUT);
         }
+    }
+}
+
+impl Drop for WatchedFilesHandle {
+    fn drop(&mut self) {
+        self.shutdown();
     }
 }
 
@@ -498,10 +537,18 @@ fn run_worker(
 ) {
     let mut state = RegistrationState::default();
     let mut watched_roots = HashSet::new();
-    let mut pending = HashMap::<(String, u32), FileEvent>::new();
+    let mut pending = PendingFileEvents::default();
     let mut flush_at: Option<Instant> = None;
 
     loop {
+        if flush_at.is_some_and(|deadline| Instant::now() >= deadline) {
+            if !pending.is_empty() {
+                let _ = sink(pending.drain());
+            }
+            flush_at = None;
+            continue;
+        }
+
         let timeout = flush_at
             .map(|deadline| deadline.saturating_duration_since(Instant::now()))
             .unwrap_or(Duration::from_secs(3600));
@@ -540,10 +587,7 @@ fn run_worker(
             Ok(WatcherCommand::Shutdown) => break,
             Ok(WatcherCommand::Event(Ok(event))) => {
                 for change in state.matching_events(&event) {
-                    pending.insert(
-                        (change.uri.to_string(), file_change_code(change.typ)),
-                        change,
-                    );
+                    pending.insert(change);
                 }
                 if !pending.is_empty() && flush_at.is_none() {
                     flush_at = Some(Instant::now() + Duration::from_millis(50));
@@ -554,8 +598,7 @@ fn run_worker(
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 if !pending.is_empty() {
-                    let changes = pending.drain().map(|(_, event)| event).collect();
-                    let _ = sink(changes);
+                    let _ = sink(pending.drain());
                 }
                 flush_at = None;
             }
@@ -666,6 +709,173 @@ mod tests {
         }
     }
 
+    fn file_event(path: PathBuf, kind: EventKind) -> Event {
+        Event {
+            kind,
+            paths: vec![path],
+            attrs: Default::default(),
+        }
+    }
+
+    struct TempWatchRoot {
+        path: PathBuf,
+    }
+
+    impl TempWatchRoot {
+        fn create() -> Self {
+            static NEXT_DIR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+            let path = std::env::temp_dir().join(format!(
+                "nevi-watched-files-{}-{}",
+                std::process::id(),
+                NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+            ));
+            std::fs::create_dir_all(path.join("src")).unwrap();
+            Self { path }
+        }
+    }
+
+    impl Drop for TempWatchRoot {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn request_waits_for_delayed_worker_reply() {
+        let (command_tx, command_rx) = mpsc::channel();
+        let handle = WatchedFilesHandle {
+            tx: command_tx,
+            join: None,
+        };
+
+        let worker = thread::spawn(move || match command_rx.recv().expect("request command") {
+            WatcherCommand::Register { reply, .. } => {
+                thread::sleep(Duration::from_millis(2_200));
+                let _ = reply.send(Ok(()));
+            }
+            other => panic!("unexpected command: {other:?}"),
+        });
+
+        let result = handle.request(|reply| WatcherCommand::Register {
+            registrations: Vec::new(),
+            reply,
+        });
+
+        worker.join().expect("worker joined");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn shutdown_returns_without_waiting_forever_for_worker_thread() {
+        let (command_tx, _command_rx) = mpsc::channel();
+        let join = thread::spawn(|| {
+            thread::sleep(Duration::from_secs(1));
+        });
+        let mut handle = WatchedFilesHandle {
+            tx: command_tx,
+            join: Some(join),
+        };
+        let (done_tx, done_rx) = mpsc::channel();
+
+        thread::spawn(move || {
+            handle.shutdown();
+            let _ = done_tx.send(());
+        });
+
+        assert!(done_rx.recv_timeout(Duration::from_millis(500)).is_ok());
+    }
+
+    #[test]
+    fn dropping_handle_requests_worker_shutdown() {
+        let (command_tx, command_rx) = mpsc::channel();
+        let (seen_tx, seen_rx) = mpsc::channel();
+        let join = thread::spawn(move || {
+            let saw_shutdown = matches!(command_rx.recv(), Ok(WatcherCommand::Shutdown));
+            let _ = seen_tx.send(saw_shutdown);
+        });
+
+        let handle = WatchedFilesHandle {
+            tx: command_tx,
+            join: Some(join),
+        };
+        drop(handle);
+
+        assert_eq!(seen_rx.recv_timeout(Duration::from_millis(500)), Ok(true));
+    }
+
+    #[test]
+    fn matching_events_preserves_rename_delete_then_create_order() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let mut state = RegistrationState::default();
+        state
+            .register(
+                vec![watched_registration("rust-files", &root, "**/*.rs")],
+                &root,
+            )
+            .expect("register");
+        let old_path = root.join("src/old.rs");
+        let new_path = root.join("src/new.rs");
+        let event = Event {
+            kind: EventKind::Modify(ModifyKind::Name(RenameMode::Both)),
+            paths: vec![old_path.clone(), new_path.clone()],
+            attrs: Default::default(),
+        };
+
+        let changes = state.matching_events(&event);
+
+        let paths = changes
+            .iter()
+            .map(|event| event.uri.to_file_path().expect("file path"))
+            .collect::<Vec<_>>();
+        let kinds = changes.iter().map(|event| event.typ).collect::<Vec<_>>();
+        assert_eq!(paths, vec![old_path, new_path]);
+        assert_eq!(
+            kinds,
+            vec![FileChangeType::DELETED, FileChangeType::CREATED]
+        );
+    }
+
+    #[test]
+    fn worker_flushes_due_batch_while_events_keep_arriving() {
+        let root = PathBuf::from("/tmp/nevi-watch-root");
+        let (events_tx, events_rx) = mpsc::channel();
+        let mut handle = WatchedFilesHandle::start_with_sink(
+            root.clone(),
+            Box::new(move |changes| {
+                events_tx
+                    .send(changes)
+                    .map_err(|error| anyhow!(error.to_string()))
+            }),
+            Box::new(|_| {}),
+        )
+        .expect("watcher");
+        handle
+            .register(vec![watched_registration("rust-files", &root, "**/*.rs")])
+            .expect("register");
+
+        let command_tx = handle.command_sender();
+        let path = root.join("src/main.rs");
+        let producer = thread::spawn(move || {
+            let deadline = Instant::now() + Duration::from_millis(350);
+            while Instant::now() < deadline {
+                let _ = command_tx.send(WatcherCommand::Event(Ok(file_event(
+                    path.clone(),
+                    EventKind::Create(notify::event::CreateKind::File),
+                ))));
+            }
+        });
+
+        let result = events_rx.recv_timeout(Duration::from_millis(250));
+
+        producer.join().expect("producer joined");
+        handle.shutdown();
+        assert!(
+            result.is_ok(),
+            "worker did not flush while events continued"
+        );
+    }
+
     #[test]
     fn registration_state_adds_and_removes_registration_by_id() {
         let root = PathBuf::from("/tmp/nevi-watch-root");
@@ -687,14 +897,8 @@ mod tests {
 
     #[test]
     fn worker_emits_matching_changes_and_ignores_unrelated_files() {
-        static NEXT_DIR: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
-
-        let root = std::env::temp_dir().join(format!(
-            "nevi-watched-files-{}-{}",
-            std::process::id(),
-            NEXT_DIR.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
-        ));
-        std::fs::create_dir_all(root.join("src")).unwrap();
+        let temp_root = TempWatchRoot::create();
+        let root = temp_root.path.clone();
 
         let (events_tx, events_rx) = mpsc::channel();
         let mut handle = WatchedFilesHandle::start_with_sink(
@@ -726,7 +930,6 @@ mod tests {
         }));
 
         handle.shutdown();
-        std::fs::remove_dir_all(root).unwrap();
     }
 
     #[test]

--- a/src/lsp/watched_files.rs
+++ b/src/lsp/watched_files.rs
@@ -1,29 +1,18 @@
-use std::collections::{HashMap, HashSet};
-use std::io::Write;
 use std::path::{Component, Path, PathBuf};
-use std::sync::mpsc::{self, Receiver, Sender, SyncSender};
-use std::thread::{self, JoinHandle};
-use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use globset::{GlobBuilder, GlobMatcher};
 use lsp_types::{
-    DidChangeWatchedFilesParams, DidChangeWatchedFilesRegistrationOptions, FileChangeType,
-    FileEvent, GlobPattern, OneOf, RegistrationParams, RelativePattern, UnregistrationParams, Url,
-    WatchKind,
+    DidChangeWatchedFilesRegistrationOptions, FileChangeType, GlobPattern, OneOf,
+    RegistrationParams, RelativePattern, UnregistrationParams, WatchKind,
 };
-use notify::event::{ModifyKind, RenameMode};
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
-use serde_json::json;
-
-use super::client::SharedStdin;
-use super::types::LspNotification;
 
 pub(crate) const WATCHED_FILES_METHOD: &str = "workspace/didChangeWatchedFiles";
 
 #[derive(Debug)]
 pub(crate) enum WatcherRequestError {
     InvalidParams(String),
+    #[allow(dead_code)] // Used by later registration routing when watcher setup can fail.
     Setup(String),
 }
 
@@ -37,22 +26,10 @@ impl std::fmt::Display for WatcherRequestError {
 
 #[derive(Debug)]
 pub(crate) struct WatchedFileRegistration {
+    #[allow(dead_code)] // Read by later unregister/register lifecycle routing.
     pub(crate) id: String,
+    #[allow(dead_code)] // Compiled into watchers when registration lifecycle lands.
     pub(crate) options: DidChangeWatchedFilesRegistrationOptions,
-}
-
-#[derive(Debug)]
-pub(crate) enum WatcherCommand {
-    Register {
-        registrations: Vec<WatchedFileRegistration>,
-        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
-    },
-    Unregister {
-        registration_ids: Vec<String>,
-        reply: SyncSender<std::result::Result<(), WatcherRequestError>>,
-    },
-    Event(notify::Result<Event>),
-    Shutdown,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -64,15 +41,11 @@ enum MatchInput {
 #[derive(Clone)]
 struct CompiledWatcher {
     base: PathBuf,
+    #[allow(dead_code)] // Read by registration lifecycle when syncing watch roots.
     root: PathBuf,
     matcher: GlobMatcher,
     input: MatchInput,
     kind: WatchKind,
-}
-
-#[derive(Clone, Default)]
-struct RegistrationState {
-    registrations: HashMap<String, Vec<CompiledWatcher>>,
 }
 
 fn normalized_match_path(path: &Path) -> String {
@@ -242,16 +215,126 @@ impl CompiledWatcher {
     }
 }
 
+// Task 2 intentionally lands parser/matcher foundations before Tasks 4 and 5
+// wire them into the runtime watcher and dynamic-registration routing.
+const _: fn(
+    Option<serde_json::Value>,
+) -> std::result::Result<Vec<WatchedFileRegistration>, WatcherRequestError> =
+    parse_register_params;
+const _: fn(Option<serde_json::Value>) -> std::result::Result<Vec<String>, WatcherRequestError> =
+    parse_unregister_params;
+const _: fn(&lsp_types::FileSystemWatcher, &Path) -> Result<CompiledWatcher> = compile_watcher;
+const _: fn(&CompiledWatcher, &Path, FileChangeType) -> bool = CompiledWatcher::matches;
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use lsp_types::{FileSystemWatcher, WorkspaceFolder};
+    use lsp_types::{
+        FileSystemWatcher, Registration, RegistrationParams, Unregistration, UnregistrationParams,
+        Url, WorkspaceFolder,
+    };
+    use serde_json::json;
 
     fn workspace_folder(path: &Path) -> WorkspaceFolder {
         WorkspaceFolder {
             uri: Url::from_file_path(path).expect("workspace URI"),
             name: "workspace".to_string(),
         }
+    }
+
+    fn register_params(registrations: Vec<Registration>) -> Option<serde_json::Value> {
+        Some(serde_json::to_value(RegistrationParams { registrations }).unwrap())
+    }
+
+    fn unregister_params(unregisterations: Vec<Unregistration>) -> Option<serde_json::Value> {
+        Some(serde_json::to_value(UnregistrationParams { unregisterations }).unwrap())
+    }
+
+    fn watched_file_registration(id: &str, register_options: serde_json::Value) -> Registration {
+        Registration {
+            id: id.to_string(),
+            method: WATCHED_FILES_METHOD.to_string(),
+            register_options: Some(register_options),
+        }
+    }
+
+    #[test]
+    fn parse_register_params_returns_watched_file_registration_options() {
+        let params = register_params(vec![watched_file_registration(
+            "rust-files",
+            json!({
+                "watchers": [
+                    {
+                        "globPattern": "**/*.rs",
+                        "kind": 3
+                    }
+                ]
+            }),
+        )]);
+
+        let registrations = parse_register_params(params).expect("registration params");
+
+        assert_eq!(registrations.len(), 1);
+        assert_eq!(registrations[0].id, "rust-files");
+        assert_eq!(registrations[0].options.watchers.len(), 1);
+        assert_eq!(
+            registrations[0].options.watchers[0].glob_pattern,
+            GlobPattern::String("**/*.rs".to_string())
+        );
+        assert_eq!(
+            registrations[0].options.watchers[0].kind,
+            Some(WatchKind::Create | WatchKind::Change)
+        );
+    }
+
+    #[test]
+    fn parse_register_params_filters_unrelated_registration_methods() {
+        let params = register_params(vec![Registration {
+            id: "configuration".to_string(),
+            method: "workspace/didChangeConfiguration".to_string(),
+            register_options: None,
+        }]);
+
+        let registrations = parse_register_params(params).expect("registration params");
+
+        assert!(registrations.is_empty());
+    }
+
+    #[test]
+    fn parse_register_params_rejects_missing_params_or_malformed_watched_file_options() {
+        assert!(matches!(
+            parse_register_params(None),
+            Err(WatcherRequestError::InvalidParams(message))
+                if message == "missing registration params"
+        ));
+
+        let malformed = register_params(vec![watched_file_registration(
+            "rust-files",
+            json!({ "watchers": "not an array" }),
+        )]);
+
+        assert!(matches!(
+            parse_register_params(malformed),
+            Err(WatcherRequestError::InvalidParams(_))
+        ));
+    }
+
+    #[test]
+    fn parse_unregister_params_filters_to_watched_file_registration_ids() {
+        let params = unregister_params(vec![
+            Unregistration {
+                id: "rust-files".to_string(),
+                method: WATCHED_FILES_METHOD.to_string(),
+            },
+            Unregistration {
+                id: "configuration".to_string(),
+                method: "workspace/didChangeConfiguration".to_string(),
+            },
+        ]);
+
+        let registration_ids = parse_unregister_params(params).expect("unregistration params");
+
+        assert_eq!(registration_ids, vec!["rust-files".to_string()]);
     }
 
     #[test]
@@ -271,6 +354,31 @@ mod tests {
         assert!(!compiled.matches(&root.join("README.md"), FileChangeType::CHANGED));
         assert!(!compiled.matches(
             Path::new("/tmp/other/src/main.rs"),
+            FileChangeType::CHANGED
+        ));
+    }
+
+    #[test]
+    fn relative_pattern_accepts_base_uri_as_url() {
+        let workspace_root = PathBuf::from("/tmp/nevi-watch-workspace");
+        let base = PathBuf::from("/tmp/nevi-watch-base");
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::Relative(RelativePattern {
+                base_uri: OneOf::Right(Url::from_file_path(&base).expect("base URI")),
+                pattern: "src/**/*.rs".to_string(),
+            }),
+            kind: None,
+        };
+
+        let compiled = compile_watcher(&watcher, &workspace_root).expect("compiled watcher");
+
+        assert_eq!(compiled.root, base);
+        assert!(compiled.matches(
+            Path::new("/tmp/nevi-watch-base/src/nested/lib.rs"),
+            FileChangeType::CHANGED
+        ));
+        assert!(!compiled.matches(
+            Path::new("/tmp/nevi-watch-workspace/src/nested/lib.rs"),
             FileChangeType::CHANGED
         ));
     }
@@ -304,6 +412,24 @@ mod tests {
         assert_eq!(compiled.root, root);
         assert!(compiled.matches(&manifest, FileChangeType::CHANGED));
         assert!(!compiled.matches(&root.join("Cargo.lock"), FileChangeType::CHANGED));
+    }
+
+    #[test]
+    fn absolute_string_glob_pattern_watches_static_prefix_and_matches_descendants() {
+        let root = std::env::temp_dir().join("nevi-watch-root");
+        let src = root.join("src");
+        let pattern = format!("{}/**/*.rs", normalized_match_path(&src));
+        let watcher = FileSystemWatcher {
+            glob_pattern: GlobPattern::String(pattern),
+            kind: None,
+        };
+
+        let compiled = compile_watcher(&watcher, &root).expect("compiled watcher");
+
+        assert_eq!(compiled.root, src);
+        assert!(compiled.matches(&root.join("src/nested/lib.rs"), FileChangeType::CHANGED));
+        assert!(!compiled.matches(&root.join("tests/nested/lib.rs"), FileChangeType::CHANGED));
+        assert!(!compiled.matches(&root.join("src/nested/lib.toml"), FileChangeType::CHANGED));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1251,6 +1251,16 @@ fn main() -> anyhow::Result<()> {
                             );
                             needs_redraw = true;
                         }
+                        LspNotification::ServerStatus { .. } => {
+                            // Analysis readiness changed (indexing <-> quiescent);
+                            // refresh the statusline so it stops claiming "ready"
+                            // while the server is still indexing.
+                            let current_path = editor.buffer().path.clone();
+                            editor.set_lsp_status(
+                                mlsp.status(current_path.as_ref().map(|p| p.as_path())),
+                            );
+                            needs_redraw = true;
+                        }
                         LspNotification::Formatting {
                             edits,
                             request_uri,


### PR DESCRIPTION
PR covers: 

Advertise and implement dynamic workspace/didChangeWatchedFiles support so rust-analyzer can register file watchers during initialization. This fixes the multi-minute delay before hover/goto became useful in Rust projects.