### PR TITLE
feat(keymaps): add searchable :Keymaps cheatsheet picker

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -134,6 +134,8 @@ pub enum Command {
     Theme(String),
     /// :Themes - Open theme picker
     Themes,
+    /// :Keymaps - Open searchable keybinding cheatsheet
+    Keymaps,
     /// :marks - Show all marks
     Marks,
     /// :delmarks {marks} - Delete specified marks
@@ -565,6 +567,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "Keymaps",
+        aliases: &["keymaps", "keys"],
+        description: "Open searchable keybinding cheatsheet",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "marks",
         aliases: &[],
         description: "Show all marks",
@@ -936,6 +944,7 @@ pub fn parse_command(input: &str) -> Command {
             }
         }
         "Themes" | "themes" => Command::Themes,
+        "Keymaps" | "keymaps" | "keys" => Command::Keymaps,
 
         // Marks commands
         "marks" => Command::Marks,
@@ -1505,6 +1514,13 @@ mod tests {
         assert!(matches!(parse_command("GitChanges"), Command::GitChanges));
         assert!(matches!(parse_command("changes"), Command::GitChanges));
         assert!(matches!(parse_command("gc"), Command::GitChanges));
+    }
+
+    #[test]
+    fn parses_keymaps_command() {
+        assert!(matches!(parse_command("Keymaps"), Command::Keymaps));
+        assert!(matches!(parse_command("keymaps"), Command::Keymaps));
+        assert!(matches!(parse_command("keys"), Command::Keymaps));
     }
 
     #[test]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -586,4 +586,17 @@ mod tests {
         let key = parse_key_notation("<F12>").unwrap();
         assert_eq!(key.code, KeyCode::F(12));
     }
+
+    #[test]
+    fn default_leader_includes_keymaps_picker() {
+        use super::super::KeymapSettings;
+        let settings = KeymapSettings::default();
+        assert!(
+            settings
+                .leader_mappings
+                .iter()
+                .any(|m| m.key == "fk" && m.action.contains("Keymaps")),
+            "default leader mappings should bind fk -> :Keymaps"
+        );
+    }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -343,6 +343,12 @@ impl Default for KeymapSettings {
                     action: ":Terminals".to_string(),
                     desc: Some("Open terminal picker".to_string()),
                 },
+                // Keymap cheatsheet
+                LeaderMapping {
+                    key: "fk".to_string(),
+                    action: ":Keymaps".to_string(),
+                    desc: Some("Search keymaps".to_string()),
+                },
             ],
         }
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -6907,6 +6907,13 @@ impl Editor {
         self.mode = Mode::Finder;
     }
 
+    /// Open the fuzzy finder in keymaps cheatsheet mode (read-only).
+    pub fn open_keymaps_picker(&mut self) {
+        let items = crate::finder::keymap_finder_items();
+        self.finder.open_keymaps(items);
+        self.mode = Mode::Finder;
+    }
+
     /// Open the fuzzy finder in marks mode
     pub fn open_finder_marks(&mut self) {
         use crate::finder::MarkInfo;

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -1,0 +1,203 @@
+//! Keybinding cheatsheet data, parsed from the embedded `KEYBINDS.toml`.
+//!
+//! `docs/KEYBINDS.toml` is the documented single source of truth for keybindings.
+//! It is embedded at compile time so the `:Keymaps` picker ships in the binary.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+use super::FinderItem;
+
+/// Raw entry as stored in KEYBINDS.toml. Mode + category come from the table path.
+#[derive(Debug, Clone, Deserialize)]
+struct RawKeybind {
+    key: String,
+    action: String,
+    #[serde(default)]
+    desc: String,
+    #[serde(default)]
+    status: String,
+    #[serde(default)]
+    vim_default: bool,
+}
+
+/// A single documented keybinding, flattened with its mode and category.
+/// Some fields (`action`, `vim_default`) are carried for future introspection
+/// features (which-key, keymap doctor) and not read yet.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct KeybindEntry {
+    pub mode: String,
+    pub category: String,
+    pub key: String,
+    pub action: String,
+    pub desc: String,
+    pub status: String,
+    pub vim_default: bool,
+}
+
+/// A mode's entries are stored one of two ways in KEYBINDS.toml:
+/// - `[[mode.category]]` — grouped by category (normal, visual, insert, leader, finder, commands)
+/// - `[[mode]]` — a flat array with no category (terminal, text_objects, registers)
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+enum ModeSection {
+    /// `[[mode]]` — entries directly under the mode.
+    Flat(Vec<RawKeybind>),
+    /// `[[mode.category]]` — entries grouped by category.
+    Categorized(BTreeMap<String, Vec<RawKeybind>>),
+}
+
+/// Parse KEYBINDS.toml text into a flat, deterministically-ordered list.
+///
+/// Handles both the categorized (`[[mode.category]]`) and flat (`[[mode]]`)
+/// table shapes. A parse failure yields an empty list.
+pub fn parse_keybinds(raw: &str) -> Vec<KeybindEntry> {
+    let parsed: BTreeMap<String, ModeSection> = match toml::from_str(raw) {
+        Ok(parsed) => parsed,
+        Err(_) => return Vec::new(),
+    };
+
+    let mut entries = Vec::new();
+    for (mode, section) in parsed {
+        match section {
+            ModeSection::Flat(binds) => {
+                for b in binds {
+                    entries.push(make_entry(&mode, "", b));
+                }
+            }
+            ModeSection::Categorized(categories) => {
+                for (category, binds) in categories {
+                    for b in binds {
+                        entries.push(make_entry(&mode, &category, b));
+                    }
+                }
+            }
+        }
+    }
+    entries
+}
+
+fn make_entry(mode: &str, category: &str, b: RawKeybind) -> KeybindEntry {
+    KeybindEntry {
+        mode: mode.to_string(),
+        category: category.to_string(),
+        key: b.key,
+        action: b.action,
+        desc: b.desc,
+        status: b.status,
+        vim_default: b.vim_default,
+    }
+}
+
+/// Load and parse the embedded KEYBINDS.toml.
+pub fn load_keybinds() -> Vec<KeybindEntry> {
+    const RAW: &str = include_str!("../../docs/KEYBINDS.toml");
+    parse_keybinds(RAW)
+}
+
+/// Short mode tag for the display row (e.g. "normal" -> "n").
+/// Provided for you to use inside `display_row`.
+fn mode_tag(mode: &str) -> &str {
+    match mode {
+        "normal" => "n",
+        "visual" => "v",
+        "insert" => "i",
+        "leader" => "leader",
+        "commands" => "cmd",
+        "finder" => "finder",
+        "terminal" => "term",
+        "text_objects" => "text-obj",
+        "registers" => "reg",
+        other => other,
+    }
+}
+
+/// Format one keybinding as a single row shown in the `:Keymaps` picker.
+pub fn display_row(entry: &KeybindEntry) -> String {
+    let key = if entry.mode == "leader" {
+        format!("<leader>{}", entry.key)
+    } else {
+        entry.key.clone()
+    };
+    format!("{:<7} {:<18} {}", mode_tag(&entry.mode), key, entry.desc)
+}
+
+/// Build finder items for every *implemented* keybinding.
+pub fn keymap_finder_items() -> Vec<FinderItem> {
+    keymap_items_from(load_keybinds())
+}
+
+/// Filter to implemented entries and render each as an inert finder item
+/// (empty path, no buffer/terminal/git metadata) so Enter has nothing to act on.
+fn keymap_items_from(entries: Vec<KeybindEntry>) -> Vec<FinderItem> {
+    entries
+        .into_iter()
+        .filter(|entry| entry.status == "implemented")
+        .map(|entry| FinderItem::new(display_row(&entry), PathBuf::new()).with_icon("  "))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"
+[[normal.movement]]
+key = "h"
+action = "move_left"
+desc = "Move cursor left"
+status = "implemented"
+vim_default = true
+
+[[leader.files]]
+key = "ff"
+action = ":FindFiles<CR>"
+desc = "Find files"
+status = "implemented"
+
+[[normal.lsp]]
+key = "gD"
+action = "goto_declaration"
+desc = "Go to declaration"
+status = "planned"
+vim_default = true
+"#;
+
+    #[test]
+    fn parses_mode_and_category_from_table_path() {
+        let entries = parse_keybinds(SAMPLE);
+        assert_eq!(entries.len(), 3);
+        let h = entries.iter().find(|e| e.key == "h").expect("h entry");
+        assert_eq!(h.mode, "normal");
+        assert_eq!(h.category, "movement");
+        assert_eq!(h.desc, "Move cursor left");
+        assert_eq!(h.status, "implemented");
+        assert!(h.vim_default);
+    }
+
+    #[test]
+    fn items_include_only_implemented() {
+        let items = keymap_items_from(parse_keybinds(SAMPLE));
+        // h and ff are implemented; gD is planned and excluded
+        assert_eq!(items.len(), 2);
+    }
+
+    #[test]
+    fn leader_rows_get_leader_prefix() {
+        let entries = parse_keybinds(SAMPLE);
+        let ff = entries.iter().find(|e| e.key == "ff").unwrap();
+        let row = display_row(ff);
+        assert!(row.contains("<leader>ff"), "row was: {}", row);
+    }
+
+    #[test]
+    fn embedded_file_parses_and_is_fully_described() {
+        let entries = load_keybinds();
+        assert!(entries.len() > 250, "expected a substantial keymap, got {}", entries.len());
+        assert!(entries.iter().all(|e| !e.desc.is_empty()), "every entry needs a description");
+        assert!(entries.iter().any(|e| e.status == "implemented"));
+    }
+}

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -1,10 +1,12 @@
 mod file_picker;
 mod grep;
 mod matcher;
+mod keybinds;
 
 pub use file_picker::FilePicker;
 pub use grep::GrepSearcher;
 pub use matcher::FuzzyMatcher;
+pub use keybinds::keymap_finder_items;
 
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -35,6 +37,7 @@ pub enum FinderMode {
     Marks,
     GitChanges,
     Terminals,
+    Keymaps,
 }
 
 /// Input mode for the fuzzy finder (like vim modes)
@@ -422,6 +425,22 @@ impl FuzzyFinder {
         self.cancel_grep_search();
 
         self.items = terminal_items;
+        self.filtered = (0..self.items.len()).collect();
+        self.populated = true;
+    }
+
+    /// Open the finder in keymaps (cheatsheet) mode — read-only, no preview pane.
+    pub fn open_keymaps(&mut self, items: Vec<FinderItem>) {
+        self.mode = FinderMode::Keymaps;
+        self.input_mode = FinderInputMode::Insert;
+        self.query.clear();
+        self.cursor = 0;
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.clear_preview_cache();
+        self.cancel_grep_search();
+
+        self.items = items;
         self.filtered = (0..self.items.len()).collect();
         self.populated = true;
     }
@@ -1153,6 +1172,33 @@ mod tests {
             std::thread::sleep(Duration::from_millis(10));
         }
         panic!("async grep search did not finish");
+    }
+
+    #[test]
+    fn open_keymaps_sets_mode_and_loads_items() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_keymaps(vec![
+            FinderItem::new("n       h                  Move cursor left".to_string(), PathBuf::new()),
+            FinderItem::new("leader  <leader>ff         Find files".to_string(), PathBuf::new()),
+        ]);
+
+        assert_eq!(finder.mode, FinderMode::Keymaps);
+        assert_eq!(finder.items.len(), 2);
+        assert!(finder.populated);
+        assert!(!finder.mode_supports_preview(), "keymaps mode has no preview pane");
+    }
+
+    #[test]
+    fn keymap_items_are_inert() {
+        let items = crate::finder::keymap_finder_items();
+        assert!(!items.is_empty(), "expected some implemented keybindings");
+        for item in &items {
+            assert_eq!(item.path, std::path::PathBuf::new(), "keymap items must have no path");
+            assert!(item.buffer_idx.is_none());
+            assert!(item.terminal_session_position.is_none());
+            assert!(item.git_status.is_none());
+            assert!(item.line.is_none());
+        }
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use nevi::copilot::{
 use nevi::editor::{CopilotAction, CopilotGhostText, LspAction};
 use nevi::lsp;
 use nevi::terminal::{execute_leader_action, handle_key, EditorEvent};
+
 use nevi::{
     editor::RegisterContent,
     floating_terminal::{

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4884,6 +4884,7 @@ impl Terminal {
             crate::finder::FinderMode::Marks => " Marks ",
             crate::finder::FinderMode::GitChanges => " Git Changes ",
             crate::finder::FinderMode::Terminals => " Terminals ",
+            crate::finder::FinderMode::Keymaps => " Key Maps ",
         };
 
         if preview_enabled {
@@ -7728,7 +7729,10 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
 
         // Select item
         (KeyModifiers::NONE, KeyCode::Enter) => {
-            if let Some(item) = editor.finder_select() {
+            if editor.finder.mode == crate::finder::FinderMode::Keymaps {
+                // Read-only cheatsheet: Enter just closes, no action dispatched.
+                editor.finder_select();
+            } else if let Some(item) = editor.finder_select() {
                 if let Some(position) = item.terminal_session_position {
                     match editor.floating_terminal.select_session(position) {
                         Ok(message) => editor.set_status(message),
@@ -9082,6 +9086,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
         }
         Command::Themes => {
             editor.open_theme_picker();
+            CommandResult::Ok
+        }
+        Command::Keymaps => {
+            editor.open_keymaps_picker();
             CommandResult::Ok
         }
 


### PR DESCRIPTION
PR covers:
Add a read-only, fuzzy-searchable picker (:Keymaps, <leader>fk) listing every implemented keybinding with its description, sourced from an embedded KEYBINDS.toml. Adds FinderMode::Keymaps modeled on the git-changes picker; every implemented keybinding with its description, sourced from an embedded KEYBINDS.toml. Adds FinderMode::Keymaps modeled on the git-changes picker; Enter/Esc just close (no execution); only implemented bindings are shown.