### PR TITLE
Implement keybind roadmap batch

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -15,6 +15,13 @@ The leader key is `Space` by default. To change it:
 leader = ","  # Use comma as leader instead
 ```
 
+To disable the leader popup while keeping leader mappings active:
+
+```toml
+[keymap]
+show_leader_popup = false
+```
+
 ### Remapping Keys in Normal Mode
 
 Want `H` to go to the start of the line and `L` to go to the end? Add this:
@@ -147,8 +154,17 @@ When specifying keys, use these formats:
 | `0` | Move to start of line (column 0) |
 | `^` | Move to first non-blank character |
 | `$` | Move to end of line |
+| `+` | Move to first non-blank of next line |
+| `-` | Move to first non-blank of previous line |
+| `gj` | Move down by display line when wrap is enabled |
+| `gk` | Move up by display line when wrap is enabled |
+| `g0` | Move to start of display line when wrap is enabled |
+| `g$` | Move to end of display line when wrap is enabled |
+| `g^` | Move to first non-blank of display line when wrap is enabled |
 | `{` | Move to previous blank line (paragraph) |
 | `}` | Move to next blank line (paragraph) |
+| `(` | Move to previous sentence |
+| `)` | Move to next sentence |
 
 ### File Movement
 
@@ -200,6 +216,8 @@ Nevi tracks where you jump from, so you can navigate back and forth.
 |-----|--------|
 | `Ctrl+o` | Jump to older position |
 | `Ctrl+i` | Jump to newer position |
+| `''` | Jump to the line before the last jump |
+| <code>``</code> | Jump to the exact position before the last jump |
 
 ### Change List
 
@@ -209,6 +227,10 @@ Navigate through positions where you made edits.
 |-----|--------|
 | `g;` | Jump to older change position |
 | `g,` | Jump to newer change position |
+| `'.` | Jump to the line of the last change |
+| <code>`.</code> | Jump to the exact position of the last change |
+| `'^` | Jump to the line of the last insert |
+| <code>`^</code> | Jump to the exact position of the last insert |
 | `gi` | Go to last insert position and enter insert mode |
 
 ---
@@ -226,6 +248,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `y` | Yank (copy) |
 | `>` | Indent right |
 | `<` | Indent left |
+| `=` | Auto-indent |
 | `gu` | Lowercase |
 | `gU` | Uppercase |
 | `g~` | Toggle case |
@@ -246,6 +269,8 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `S` / `{n}S` | Substitute entire line(s) |
 | `p` / `{n}p` | Paste after cursor |
 | `P` / `{n}P` | Paste before cursor |
+| `gp` / `{n}gp` | Paste after and leave cursor after pasted text |
+| `gP` / `{n}gP` | Paste before and leave cursor after pasted text |
 | `r{char}` / `{n}r{char}` | Replace character(s) under cursor |
 | `.` | Repeat last change |
 
@@ -271,6 +296,8 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `<<` | Dedent current line |
 | `>{motion}` | Indent with motion (e.g., `>j` indents current and next line) |
 | `<{motion}` | Dedent with motion |
+| `==` | Auto-indent current line |
+| `={motion}` | Auto-indent with motion |
 
 ### Case
 
@@ -303,6 +330,8 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `N` | Go to previous match |
 | `*` | Search word under cursor forward |
 | `#` | Search word under cursor backward |
+| `gn` | Search forward and select match |
+| `gN` | Search backward and select match |
 
 > **Tip:** Search supports regex. Use `\c` at the start for case-insensitive search (e.g., `/\cfoo`).
 
@@ -367,6 +396,11 @@ Record and replay sequences of commands.
 | `Backspace` | Delete character before cursor |
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+u` | Delete to start of line |
+| `Ctrl+t` | Increase indent of current line |
+| `Ctrl+d` | Decrease indent of current line |
+| `Ctrl+a` | Insert previously inserted text |
+| `Ctrl+r {reg}` | Insert contents of register |
+| `Ctrl+o` | Run one normal-mode command, then return to insert |
 
 **Copilot (if enabled):**
 
@@ -396,6 +430,7 @@ Record and replay sequences of commands.
 | `y` | Yank selection |
 | `p` | Paste over selection |
 | `o` | Swap to other end of selection |
+| `O` | Swap to other corner in visual block mode |
 | `>` | Indent selection |
 | `<` | Dedent selection |
 | `gc` | Toggle comment on selection |
@@ -425,6 +460,9 @@ Text objects define regions of text. Use them with operators (`d`, `c`, `y`, etc
 | `iB` / `aB` | Inner/around braces (alias) |
 | `i[` / `a[` | Inner/around brackets |
 | `i<` / `a<` | Inner/around angle brackets |
+| `ip` / `ap` | Inner/around paragraph |
+| `is` / `as` | Inner/around sentence |
+| `it` / `at` | Inner/around HTML/XML tag |
 
 > **Examples:**
 > - `ci"` - Change inside double quotes
@@ -445,6 +483,10 @@ Registers are like named clipboards. Prefix operations with `"{register}`.
 | `"*` | Selection clipboard (same as `+` on macOS) |
 | `"_` | Black hole (delete without saving) |
 | `"0` | Last yank |
+| `".` | Last inserted text |
+| `"%` | Current filename |
+| `":` | Last command |
+| `"#` | Alternate filename |
 
 > **Examples:**
 > - `"ayy` - Yank line into register `a`
@@ -462,6 +504,10 @@ Language Server Protocol features for code intelligence.
 | Key | Action |
 |-----|--------|
 | `gd` | Go to definition |
+| `gD` | Go to declaration |
+| `gI` | Go to implementation |
+| `gf` | Open file under cursor |
+| `gx` | Open URL under cursor |
 | `gr` | Find references |
 | `K` | Show hover documentation |
 | `gl` | Show diagnostic in floating window |
@@ -539,6 +585,10 @@ Split and navigate between windows.
 | `Ctrl+w j` | Move to window below |
 | `Ctrl+w k` | Move to window above |
 | `Ctrl+w l` | Move to window on the right |
+| `Ctrl+w =` | Make all windows equal size |
+| `Ctrl+w r` | Rotate windows down/right |
+| `Ctrl+w R` | Rotate windows up/left |
+| `Ctrl+w x` | Exchange current window with next |
 | `Ctrl+h` / `Ctrl+j` / `Ctrl+k` / `Ctrl+l` | Move directly to neighboring windows |
 
 > **Note:** Currently all splits share the same orientation (all vertical OR all horizontal). Mixed layouts like having one vertical split with a horizontal split inside it are not yet supported.
@@ -548,6 +598,8 @@ Split and navigate between windows.
 ## Leader Key Mappings
 
 The leader key is `Space` by default. Press `Space` followed by these keys:
+Press `Space` by itself to show available continuations, keep typing to narrow
+the popup, or press `Esc` to cancel.
 
 ### Files & Navigation (Telescope-like)
 
@@ -623,6 +675,8 @@ When a finder popup is open (file finder, grep, buffers, etc.):
 | `Esc` | Switch to normal mode |
 | `Ctrl+c` | Close finder |
 | `Ctrl+t` | Toggle preview panel |
+| `Ctrl+d` | Scroll preview down |
+| `Ctrl+u` | Scroll preview up |
 
 ### Normal Mode (navigating results)
 
@@ -635,6 +689,8 @@ When a finder popup is open (file finder, grep, buffers, etc.):
 | `Esc` / `Ctrl+[` / `Ctrl+c` | Close finder |
 | `i` | Enter insert mode |
 | `p` | Toggle preview |
+| `Ctrl+d` | Scroll preview down |
+| `Ctrl+u` | Scroll preview up |
 
 ### Harpoon/Marks Finder Actions
 
@@ -734,6 +790,8 @@ Type `:` to enter command mode. Implemented commands include:
 |---------|--------|
 | `:bn` | Next buffer |
 | `:bp` | Previous buffer |
+| `:bd` / `:bdelete` | Close current buffer (fails if unsaved) |
+| `:bd!` / `:bdelete!` | Force close current buffer |
 
 ### Splits
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 238 keybinds implemented, 49 planned.**
+**Status: 283 keybinds implemented, 1 planned.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -17,57 +17,8 @@ keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
 
 ## Planned
 
-### Motions
-- `(` / `)` — move to previous / next sentence
-- `+` / `-` — move to first non-blank of next / previous line
-- `gj` / `gk` — move down / up by *display* line (for wrapped lines)
-- `g0` / `g$` / `g^` — start / end / first non-blank of the display line
-- `''` / `` `` `` — jump to line / exact position before the last jump
-- `'.` / `` `. `` — jump to line / exact position of the last change
-- `'^` / `` `^ `` — jump to line / exact position of the last insert
-
-### Text objects
-- `ip` / `ap` — inner / around paragraph
-- `is` / `as` — inner / around sentence
-- `it` / `at` — inner / around HTML/XML tag
-
-### Editing
-- `gp` / `gP` — paste and leave the cursor after the pasted text
-- `==` / `={motion}` — auto-indent current line / with a motion
-- `gn` / `gN` — search forward / backward and select the match
-
-### LSP / navigation
-- `gD` — go to declaration
-- `gI` — go to implementation
-- `gf` — open the file under the cursor
-- `gx` — open the URL under the cursor
-
-### Window management
-- `<C-w>=` — make all windows equal size
-- `<C-w>r` / `<C-w>R` — rotate windows down-right / up-left
-- `<C-w>x` — exchange the current window with the next
-
-### Insert mode
-- `<C-o>` — run one normal-mode command, then return to insert
-- `<C-r>{reg}` — insert the contents of a register
-- `<C-t>` / `<C-d>` — increase / decrease indent of the current line
-- `<C-a>` — insert the previously inserted text
-
-### Visual block
-- `O` — move to the other corner of the block
-
-### Finder preview
-- `<C-d>` / `<C-u>` — scroll the preview down / up
-
 ### Registers (read-only)
-- `".` — last inserted text
-- `"%` — current filename
-- `":` — last command
-- `"#` — alternate filename
 - `"=` — expression register
-
-### Buffers
-- `:bd` — delete (close) a buffer *(command parsing not wired up yet)*
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -176,19 +176,19 @@ Nevi aims for full vim/neovim keybind compatibility. Most common keybindings are
 > **Full reference:** See [KEYBINDINGS.md](KEYBINDINGS.md) for the complete keybind documentation with examples and tips.
 
 ### Movement
-`h/j/k/l`, `w/b/e/W/B/E`, `0/^/$`, `gg/G`, `{/}`, `f/F/t/T`, `;/,`, `%`, `H/M/L`
+`h/j/k/l`, `w/b/e/W/B/E`, `0/^/$`, `+/-`, `gg/G`, `{/}`, `(`/`)`, `f/F/t/T`, `;/,`, `%`, `H/M/L`, `gj/gk/g0/g$/g^`
 
 ### Editing
-`d/c/y` + motions, `dd/cc/yy`, `p/P`, `x/X`, `r`, `J`, `.`, `u/Ctrl+r`
+`d/c/y` + motions, `dd/cc/yy`, `p/P/gp/gP`, `x/X`, `r`, `J/gJ`, `==/={motion}`, `.`, `u/Ctrl+r`
 
 ### Text Objects
-`iw/aw`, `iW/aW`, `i"/a"`, `i'/a'`, `i(/a(`, `i{/a{`, `i[/a[`, `i</a<`
+`iw/aw`, `iW/aW`, `i"/a"`, `i'/a'`, `i(/a(`, `i{/a{`, `i[/a[`, `i</a<`, `ip/ap`, `is/as`, `it/at`
 
 ### Search
-`/`, `?`, `n/N`, `*/#`
+`/`, `?`, `n/N`, `*/#`, `gn/gN`
 
 ### LSP
-`gd` (definition), `gr` (references), `K` (hover), `gl` (diagnostic), `]d/[d` (next/prev diagnostic)
+`gd` (definition), `gD` (declaration), `gI` (implementation), `gf` (file under cursor), `gx` (URL under cursor), `gr` (references), `K` (hover), `gl` (diagnostic), `]d/[d` (next/prev diagnostic)
 
 ### Surround
 `ds{char}` (delete), `cs{old}{new}` (change), `ys{motion}{char}` (add)
@@ -197,6 +197,8 @@ Nevi aims for full vim/neovim keybind compatibility. Most common keybindings are
 `gcc` (line), `gc{motion}` (motion)
 
 ### Leader (`<Space>`)
+Press `<Space>` by itself to show available leader continuations. Set `[keymap] show_leader_popup = false` to disable that popup.
+
 | Key | Action |
 |-----|--------|
 | `ff` | Find files |
@@ -220,10 +222,10 @@ Nevi aims for full vim/neovim keybind compatibility. Most common keybindings are
 | `1-4` | Jump to harpoon slot |
 
 ### Window Management
-`Ctrl+w v` (vsplit), `Ctrl+w s` (hsplit), `Ctrl+w q` (close), `Ctrl+w h/j/k/l` or `Ctrl+h/j/k/l` (navigate), `Ctrl+w w/W` (next/previous)
+`Ctrl+w v` (vsplit), `Ctrl+w s` (hsplit), `Ctrl+w q` (close), `Ctrl+w h/j/k/l` or `Ctrl+h/j/k/l` (navigate), `Ctrl+w w/W` (next/previous), `Ctrl+w =` (equalize), `Ctrl+w r/R` (rotate), `Ctrl+w x` (exchange)
 
 ### And More
-Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), registers (`"{a-z}/"+`), replace mode (`R`)
+Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-only registers (`"%`, `":`, `"#`, `".`), insert helpers (`Ctrl+t/Ctrl+d/Ctrl+a/Ctrl+r/Ctrl+o`), replace mode (`R`)
 
 > **Missing a keybind?** Check [KEYBINDINGS.md](KEYBINDINGS.md) for the full list of what's implemented. If you don't see the one you want, take a look at the [keybind roadmap](KEYBINDS_ROADMAP.md) to see if it's already planned — and if it's not, [open an issue](https://github.com/anthonyamaro15/nevi/issues) to request it (PRs welcome too).
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -33,6 +33,8 @@ pub enum Command {
     Next,
     /// :N or :prev - Go to previous buffer
     Prev,
+    /// :bd or :bdelete - Close the current buffer
+    BufferDelete(bool),
     /// :set option[=value] - Set an option
     Set(String, Option<String>),
     /// :[number] - Go to line number
@@ -276,6 +278,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         command: "N",
         aliases: &["prev", "previous", "bp", "bprev", "bprevious"],
         description: "Go to previous buffer",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "bd",
+        aliases: &["bdelete"],
+        description: "Delete current buffer",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "bd!",
+        aliases: &["bdelete!"],
+        description: "Force delete current buffer",
         takes_args: false,
     },
     CommandSpec {
@@ -832,6 +846,8 @@ pub fn parse_command(input: &str) -> Command {
         // Buffer navigation
         "n" | "next" | "bn" | "bnext" => Command::Next,
         "N" | "prev" | "previous" | "bp" | "bprev" | "bprevious" => Command::Prev,
+        "bd" | "bdelete" => Command::BufferDelete(false),
+        "bd!" | "bdelete!" => Command::BufferDelete(true),
 
         // Set options
         "set" => {
@@ -1535,6 +1551,20 @@ mod tests {
         assert!(matches!(parse_command("Keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keys"), Command::Keymaps));
+    }
+
+    #[test]
+    fn parses_buffer_delete_commands() {
+        assert!(matches!(parse_command("bd"), Command::BufferDelete(false)));
+        assert!(matches!(
+            parse_command("bdelete"),
+            Command::BufferDelete(false)
+        ));
+        assert!(matches!(parse_command("bd!"), Command::BufferDelete(true)));
+        assert!(matches!(
+            parse_command("bdelete!"),
+            Command::BufferDelete(true)
+        ));
     }
 
     #[test]

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,7 +1,7 @@
 //! Keymap parsing and lookup for custom key remappings
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::KeymapSettings;
 
@@ -12,6 +12,27 @@ pub enum LeaderAction {
     Command(String),
     /// Execute a key sequence (for motions, etc.)
     Keys(Vec<KeyEvent>),
+}
+
+/// Metadata for one visible leader-key continuation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaderHint {
+    /// Next key to press from the current prefix.
+    pub key: String,
+    /// Full sequence after the leader key.
+    pub sequence: String,
+    /// Description shown in leader popup UIs.
+    pub description: String,
+    /// Whether this sequence executes a mapping directly.
+    pub is_exact: bool,
+    /// Whether this sequence has longer continuations.
+    pub has_children: bool,
+}
+
+#[derive(Debug, Clone)]
+struct LeaderMetadata {
+    action: String,
+    desc: Option<String>,
 }
 
 /// Action for command mode (`:` prompt) keybindings.
@@ -44,6 +65,8 @@ pub struct KeymapLookup {
     leader_key: Option<KeyEvent>,
     /// Leader mappings: key sequence -> action
     leader_mappings: HashMap<String, LeaderAction>,
+    /// Leader mapping metadata used for discoverability UI.
+    leader_metadata: HashMap<String, LeaderMetadata>,
 }
 
 impl Default for KeymapLookup {
@@ -55,6 +78,7 @@ impl Default for KeymapLookup {
             command: HashMap::new(),
             leader_key: None,
             leader_mappings: HashMap::new(),
+            leader_metadata: HashMap::new(),
         }
     }
 }
@@ -154,9 +178,17 @@ impl KeymapLookup {
 
         // Parse leader mappings
         let mut leader_mappings = HashMap::new();
+        let mut leader_metadata = HashMap::new();
         for mapping in &settings.leader_mappings {
             let action = parse_action(&mapping.action);
             leader_mappings.insert(mapping.key.clone(), action);
+            leader_metadata.insert(
+                mapping.key.clone(),
+                LeaderMetadata {
+                    action: mapping.action.clone(),
+                    desc: mapping.desc.clone(),
+                },
+            );
         }
 
         (
@@ -167,6 +199,7 @@ impl KeymapLookup {
                 command,
                 leader_key,
                 leader_mappings,
+                leader_metadata,
             },
             errors,
         )
@@ -231,6 +264,61 @@ impl KeymapLookup {
         self.leader_mappings
             .keys()
             .any(|k| k.starts_with(sequence) && k != sequence)
+    }
+
+    /// Return available leader continuations for the current prefix.
+    pub fn leader_hints(&self, prefix: &str) -> Vec<LeaderHint> {
+        let mut hints = BTreeMap::new();
+
+        for sequence in self.leader_mappings.keys() {
+            let Some(remainder) = sequence.strip_prefix(prefix) else {
+                continue;
+            };
+            if remainder.is_empty() {
+                continue;
+            }
+
+            let Some(next_key) = remainder.chars().next() else {
+                continue;
+            };
+            let key = next_key.to_string();
+            let candidate = format!("{}{}", prefix, key);
+            let is_exact = self.leader_mappings.contains_key(&candidate);
+            let has_children = self.is_leader_prefix(&candidate);
+            let description = self.leader_hint_description(&candidate, is_exact, has_children);
+
+            hints.entry(key.clone()).or_insert(LeaderHint {
+                key,
+                sequence: candidate,
+                description,
+                is_exact,
+                has_children,
+            });
+        }
+
+        hints.into_values().collect()
+    }
+
+    fn leader_hint_description(
+        &self,
+        sequence: &str,
+        is_exact: bool,
+        has_children: bool,
+    ) -> String {
+        if is_exact {
+            if let Some(metadata) = self.leader_metadata.get(sequence) {
+                if let Some(desc) = metadata.desc.as_ref().filter(|desc| !desc.is_empty()) {
+                    return desc.clone();
+                }
+                return metadata.action.clone();
+            }
+        }
+
+        if has_children {
+            "prefix".to_string()
+        } else {
+            String::new()
+        }
     }
 }
 
@@ -455,6 +543,7 @@ mod tests {
         let settings = KeymapSettings {
             leader: " ".to_string(), // Literal space, as used in default config
             timeoutlen: 1000,
+            show_leader_popup: true,
             normal: vec![],
             visual: vec![],
             insert: vec![],
@@ -488,6 +577,7 @@ mod tests {
         let settings = KeymapSettings {
             leader: "<Space>".to_string(),
             timeoutlen: 1000,
+            show_leader_popup: true,
             normal: vec![],
             visual: vec![],
             insert: vec![],
@@ -560,6 +650,43 @@ mod tests {
         assert!(lookup.is_leader_prefix("f"));
         assert!(lookup.is_leader_prefix("t"));
         assert!(lookup.is_leader_prefix("g"));
+    }
+
+    #[test]
+    fn leader_hints_show_available_continuations_for_prefix() {
+        use super::super::KeymapSettings;
+
+        let (lookup, errors) = KeymapLookup::from_settings(&KeymapSettings::default());
+        assert!(errors.is_empty(), "Should have no errors");
+
+        let root_hints = lookup.leader_hints("");
+        let files_group = root_hints
+            .iter()
+            .find(|hint| hint.key == "f")
+            .expect("expected <leader>f group");
+        assert_eq!(files_group.sequence, "f");
+        assert!(files_group.has_children);
+        assert!(!files_group.is_exact);
+
+        let save = root_hints
+            .iter()
+            .find(|hint| hint.key == "w")
+            .expect("expected <leader>w");
+        assert_eq!(save.sequence, "w");
+        assert_eq!(save.description, "Save file");
+        assert!(save.is_exact);
+        assert!(!save.has_children);
+
+        let file_hints = lookup.leader_hints("f");
+        assert!(file_hints.iter().any(|hint| {
+            hint.key == "f" && hint.sequence == "ff" && hint.description == "Find files"
+        }));
+        assert!(file_hints.iter().any(|hint| {
+            hint.key == "g" && hint.sequence == "fg" && hint.description == "Live grep"
+        }));
+        assert!(file_hints.iter().any(|hint| {
+            hint.key == "k" && hint.sequence == "fk" && hint.description == "Search keymaps"
+        }));
     }
 
     #[test]

--- a/src/config/languages.rs
+++ b/src/config/languages.rs
@@ -213,15 +213,13 @@ pub fn load_languages_config() -> LanguagesConfig {
     }
 
     match std::fs::read_to_string(&path) {
-        Ok(content) => {
-            match toml::from_str::<LanguagesConfig>(&content) {
-                Ok(config) => config,
-                Err(e) => {
-                    eprintln!("Warning: Failed to parse languages.toml: {}", e);
-                    LanguagesConfig::default()
-                }
+        Ok(content) => match toml::from_str::<LanguagesConfig>(&content) {
+            Ok(config) => config,
+            Err(e) => {
+                eprintln!("Warning: Failed to parse languages.toml: {}", e);
+                LanguagesConfig::default()
             }
-        }
+        },
         Err(e) => {
             eprintln!("Warning: Failed to read languages.toml: {}", e);
             LanguagesConfig::default()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,7 +9,7 @@ pub mod languages;
 use serde::Deserialize;
 use std::path::PathBuf;
 
-pub use keymap::{CommandModeAction, KeymapLookup, LeaderAction};
+pub use keymap::{CommandModeAction, KeymapLookup, LeaderAction, LeaderHint};
 pub use languages::{load_languages_config, FormatterConfig, LanguageConfig, LanguagesConfig};
 
 /// Main settings structure
@@ -182,6 +182,8 @@ pub struct KeymapSettings {
     /// When a sequence matches both an exact mapping AND is a prefix of longer mappings,
     /// wait this long before executing the shorter match.
     pub timeoutlen: u64,
+    /// Show available leader-key continuations while a leader sequence is active.
+    pub show_leader_popup: bool,
     /// Normal mode key remappings
     pub normal: Vec<KeymapEntry>,
     /// Visual mode key remappings
@@ -199,6 +201,7 @@ impl Default for KeymapSettings {
         Self {
             leader: " ".to_string(), // Space as leader (common in Neovim)
             timeoutlen: 1000,        // 1 second (matches Vim default)
+            show_leader_popup: true,
             normal: Vec::new(),
             visual: Vec::new(),
             insert: Vec::new(),
@@ -688,7 +691,7 @@ pub fn config_path() -> Option<PathBuf> {
 /// Template config file with comments explaining all options
 /// This is generated when no config file exists
 fn default_config_template() -> &'static str {
-    r#"# Nevi Configuration
+    r##"# Nevi Configuration
 # This file is for overriding default settings.
 # All vim/neovim keybindings work out of the box - you don't need to configure them here.
 # Only add settings you want to change from the defaults.
@@ -775,6 +778,7 @@ fn default_config_template() -> &'static str {
 #                            # of longer mappings (e.g., <leader>e and <leader>ee), wait this
 #                            # long before executing the shorter match. Set to 0 for immediate
 #                            # execution (disables overlapping mapping support).
+# show_leader_popup = true   # Show available <leader> continuations while typing a leader mapping
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Movement
@@ -787,11 +791,15 @@ fn default_config_template() -> &'static str {
 # 0                - Move to start of line
 # ^                - Move to first non-blank character
 # $                - Move to end of line
+# +/-              - Move to first non-blank of next/previous line
 # gg               - Move to start of file
 # G                - Move to end of file (or line N with count)
 # {/}              - Move to previous/next paragraph
+# ( and )          - Move to previous/next sentence
 # %                - Jump to matching bracket
 # H/M/L            - Move to top/middle/bottom of screen
+# gj/gk            - Move down/up by display line when wrapping
+# g0/g$/g^         - Start/end/first non-blank of display line
 # f{char}/F{char}  - Find character forward/backward
 # t{char}/T{char}  - Move till character forward/backward
 # ;/,              - Repeat last f/F/t/T / in reverse
@@ -808,12 +816,15 @@ fn default_config_template() -> &'static str {
 # ----------------------------------------------------------------------------
 # Ctrl+o           - Jump to older position in jump list
 # Ctrl+i           - Jump to newer position in jump list
+# ''/``            - Jump to line/exact position before last jump
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Change List
 # ----------------------------------------------------------------------------
 # g;               - Jump to older change position (where you edited)
 # g,               - Jump to newer change position
+# '. and `.        - Jump to line/exact position of last change
+# '^ and `^        - Jump to line/exact position of last insert
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Editing
@@ -822,6 +833,7 @@ fn default_config_template() -> &'static str {
 # c{motion}/cc/C   - Change with motion / line / to end
 # y{motion}/yy/Y   - Yank with motion / line / line
 # p/P              - Paste after/before cursor (supports count)
+# gp/gP            - Paste after/before and leave cursor after pasted text
 # x/X              - Delete char under/before cursor (supports count)
 # r{char}          - Replace character (supports count)
 # J                - Join lines with space (supports count)
@@ -836,6 +848,7 @@ fn default_config_template() -> &'static str {
 # <<               - Dedent current line
 # >{motion}        - Indent with motion
 # <{motion}        - Dedent with motion
+# ==/={motion}     - Auto-indent current line / motion range
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Case
@@ -872,11 +885,16 @@ fn default_config_template() -> &'static str {
 # n/N              - Next/previous search match
 # *                - Search word under cursor forward
 # #                - Search word under cursor backward
+# gn/gN            - Select next/previous search match
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - LSP
 # ----------------------------------------------------------------------------
 # gd               - Go to definition
+# gD               - Go to declaration
+# gI               - Go to implementation
+# gf               - Open file under cursor
+# gx               - Open URL under cursor
 # gr               - Find references
 # K                - Show hover documentation
 # gl               - Show diagnostic in float
@@ -922,6 +940,9 @@ fn default_config_template() -> &'static str {
 # Ctrl+w w/W       - Next/previous window
 # Ctrl+w h/j/k/l   - Move to window left/down/up/right
 # Ctrl+h/j/k/l     - Move directly to window left/down/up/right
+# Ctrl+w =         - Make all windows equal size
+# Ctrl+w r/R       - Rotate windows down-right / up-left
+# Ctrl+w x         - Exchange current window with next
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Harpoon
@@ -937,6 +958,10 @@ fn default_config_template() -> &'static str {
 # Tab              - Insert tab/spaces
 # Ctrl+w           - Delete word before cursor
 # Ctrl+u           - Delete to start of line
+# Ctrl+t/Ctrl+d    - Increase/decrease indent of current line
+# Ctrl+a           - Insert previously inserted text
+# Ctrl+r {reg}     - Insert contents of register
+# Ctrl+o           - Execute one normal-mode command, then return to insert
 # Ctrl+l           - Accept Copilot suggestion
 # Alt+]/Alt+[      - Next/previous Copilot suggestion
 #
@@ -947,6 +972,7 @@ fn default_config_template() -> &'static str {
 # d/c/y            - Delete/change/yank selection
 # p                - Paste over selection
 # o                - Swap selection end
+# O                - Swap to other corner in visual block mode
 # >/<              - Indent/dedent selection
 # gc               - Toggle comment
 # S{char}          - Surround selection
@@ -963,6 +989,9 @@ fn default_config_template() -> &'static str {
 # i{/a{ or iB/aB   - Inner/around braces
 # i[/a[            - Inner/around brackets
 # i</a<            - Inner/around angle brackets
+# ip/ap            - Inner/around paragraph
+# is/as            - Inner/around sentence
+# it/at            - Inner/around HTML/XML tag
 #
 # ----------------------------------------------------------------------------
 # REGISTERS (prefix with ")
@@ -973,6 +1002,10 @@ fn default_config_template() -> &'static str {
 # "*               - Selection clipboard
 # "_               - Black hole (discard)
 # "0               - Last yank
+# ".               - Last inserted text
+# "%               - Current filename
+# ":               - Last command
+# "#               - Alternate filename
 #
 # ----------------------------------------------------------------------------
 # LEADER MAPPINGS (default: Space)
@@ -986,6 +1019,7 @@ fn default_config_template() -> &'static str {
 # <leader>fb       - Find buffers
 # <leader>ft       - Theme picker
 # <leader>tt       - Terminal picker
+# <leader>fk       - Search keymaps
 #
 # Floating terminal:
 # Ctrl+\           - Toggle active terminal
@@ -1116,7 +1150,7 @@ fn default_config_template() -> &'static str {
 # auto_trigger = true        # Auto-trigger in insert mode
 # hide_during_completion = true  # Hide when LSP popup visible
 # disabled_languages = []    # Languages where Copilot is disabled
-"#
+"##
 }
 
 /// Ensure config directory and template file exist
@@ -1315,6 +1349,21 @@ mod tests {
             settings.lsp.servers.rust.preset,
             Some(LspPreset::RustAnalyzer)
         );
+    }
+
+    #[test]
+    fn keymap_leader_popup_is_enabled_by_default_and_configurable() {
+        assert!(KeymapSettings::default().show_leader_popup);
+
+        let settings: Settings = toml::from_str(
+            r#"
+            [keymap]
+            show_leader_popup = false
+            "#,
+        )
+        .expect("parse settings");
+
+        assert!(!settings.keymap.show_leader_popup);
     }
 }
 

--- a/src/copilot/client.rs
+++ b/src/copilot/client.rs
@@ -107,7 +107,10 @@ pub struct CopilotClient {
 
 impl CopilotClient {
     /// Spawn a new Copilot server process
-    pub fn spawn(node_path: &str, server_path: &str) -> Result<(Self, PendingRequests, SharedStdin)> {
+    pub fn spawn(
+        node_path: &str,
+        server_path: &str,
+    ) -> Result<(Self, PendingRequests, SharedStdin)> {
         let mut process = Command::new(node_path)
             .arg(server_path)
             .arg("--stdio")
@@ -192,7 +195,11 @@ impl CopilotClient {
 
     /// Initiate device flow sign-in
     pub fn sign_in_initiate(&mut self) -> Result<u64> {
-        self.send_request("signInInitiate", json!({}), CopilotRequestKind::SignInInitiate)
+        self.send_request(
+            "signInInitiate",
+            json!({}),
+            CopilotRequestKind::SignInInitiate,
+        )
     }
 
     /// Confirm sign-in with user code
@@ -274,7 +281,13 @@ impl CopilotClient {
     }
 
     /// Notify server that a document was opened
-    pub fn did_open(&mut self, uri: &str, language_id: &str, version: i32, text: &str) -> Result<()> {
+    pub fn did_open(
+        &mut self,
+        uri: &str,
+        language_id: &str,
+        version: i32,
+        text: &str,
+    ) -> Result<()> {
         let params = json!({
             "textDocument": {
                 "uri": uri,
@@ -319,7 +332,12 @@ impl CopilotClient {
     }
 
     /// Send a JSON-RPC request and track it
-    fn send_request(&mut self, method: &str, params: Value, kind: CopilotRequestKind) -> Result<u64> {
+    fn send_request(
+        &mut self,
+        method: &str,
+        params: Value,
+        kind: CopilotRequestKind,
+    ) -> Result<u64> {
         let id = self.request_id.fetch_add(1, Ordering::SeqCst);
 
         // Track request before sending
@@ -331,12 +349,19 @@ impl CopilotClient {
             jsonrpc: "2.0",
             id,
             method: method.to_string(),
-            params: if params.is_null() { None } else { Some(params.clone()) },
+            params: if params.is_null() {
+                None
+            } else {
+                Some(params.clone())
+            },
         };
 
         debug_log(&format!("SEND REQUEST id={} method={}", id, method));
         if method == "getCompletions" {
-            debug_log(&format!("  params={}", serde_json::to_string_pretty(&params).unwrap_or_default()));
+            debug_log(&format!(
+                "  params={}",
+                serde_json::to_string_pretty(&params).unwrap_or_default()
+            ));
         }
 
         if let Err(err) = self.send_message(&serde_json::to_string(&request)?) {
@@ -363,7 +388,10 @@ impl CopilotClient {
     /// Send a raw message with Content-Length header
     fn send_message(&mut self, content: &str) -> Result<()> {
         let message = format!("Content-Length: {}\r\n\r\n{}", content.len(), content);
-        let mut stdin = self.stdin.lock().map_err(|_| anyhow!("Failed to lock stdin"))?;
+        let mut stdin = self
+            .stdin
+            .lock()
+            .map_err(|_| anyhow!("Failed to lock stdin"))?;
         stdin.write_all(message.as_bytes())?;
         stdin.flush()?;
         Ok(())
@@ -478,7 +506,10 @@ fn handle_message(
 
     // Handle errors
     if let Some(error) = msg.error {
-        debug_log(&format!("  ERROR code={} message={}", error.code, error.message));
+        debug_log(&format!(
+            "  ERROR code={} message={}",
+            error.code, error.message
+        ));
         if let Ok(mut pending_map) = pending.lock() {
             pending_map.remove(&id_num);
         }
@@ -564,7 +595,9 @@ fn handle_notification(method: &str, params: Option<Value>) -> Option<CopilotNot
 /// Handle a server-initiated request
 fn handle_server_request(id: JsonRpcId, method: &str, _params: Option<Value>) -> Option<String> {
     match method {
-        "workspace/configuration" | "client/registerCapability" | "window/workDoneProgress/create" => {
+        "workspace/configuration"
+        | "client/registerCapability"
+        | "window/workDoneProgress/create" => {
             // Return empty/null result
             build_response(JsonRpcResponseOut {
                 jsonrpc: "2.0",
@@ -596,7 +629,10 @@ fn build_response(response: JsonRpcResponseOut) -> Option<String> {
 /// Handle checkStatus response
 fn handle_check_status_response(result: Value) -> Option<CopilotNotification> {
     let status = result.get("status")?.as_str()?;
-    let user = result.get("user").and_then(|u| u.as_str()).map(|s| s.to_string());
+    let user = result
+        .get("user")
+        .and_then(|u| u.as_str())
+        .map(|s| s.to_string());
 
     let auth_status = match status {
         "OK" | "Normal" => {
@@ -617,7 +653,10 @@ fn handle_check_status_response(result: Value) -> Option<CopilotNotification> {
 fn handle_sign_in_initiate_response(result: Value) -> Option<CopilotNotification> {
     let verification_uri = result.get("verificationUri")?.as_str()?.to_string();
     let user_code = result.get("userCode")?.as_str()?.to_string();
-    let expires_in = result.get("expiresIn").and_then(|e| e.as_u64()).unwrap_or(900) as u32;
+    let expires_in = result
+        .get("expiresIn")
+        .and_then(|e| e.as_u64())
+        .unwrap_or(900) as u32;
     let interval = result.get("interval").and_then(|i| i.as_u64()).unwrap_or(5) as u32;
 
     Some(CopilotNotification::SignInRequired(SignInInfo {
@@ -631,7 +670,10 @@ fn handle_sign_in_initiate_response(result: Value) -> Option<CopilotNotification
 /// Handle signInConfirm response
 fn handle_sign_in_confirm_response(result: Value) -> Option<CopilotNotification> {
     let status = result.get("status")?.as_str()?;
-    let user = result.get("user").and_then(|u| u.as_str()).map(|s| s.to_string());
+    let user = result
+        .get("user")
+        .and_then(|u| u.as_str())
+        .map(|s| s.to_string());
 
     let auth_status = match status {
         "OK" | "Normal" => {
@@ -655,13 +697,16 @@ fn handle_sign_in_confirm_response(result: Value) -> Option<CopilotNotification>
 }
 
 /// Handle completions response
-fn handle_completions_response(
-    result: Value,
-    request_id: u64,
-) -> Option<CopilotNotification> {
-    debug_log(&format!("  Parsing completions response: {}", serde_json::to_string(&result).unwrap_or_default()));
+fn handle_completions_response(result: Value, request_id: u64) -> Option<CopilotNotification> {
+    debug_log(&format!(
+        "  Parsing completions response: {}",
+        serde_json::to_string(&result).unwrap_or_default()
+    ));
     let completions_json = result.get("completions")?.as_array()?;
-    debug_log(&format!("  Found {} completions in response", completions_json.len()));
+    debug_log(&format!(
+        "  Found {} completions in response",
+        completions_json.len()
+    ));
 
     let completions: Vec<CopilotCompletion> = completions_json
         .iter()

--- a/src/copilot/mod.rs
+++ b/src/copilot/mod.rs
@@ -370,7 +370,11 @@ impl CopilotManager {
         }
 
         // Check if language is disabled
-        if self.settings.disabled_languages.contains(&language_id.to_string()) {
+        if self
+            .settings
+            .disabled_languages
+            .contains(&language_id.to_string())
+        {
             return Ok(());
         }
 
@@ -407,7 +411,11 @@ impl CopilotManager {
 
         debug_log(&format!(
             "REQUEST: getCompletions uri={} line={} col={} utf16_col={} source_len={}",
-            relative_path, line, col, utf16_col, source.len()
+            relative_path,
+            line,
+            col,
+            utf16_col,
+            source.len()
         ));
 
         // Send request
@@ -544,7 +552,13 @@ impl CopilotManager {
     }
 
     /// Notify that a document was opened
-    pub fn did_open(&mut self, uri: &str, language_id: &str, version: i32, text: &str) -> Result<()> {
+    pub fn did_open(
+        &mut self,
+        uri: &str,
+        language_id: &str,
+        version: i32,
+        text: &str,
+    ) -> Result<()> {
         if let Some(client) = &mut self.client {
             client.did_open(uri, language_id, version, text)?;
         }

--- a/src/copilot/types.rs
+++ b/src/copilot/types.rs
@@ -145,7 +145,9 @@ pub enum CopilotRequestKind {
     Initialize,
     CheckStatus,
     SignInInitiate,
-    SignInConfirm { user_code: String },
+    SignInConfirm {
+        user_code: String,
+    },
     GetCompletions {
         uri: String,
         version: i32,

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -196,7 +196,13 @@ impl Buffer {
     }
 
     /// Delete a range of characters
-    pub fn delete_range(&mut self, start_line: usize, start_col: usize, end_line: usize, end_col: usize) {
+    pub fn delete_range(
+        &mut self,
+        start_line: usize,
+        start_col: usize,
+        end_line: usize,
+        end_col: usize,
+    ) {
         let start = self.line_col_to_char(start_line, start_col);
         let end = self.line_col_to_char(end_line, end_col);
         if start < end && end <= self.text.len_chars() {
@@ -277,7 +283,13 @@ impl Buffer {
     }
 
     /// Get text in a range as a string
-    pub fn get_text_range(&self, start_line: usize, start_col: usize, end_line: usize, end_col: usize) -> String {
+    pub fn get_text_range(
+        &self,
+        start_line: usize,
+        start_col: usize,
+        end_line: usize,
+        end_col: usize,
+    ) -> String {
         let start = self.line_col_to_char(start_line, start_col);
         let end = self.line_col_to_char(end_line, end_col);
         if start < end && end <= self.text.len_chars() {
@@ -289,7 +301,9 @@ impl Buffer {
 
     /// Get a single character as a string
     pub fn get_char_str(&self, line: usize, col: usize) -> String {
-        self.char_at(line, col).map(|c| c.to_string()).unwrap_or_default()
+        self.char_at(line, col)
+            .map(|c| c.to_string())
+            .unwrap_or_default()
     }
 
     /// Get leading whitespace from a line
@@ -358,7 +372,9 @@ fn write_file_atomically(
     let file_name = path
         .file_name()
         .ok_or_else(|| anyhow::anyhow!("Invalid file path: {}", path.display()))?;
-    let target_permissions = fs::metadata(path).ok().map(|metadata| metadata.permissions());
+    let target_permissions = fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.permissions());
     let (temp_path, temp_file) = create_save_temp_file(parent, file_name)?;
     let mut writer = io::BufWriter::new(temp_file);
 

--- a/src/editor/marks.rs
+++ b/src/editor/marks.rs
@@ -60,7 +60,9 @@ impl Marks {
 
     /// Get a local mark for a specific buffer
     pub fn get_local(&self, buffer_key: &str, name: char) -> Option<&Mark> {
-        self.local.get(buffer_key).and_then(|marks| marks.get(&name))
+        self.local
+            .get(buffer_key)
+            .and_then(|marks| marks.get(&name))
     }
 
     /// Get a global mark
@@ -78,7 +80,14 @@ impl Marks {
     }
 
     /// Set a mark by name (determines local vs global based on case)
-    pub fn set(&mut self, buffer_key: &str, path: Option<PathBuf>, name: char, line: usize, col: usize) {
+    pub fn set(
+        &mut self,
+        buffer_key: &str,
+        path: Option<PathBuf>,
+        name: char,
+        line: usize,
+        col: usize,
+    ) {
         if name.is_lowercase() {
             self.set_local(buffer_key, name, line, col);
         } else if let Some(p) = path {
@@ -104,7 +113,8 @@ impl Marks {
 
     /// Get all global marks (sorted by name)
     pub fn get_global_marks(&self) -> Vec<(char, &Mark)> {
-        let mut marks: Vec<(char, &Mark)> = self.global.iter().map(|(c, mark)| (*c, mark)).collect();
+        let mut marks: Vec<(char, &Mark)> =
+            self.global.iter().map(|(c, mark)| (*c, mark)).collect();
         marks.sort_by_key(|(c, _)| *c);
         marks
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -13,7 +13,7 @@ pub use register::{RegisterContent, Registers};
 pub use undo::{Change, UndoEntry, UndoStack};
 
 use crate::commands::CommandLine;
-use crate::config::{KeymapLookup, LeaderAction, Settings};
+use crate::config::{KeymapLookup, LeaderAction, LeaderHint, Settings};
 use crate::explorer::FileExplorer;
 use crate::finder::FuzzyFinder;
 use crate::frecency::FrecencyDb;
@@ -25,6 +25,7 @@ use crate::syntax::SyntaxManager;
 use crate::theme::ThemeManager;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
+use unicode_width::UnicodeWidthChar;
 
 /// The current mode of the editor
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -65,11 +66,44 @@ impl Mode {
     }
 }
 
+#[derive(Debug, Clone)]
+struct TagToken {
+    name: String,
+    start: usize,
+    end: usize,
+    kind: TagTokenKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TagTokenKind {
+    Open,
+    Close,
+    SelfClosing,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct DisplayLineSegment {
+    start_col: usize,
+    end_col: usize,
+    indent_width: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum DisplayLineTarget {
+    Start,
+    End,
+    FirstNonBlank,
+}
+
 /// Pending LSP action requested by key handler
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum LspAction {
     /// Go to definition (gd)
     GotoDefinition,
+    /// Go to declaration (gD)
+    GotoDeclaration,
+    /// Go to implementation (gI)
+    GotoImplementation,
     /// Show hover documentation (K)
     Hover,
     /// Format document
@@ -481,6 +515,11 @@ impl ChangeList {
         }
     }
 
+    /// Get the most recent change position without changing list navigation.
+    pub fn latest(&self) -> Option<&ChangeLocation> {
+        self.changes.last()
+    }
+
     /// Check if we have any changes recorded
     pub fn is_empty(&self) -> bool {
         self.changes.is_empty()
@@ -697,6 +736,8 @@ pub struct Editor {
     buffers: Vec<Buffer>,
     /// Index of the currently active buffer
     current_buffer_idx: usize,
+    /// Path of the previously active file buffer, for the `"#` register.
+    alternate_file_path: Option<std::path::PathBuf>,
     /// All panes (windows)
     panes: Vec<Pane>,
     /// Index of the currently active pane
@@ -820,6 +861,14 @@ pub struct Editor {
     pub macros: MacroState,
     /// Last insert position for `gi` command (line, col)
     pub last_insert_position: Option<(usize, usize)>,
+    /// Text inserted during the most recently completed insert session.
+    pub last_inserted_text: Option<String>,
+    /// Text inserted during the active insert session.
+    current_inserted_text: String,
+    /// Insert mode is waiting for a register name after `<C-r>`.
+    pub pending_insert_register: bool,
+    /// Insert mode temporarily handed control to one normal-mode command after `<C-o>`.
+    pub pending_insert_normal_once: bool,
     /// Previous jump position for `''` command (path, line, col)
     /// This is the position from which the last jump was made
     pub previous_jump_position: Option<(Option<std::path::PathBuf>, usize, usize)>,
@@ -1038,6 +1087,7 @@ impl Editor {
         Self {
             buffers: vec![Buffer::new()],
             current_buffer_idx: 0,
+            alternate_file_path: None,
             panes: vec![Pane::new(0)],
             active_pane: 0,
             split_layout: SplitLayout::Vertical,
@@ -1100,10 +1150,28 @@ impl Editor {
             last_visual_selection: None,
             macros: MacroState::new(),
             last_insert_position: None,
+            last_inserted_text: None,
+            current_inserted_text: String::new(),
+            pending_insert_register: false,
+            pending_insert_normal_once: false,
             previous_jump_position: None,
             languages_config: crate::config::load_languages_config(),
             startup_errors,
         }
+    }
+
+    /// Visible leader continuations for the current leader prefix.
+    pub fn leader_popup_items(&self) -> Vec<LeaderHint> {
+        if !self.settings.keymap.show_leader_popup {
+            return Vec::new();
+        }
+        if !matches!(self.mode, Mode::Normal | Mode::Explorer) {
+            return Vec::new();
+        }
+        let Some(prefix) = self.leader_sequence.as_deref() else {
+            return Vec::new();
+        };
+        self.keymap.leader_hints(prefix)
     }
 
     /// Take any startup errors (clears them after returning)
@@ -1986,6 +2054,10 @@ impl Editor {
         }
     }
 
+    fn remember_current_file_as_alternate(&mut self) {
+        self.alternate_file_path = self.buffers[self.current_buffer_idx].path.clone();
+    }
+
     // ============================================
     // Pane Management
     // ============================================
@@ -2142,6 +2214,71 @@ impl Editor {
         }
     }
 
+    /// Make all pane rectangles equal according to the current split layout.
+    pub fn equalize_windows(&mut self) {
+        self.update_pane_rects();
+        self.set_status("Windows equalized");
+    }
+
+    /// Rotate pane order down/right according to the current split layout.
+    pub fn rotate_windows_down_right(&mut self) {
+        self.rotate_windows(true);
+    }
+
+    /// Rotate pane order up/left according to the current split layout.
+    pub fn rotate_windows_up_left(&mut self) {
+        self.rotate_windows(false);
+    }
+
+    fn rotate_windows(&mut self, down_right: bool) {
+        let pane_count = self.panes.len();
+        if pane_count <= 1 {
+            self.set_status("Only one window");
+            return;
+        }
+
+        self.save_pane_state();
+        let old_active = self.active_pane;
+        if down_right {
+            self.panes.rotate_right(1);
+            self.active_pane = (old_active + 1) % pane_count;
+            self.set_status("Windows rotated");
+        } else {
+            self.panes.rotate_left(1);
+            self.active_pane = if old_active == 0 {
+                pane_count - 1
+            } else {
+                old_active - 1
+            };
+            self.set_status("Windows rotated reverse");
+        }
+        self.update_pane_rects();
+        self.load_pane_state();
+    }
+
+    /// Exchange the current pane with the next pane, or previous if current is last.
+    pub fn exchange_window_with_next(&mut self) {
+        let pane_count = self.panes.len();
+        if pane_count <= 1 {
+            self.set_status("Only one window");
+            return;
+        }
+
+        self.save_pane_state();
+        let old_active = self.active_pane;
+        let target = if old_active + 1 < pane_count {
+            old_active + 1
+        } else {
+            old_active - 1
+        };
+
+        self.panes.swap(old_active, target);
+        self.active_pane = target;
+        self.update_pane_rects();
+        self.load_pane_state();
+        self.set_status("Windows exchanged");
+    }
+
     /// Move to a pane in the specified direction
     pub fn move_to_pane_direction(&mut self, direction: PaneDirection) {
         // Special case: if moving left with only one pane and explorer is visible, focus explorer
@@ -2218,6 +2355,9 @@ impl Editor {
             .position(|b| b.path.as_ref().and_then(|p| p.canonicalize().ok()) == canonical_path)
         {
             // File already open, switch to that buffer
+            if existing_idx != self.current_buffer_idx {
+                self.remember_current_file_as_alternate();
+            }
             self.save_pane_state();
             self.current_buffer_idx = existing_idx;
             self.load_current_undo_stack();
@@ -2252,6 +2392,7 @@ impl Editor {
             self.reset_current_undo_stack();
             // Update active pane's buffer_idx (it's already pointing to current_buffer_idx)
         } else {
+            self.remember_current_file_as_alternate();
             self.save_pane_state();
             self.buffers.push(new_buffer);
             self.undo_stacks.push(UndoStack::new());
@@ -2460,14 +2601,13 @@ impl Editor {
 
     fn enter_insert_mode_at_change(&mut self, line: usize, col: usize) {
         self.mode = Mode::Insert;
+        self.begin_insert_session();
         self.cursor.line = line.min(
             self.buffers[self.current_buffer_idx]
                 .len_lines()
                 .saturating_sub(1),
         );
-        self.cursor.col = col.min(
-            self.buffers[self.current_buffer_idx].line_len(self.cursor.line),
-        );
+        self.cursor.col = col.min(self.buffers[self.current_buffer_idx].line_len(self.cursor.line));
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.clamp_cursor();
         self.scroll_to_cursor();
@@ -2525,6 +2665,181 @@ impl Editor {
         } else {
             pane_width.saturating_sub(SIGN_COLUMN_WIDTH)
         }
+    }
+
+    fn effective_wrap_width(&self) -> usize {
+        self.settings.editor.wrap_width.min(self.text_area_width())
+    }
+
+    fn display_char_width(ch: char, tab_width: usize) -> usize {
+        if ch == '\t' {
+            tab_width.max(1)
+        } else if ch.is_control() {
+            1
+        } else {
+            UnicodeWidthChar::width(ch).unwrap_or(0)
+        }
+    }
+
+    fn display_width_between_cols(
+        line: &str,
+        start_col: usize,
+        end_col: usize,
+        tab_width: usize,
+    ) -> usize {
+        if end_col <= start_col {
+            return 0;
+        }
+
+        line.chars()
+            .enumerate()
+            .skip(start_col)
+            .take(end_col - start_col)
+            .take_while(|(_, ch)| *ch != '\n')
+            .map(|(_, ch)| Self::display_char_width(ch, tab_width))
+            .sum()
+    }
+
+    fn display_line_segments(
+        line: &str,
+        max_width: usize,
+        tab_width: usize,
+    ) -> Vec<DisplayLineSegment> {
+        let line = line.trim_end_matches('\n');
+        let chars: Vec<char> = line.chars().collect();
+
+        if chars.is_empty() {
+            return vec![DisplayLineSegment {
+                start_col: 0,
+                end_col: 0,
+                indent_width: 0,
+            }];
+        }
+
+        if max_width == 0
+            || Self::display_width_between_cols(line, 0, chars.len(), tab_width) <= max_width
+        {
+            return vec![DisplayLineSegment {
+                start_col: 0,
+                end_col: chars.len(),
+                indent_width: 0,
+            }];
+        }
+
+        let mut indent_width = 0;
+        for ch in chars.iter().take_while(|c| c.is_whitespace()) {
+            let ch_width = Self::display_char_width(*ch, tab_width);
+            if indent_width + ch_width >= max_width {
+                break;
+            }
+            indent_width += ch_width;
+        }
+
+        let mut segments = Vec::new();
+        let mut current_col = 0;
+        let mut is_first = true;
+
+        while current_col < chars.len() {
+            let segment_indent_width = if is_first { 0 } else { indent_width };
+            let available_width = if is_first {
+                max_width
+            } else {
+                max_width.saturating_sub(indent_width)
+            };
+
+            let mut take_count = 0;
+            let mut segment_width = 0;
+
+            if available_width == 0 {
+                take_count = 1;
+            } else {
+                while current_col + take_count < chars.len() {
+                    let ch = chars[current_col + take_count];
+                    let ch_width = Self::display_char_width(ch, tab_width);
+                    if segment_width + ch_width > available_width {
+                        if take_count == 0 {
+                            take_count = 1;
+                        }
+                        break;
+                    }
+                    segment_width += ch_width;
+                    take_count += 1;
+                }
+            }
+
+            segments.push(DisplayLineSegment {
+                start_col: current_col,
+                end_col: (current_col + take_count).min(chars.len()),
+                indent_width: segment_indent_width,
+            });
+            current_col += take_count;
+            is_first = false;
+        }
+
+        segments
+    }
+
+    fn display_segment_for_col(
+        line: &str,
+        segments: &[DisplayLineSegment],
+        col: usize,
+        tab_width: usize,
+    ) -> (usize, usize) {
+        let line_len = line.trim_end_matches('\n').chars().count();
+        if line_len == 0 {
+            return (0, 0);
+        }
+
+        let target_col = col.min(line_len.saturating_sub(1));
+        for (idx, segment) in segments.iter().enumerate() {
+            if target_col >= segment.start_col && target_col < segment.end_col {
+                let display_col = segment.indent_width
+                    + Self::display_width_between_cols(
+                        line,
+                        segment.start_col,
+                        target_col,
+                        tab_width,
+                    );
+                return (idx, display_col);
+            }
+        }
+
+        let last_idx = segments.len().saturating_sub(1);
+        let last = &segments[last_idx];
+        let display_col = last.indent_width
+            + Self::display_width_between_cols(line, last.start_col, target_col, tab_width);
+        (last_idx, display_col)
+    }
+
+    fn display_col_to_buffer_col(
+        line: &str,
+        segment: DisplayLineSegment,
+        desired_display_col: usize,
+        tab_width: usize,
+    ) -> usize {
+        if segment.end_col <= segment.start_col {
+            return segment.start_col;
+        }
+
+        let desired = desired_display_col.saturating_sub(segment.indent_width);
+        let mut width = 0;
+        for (idx, ch) in line
+            .chars()
+            .enumerate()
+            .skip(segment.start_col)
+            .take(segment.end_col - segment.start_col)
+        {
+            if width >= desired {
+                return idx;
+            }
+            let ch_width = Self::display_char_width(ch, tab_width);
+            if width + ch_width > desired {
+                return idx;
+            }
+            width += ch_width;
+        }
+
+        segment.end_col.saturating_sub(1)
     }
 
     /// Get the text in a range (for yank/delete operations)
@@ -2804,7 +3119,43 @@ impl Editor {
 
     /// Paste after cursor from a register
     pub fn paste_after(&mut self, register: Option<char>) {
-        if let Some(content) = self.registers.get_content(register) {
+        self.paste_after_with_cursor_after(register, false);
+    }
+
+    /// Paste after cursor and leave cursor after the pasted text.
+    pub fn paste_after_move(&mut self, register: Option<char>) {
+        self.paste_after_with_cursor_after(register, true);
+    }
+
+    fn register_content_for_paste(&mut self, register: Option<char>) -> Option<RegisterContent> {
+        match register {
+            Some('%') => self
+                .buffer()
+                .path
+                .as_ref()
+                .map(|path| RegisterContent::Chars(path.to_string_lossy().to_string())),
+            Some(':') => self
+                .command_line
+                .history
+                .last()
+                .cloned()
+                .map(RegisterContent::Chars),
+            Some('#') => self
+                .alternate_file_path
+                .as_ref()
+                .map(|path| RegisterContent::Chars(path.to_string_lossy().to_string())),
+            Some('.') => self
+                .last_inserted_text
+                .as_ref()
+                .filter(|text| !text.is_empty())
+                .cloned()
+                .map(RegisterContent::Chars),
+            _ => self.registers.get_content(register),
+        }
+    }
+
+    fn paste_after_with_cursor_after(&mut self, register: Option<char>, cursor_after: bool) {
+        if let Some(content) = self.register_content_for_paste(register) {
             self.begin_change();
 
             match content {
@@ -2828,9 +3179,19 @@ impl Editor {
                     );
                     self.cursor.line += 1;
                     self.cursor.col = 0;
+                    let first_inserted_line = self.cursor.line;
+                    let inserted_line_count = Self::linewise_paste_line_count(trimmed);
 
                     // Insert the lines (without trailing newline if present)
                     self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, trimmed);
+                    if cursor_after {
+                        self.cursor.line = (first_inserted_line + inserted_line_count).min(
+                            self.buffers[self.current_buffer_idx]
+                                .len_lines()
+                                .saturating_sub(1),
+                        );
+                        self.cursor.col = 0;
+                    }
 
                     self.scroll_to_cursor();
                 }
@@ -2855,7 +3216,13 @@ impl Editor {
                         insert_col,
                         &text,
                     );
-                    self.cursor.col = insert_col + text.len().saturating_sub(1);
+                    let pasted_len = text.chars().count();
+                    self.cursor.col = insert_col
+                        + if cursor_after {
+                            pasted_len
+                        } else {
+                            pasted_len.saturating_sub(1)
+                        };
                     self.clamp_cursor();
                 }
             }
@@ -2873,14 +3240,32 @@ impl Editor {
         }
     }
 
+    /// Paste after cursor count times and leave cursor after the pasted text.
+    pub fn paste_after_move_count(&mut self, register: Option<char>, count: usize) {
+        for _ in 0..count.max(1) {
+            self.paste_after_move(register);
+        }
+    }
+
     /// Paste before cursor from a register
     pub fn paste_before(&mut self, register: Option<char>) {
-        if let Some(content) = self.registers.get_content(register) {
+        self.paste_before_with_cursor_after(register, false);
+    }
+
+    /// Paste before cursor and leave cursor after the pasted text.
+    pub fn paste_before_move(&mut self, register: Option<char>) {
+        self.paste_before_with_cursor_after(register, true);
+    }
+
+    fn paste_before_with_cursor_after(&mut self, register: Option<char>, cursor_after: bool) {
+        if let Some(content) = self.register_content_for_paste(register) {
             self.begin_change();
 
             match content {
                 RegisterContent::Lines(text) => {
                     // Paste on new line above
+                    let insert_line = self.cursor.line;
+                    let inserted_line_count = Self::linewise_paste_line_count(&text);
                     let insert_text = if text.ends_with('\n') {
                         text.clone()
                     } else {
@@ -2903,6 +3288,13 @@ impl Editor {
                         );
                     }
                     self.cursor.col = 0;
+                    if cursor_after {
+                        self.cursor.line = (insert_line + inserted_line_count).min(
+                            self.buffers[self.current_buffer_idx]
+                                .len_lines()
+                                .saturating_sub(1),
+                        );
+                    }
                     self.scroll_to_cursor();
                 }
                 RegisterContent::Chars(text) => {
@@ -2919,7 +3311,13 @@ impl Editor {
                         self.cursor.col,
                         &text,
                     );
-                    self.cursor.col = self.cursor.col + text.len().saturating_sub(1);
+                    let pasted_len = text.chars().count();
+                    self.cursor.col = self.cursor.col
+                        + if cursor_after {
+                            pasted_len
+                        } else {
+                            pasted_len.saturating_sub(1)
+                        };
                     self.clamp_cursor();
                 }
             }
@@ -2937,10 +3335,22 @@ impl Editor {
         }
     }
 
+    /// Paste before cursor count times and leave cursor after the pasted text.
+    pub fn paste_before_move_count(&mut self, register: Option<char>, count: usize) {
+        for _ in 0..count.max(1) {
+            self.paste_before_move(register);
+        }
+    }
+
+    fn linewise_paste_line_count(text: &str) -> usize {
+        text.trim_end_matches('\n').split('\n').count().max(1)
+    }
+
     /// Enter insert mode
     pub fn enter_insert_mode(&mut self) {
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
         self.begin_change();
     }
 
@@ -2952,6 +3362,7 @@ impl Editor {
         }
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
         self.begin_change();
     }
 
@@ -2960,6 +3371,7 @@ impl Editor {
         self.cursor.col = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
         self.begin_change();
     }
 
@@ -2973,6 +3385,7 @@ impl Editor {
                     self.cursor.col = col;
                     self.last_insert_position = Some((self.cursor.line, self.cursor.col));
                     self.mode = Mode::Insert;
+                    self.begin_insert_session();
                     self.begin_change();
                     return;
                 }
@@ -2981,7 +3394,94 @@ impl Editor {
         self.cursor.col = 0;
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
         self.begin_change();
+    }
+
+    /// Temporarily leave insert mode so the next normal command can run.
+    pub fn enter_insert_normal_once(&mut self) {
+        self.pending_insert_register = false;
+        self.pending_insert_normal_once = true;
+        self.enter_normal_mode();
+    }
+
+    /// Return to insert mode after the one-shot normal command has completed.
+    pub fn finish_insert_normal_once(&mut self) {
+        self.pending_insert_normal_once = false;
+        self.last_insert_position = Some((self.cursor.line, self.cursor.col));
+        self.mode = Mode::Insert;
+        self.begin_insert_session();
+        self.begin_change();
+        self.clamp_cursor();
+        self.scroll_to_cursor();
+    }
+
+    fn begin_insert_session(&mut self) {
+        self.current_inserted_text.clear();
+    }
+
+    fn finish_insert_session(&mut self) {
+        if !self.current_inserted_text.is_empty() {
+            self.last_inserted_text = Some(std::mem::take(&mut self.current_inserted_text));
+        } else {
+            self.current_inserted_text.clear();
+        }
+    }
+
+    fn record_inserted_text(&mut self, text: &str) {
+        if self.mode == Mode::Insert {
+            self.current_inserted_text.push_str(text);
+        }
+    }
+
+    fn record_inserted_char(&mut self, ch: char) {
+        if self.mode == Mode::Insert {
+            self.current_inserted_text.push(ch);
+        }
+    }
+
+    fn insert_text_at_cursor(&mut self, text: &str) {
+        let start_line = self.cursor.line;
+        let start_col = self.cursor.col;
+        self.undo_stack
+            .record_change(Change::insert(start_line, start_col, text.to_string()));
+        self.buffers[self.current_buffer_idx].insert_str(start_line, start_col, text);
+        self.record_inserted_text(text);
+        let (end_line, end_col) = Self::text_position_after_insert(start_line, start_col, text);
+        self.cursor.line = end_line;
+        self.cursor.col = end_col;
+        self.scroll_to_cursor();
+    }
+
+    /// Insert text from a register at the cursor while in insert mode.
+    pub fn insert_register_text(&mut self, register: char) -> bool {
+        let Some(content) = self.register_content_for_paste(Some(register)) else {
+            return false;
+        };
+        let text = match content {
+            RegisterContent::Chars(text) | RegisterContent::Lines(text) => text,
+        };
+        if text.is_empty() {
+            return false;
+        }
+
+        self.insert_text_at_cursor(&text);
+        true
+    }
+
+    /// Insert the text from the previous completed insert session.
+    pub fn insert_last_inserted_text(&mut self) -> bool {
+        let Some(text) = self
+            .last_inserted_text
+            .as_ref()
+            .filter(|text| !text.is_empty())
+            .cloned()
+        else {
+            return false;
+        };
+
+        self.insert_text_at_cursor(&text);
+        true
     }
 
     /// Enter replace mode
@@ -3071,6 +3571,10 @@ impl Editor {
 
     /// Exit to normal mode
     pub fn enter_normal_mode(&mut self) {
+        if self.mode == Mode::Insert {
+            self.finish_insert_session();
+        }
+
         // End any current undo group
         self.undo_stack
             .end_undo_group(self.cursor.line, self.cursor.col);
@@ -3118,6 +3622,7 @@ impl Editor {
                 );
                 self.cursor.col += 1;
             }
+            self.record_inserted_char(ch);
         }
         self.scroll_to_cursor();
     }
@@ -3163,6 +3668,7 @@ impl Editor {
                             self.cursor.col,
                             &insert_text,
                         );
+                        self.record_inserted_text(&insert_text);
 
                         // Move cursor to the indented middle line
                         self.cursor.line += 1;
@@ -3181,6 +3687,7 @@ impl Editor {
                             self.cursor.col,
                             &insert_text,
                         );
+                        self.record_inserted_text(&insert_text);
 
                         self.cursor.line += 1;
                         self.cursor.col = indent.len();
@@ -3246,6 +3753,7 @@ impl Editor {
                 self.cursor.col,
                 &insert_text,
             );
+            self.record_inserted_text(&insert_text);
 
             // Move cursor to the indented middle line
             self.cursor.line += 1;
@@ -3264,6 +3772,7 @@ impl Editor {
                 self.cursor.col,
                 &insert_text,
             );
+            self.record_inserted_text(&insert_text);
 
             self.cursor.line += 1;
             self.cursor.col = indent.len();
@@ -3326,6 +3835,7 @@ impl Editor {
                         bracket,
                     );
                     self.cursor.col += 1;
+                    self.record_inserted_char(bracket);
                     return;
                 }
             }
@@ -3368,6 +3878,7 @@ impl Editor {
             bracket,
         );
         self.cursor.col += 1;
+        self.record_inserted_char(bracket);
     }
 
     /// Check if cursor is preceded only by whitespace on current line
@@ -3646,6 +4157,8 @@ impl Editor {
         self.cursor.col = indent.len();
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
+        self.record_inserted_text(&insert_text);
         self.scroll_to_cursor();
     }
 
@@ -3670,6 +4183,8 @@ impl Editor {
         self.cursor.col = indent.len();
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
+        self.begin_insert_session();
+        self.record_inserted_text(&insert_text);
         self.scroll_to_cursor();
     }
 
@@ -3786,9 +4301,18 @@ impl Editor {
         }
     }
 
-    /// Jump to previous position ('' command)
-    /// This jumps to the position before the last jump, and toggles back on repeated use
-    pub fn jump_to_previous_position(&mut self) -> bool {
+    /// Jump to the line of the previous position ('' command).
+    pub fn jump_to_previous_position_line(&mut self) -> bool {
+        self.jump_to_previous_position(false)
+    }
+
+    /// Jump to the exact previous position (`` command).
+    pub fn jump_to_previous_position_exact(&mut self) -> bool {
+        self.jump_to_previous_position(true)
+    }
+
+    /// Jump to previous position and toggle back on repeated use.
+    fn jump_to_previous_position(&mut self, exact: bool) -> bool {
         if let Some((prev_path, prev_line, prev_col)) = self.previous_jump_position.take() {
             // Save current position so we can toggle back
             let current_path = self.buffer().path.clone();
@@ -3806,7 +4330,11 @@ impl Editor {
             }
 
             self.cursor.line = prev_line;
-            self.cursor.col = prev_col;
+            self.cursor.col = if exact {
+                prev_col
+            } else {
+                self.find_first_non_blank(self.cursor.line)
+            };
             self.clamp_cursor();
             self.scroll_to_cursor();
             true
@@ -3833,6 +4361,58 @@ impl Editor {
         if let Some(loc) = self.change_list.go_newer().cloned() {
             self.cursor.line = loc.line;
             self.cursor.col = loc.col;
+            self.clamp_cursor();
+            self.scroll_to_cursor();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Jump to the line of the last change ('. command).
+    pub fn jump_to_last_change_line(&mut self) -> bool {
+        self.jump_to_last_change(false)
+    }
+
+    /// Jump to the exact position of the last change (`. command).
+    pub fn jump_to_last_change_exact(&mut self) -> bool {
+        self.jump_to_last_change(true)
+    }
+
+    fn jump_to_last_change(&mut self, exact: bool) -> bool {
+        if let Some(loc) = self.change_list.latest().cloned() {
+            self.cursor.line = loc.line;
+            self.cursor.col = if exact {
+                loc.col
+            } else {
+                self.find_first_non_blank(loc.line)
+            };
+            self.clamp_cursor();
+            self.scroll_to_cursor();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Jump to the line of the last insert ('^ command).
+    pub fn jump_to_last_insert_line(&mut self) -> bool {
+        self.jump_to_last_insert(false)
+    }
+
+    /// Jump to the exact position of the last insert (`^ command).
+    pub fn jump_to_last_insert_exact(&mut self) -> bool {
+        self.jump_to_last_insert(true)
+    }
+
+    fn jump_to_last_insert(&mut self, exact: bool) -> bool {
+        if let Some((line, col)) = self.last_insert_position {
+            self.cursor.line = line;
+            self.cursor.col = if exact {
+                col
+            } else {
+                self.find_first_non_blank(line)
+            };
             self.clamp_cursor();
             self.scroll_to_cursor();
             true
@@ -4309,6 +4889,89 @@ impl Editor {
         }
     }
 
+    /// Search forward for the last pattern and select the match (gn).
+    pub fn search_select_next(&mut self, count: usize) {
+        self.search_select_match(SearchDirection::Forward, count);
+    }
+
+    /// Search backward for the last pattern and select the match (gN).
+    pub fn search_select_prev(&mut self, count: usize) {
+        self.search_select_match(SearchDirection::Backward, count);
+    }
+
+    fn search_select_match(&mut self, direction: SearchDirection, count: usize) {
+        let Some(pattern) = self.search.last_pattern.clone() else {
+            self.set_status("No previous search pattern");
+            return;
+        };
+
+        self.update_search_matches_from_pattern(&pattern);
+
+        let Some((line, start_col, end_col)) =
+            self.search_match_from_cursor(direction, count.max(1))
+        else {
+            self.set_status(format!("Pattern not found: {}", pattern));
+            return;
+        };
+
+        self.record_jump();
+        self.mode = Mode::Visual;
+        self.visual = VisualSelection::new(line, start_col);
+        self.cursor.line = line;
+        self.cursor.col = end_col.saturating_sub(1).max(start_col);
+        self.scroll_to_cursor();
+    }
+
+    fn search_match_from_cursor(
+        &self,
+        direction: SearchDirection,
+        count: usize,
+    ) -> Option<(usize, usize, usize)> {
+        if self.search_matches.is_empty() {
+            return None;
+        }
+
+        let cursor_line = self.cursor.line;
+        let cursor_col = self.cursor.col;
+        let mut ordered = Vec::with_capacity(self.search_matches.len());
+
+        match direction {
+            SearchDirection::Forward => {
+                ordered.extend(
+                    self.search_matches
+                        .iter()
+                        .copied()
+                        .filter(|(line, _, end_col)| {
+                            *line > cursor_line || (*line == cursor_line && *end_col > cursor_col)
+                        }),
+                );
+                ordered.extend(
+                    self.search_matches
+                        .iter()
+                        .copied()
+                        .filter(|(line, _, end_col)| {
+                            !(*line > cursor_line
+                                || (*line == cursor_line && *end_col > cursor_col))
+                        }),
+                );
+            }
+            SearchDirection::Backward => {
+                ordered.extend(self.search_matches.iter().rev().copied().filter(
+                    |(line, start_col, _)| {
+                        *line < cursor_line || (*line == cursor_line && *start_col <= cursor_col)
+                    },
+                ));
+                ordered.extend(self.search_matches.iter().rev().copied().filter(
+                    |(line, start_col, _)| {
+                        !(*line < cursor_line || (*line == cursor_line && *start_col <= cursor_col))
+                    },
+                ));
+            }
+        }
+
+        ordered.get((count - 1) % ordered.len()).copied()
+    }
+
     /// Get the word under the cursor
     pub fn get_word_under_cursor(&self) -> Option<String> {
         let line = self.buffers[self.current_buffer_idx].line(self.cursor.line)?;
@@ -4341,6 +5004,182 @@ impl Editor {
         } else {
             None
         }
+    }
+
+    /// Resolve a path-like token under the cursor for `gf`.
+    pub fn file_path_under_cursor(&self) -> Option<std::path::PathBuf> {
+        let token = self.get_file_token_under_cursor()?;
+        let primary = self.resolve_cursor_file_token(&token);
+        if primary.exists() {
+            return Some(primary);
+        }
+
+        let trimmed = token.trim_end_matches(|ch| matches!(ch, '.' | ',' | ';' | ':'));
+        if trimmed != token {
+            let fallback = self.resolve_cursor_file_token(trimmed);
+            if fallback.exists() {
+                return Some(fallback);
+            }
+        }
+
+        Some(primary)
+    }
+
+    pub fn open_file_under_cursor(&mut self) -> Result<std::path::PathBuf, String> {
+        let path = self
+            .file_path_under_cursor()
+            .ok_or_else(|| "No file under cursor".to_string())?;
+        if !path.exists() {
+            return Err(format!("File not found: {}", path.display()));
+        }
+
+        self.open_file(path.clone())
+            .map_err(|err| format!("Error opening file: {}", err))?;
+        Ok(path)
+    }
+
+    /// Open the URL under the cursor using the platform default browser.
+    pub fn open_url_under_cursor(&mut self) -> Result<String, String> {
+        self.open_url_under_cursor_with(Self::open_url_external)
+    }
+
+    /// Open the URL under the cursor with an injected opener.
+    pub fn open_url_under_cursor_with<F>(&mut self, mut opener: F) -> Result<String, String>
+    where
+        F: FnMut(&str) -> Result<(), String>,
+    {
+        let url = self
+            .url_under_cursor()
+            .ok_or_else(|| "No URL under cursor".to_string())?;
+        opener(&url)?;
+        Ok(url)
+    }
+
+    /// Resolve the URL token under the cursor for `gx`.
+    pub fn url_under_cursor(&self) -> Option<String> {
+        let line = self.buffers[self.current_buffer_idx].line(self.cursor.line)?;
+        let chars: Vec<char> = line.chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let col = self.cursor.col.min(chars.len().saturating_sub(1));
+        if Self::is_url_delimiter(chars[col]) {
+            return None;
+        }
+
+        let mut start = col;
+        while start > 0 && !Self::is_url_delimiter(chars[start - 1]) {
+            start -= 1;
+        }
+
+        let mut end = col;
+        while end < chars.len() && !Self::is_url_delimiter(chars[end]) {
+            end += 1;
+        }
+
+        let token: String = chars[start..end].iter().collect();
+        Self::trim_url_token(&token)
+    }
+
+    fn trim_url_token(token: &str) -> Option<String> {
+        let trimmed = token
+            .trim_start_matches(|ch| matches!(ch, '(' | '[' | '{' | '<' | '"' | '\''))
+            .trim_end_matches(|ch| {
+                matches!(
+                    ch,
+                    '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '>' | '"' | '\''
+                )
+            });
+
+        Self::is_supported_url(trimmed).then(|| trimmed.to_string())
+    }
+
+    fn is_url_delimiter(ch: char) -> bool {
+        ch.is_whitespace()
+    }
+
+    fn is_supported_url(token: &str) -> bool {
+        let lower = token.to_ascii_lowercase();
+        lower.starts_with("http://") || lower.starts_with("https://")
+    }
+
+    fn open_url_external(url: &str) -> Result<(), String> {
+        #[cfg(target_os = "macos")]
+        let mut command = {
+            let mut command = std::process::Command::new("open");
+            command.arg(url);
+            command
+        };
+
+        #[cfg(target_os = "linux")]
+        let mut command = {
+            let mut command = std::process::Command::new("xdg-open");
+            command.arg(url);
+            command
+        };
+
+        #[cfg(target_os = "windows")]
+        let mut command = {
+            let mut command = std::process::Command::new("cmd");
+            command.args(["/C", "start", "", url]);
+            command
+        };
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            let _ = url;
+            return Err("Opening URLs is not supported on this platform".to_string());
+        }
+
+        command
+            .spawn()
+            .map(|_| ())
+            .map_err(|err| format!("Failed to open URL: {}", err))
+    }
+
+    fn get_file_token_under_cursor(&self) -> Option<String> {
+        let line = self.buffers[self.current_buffer_idx].line(self.cursor.line)?;
+        let chars: Vec<char> = line.chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let col = self.cursor.col.min(chars.len().saturating_sub(1));
+        if !Self::is_file_path_char(chars[col]) {
+            return None;
+        }
+
+        let mut start = col;
+        while start > 0 && Self::is_file_path_char(chars[start - 1]) {
+            start -= 1;
+        }
+
+        let mut end = col;
+        while end < chars.len() && Self::is_file_path_char(chars[end]) {
+            end += 1;
+        }
+
+        (start < end).then(|| chars[start..end].iter().collect())
+    }
+
+    fn resolve_cursor_file_token(&self, token: &str) -> std::path::PathBuf {
+        let path = std::path::PathBuf::from(token);
+        if path.is_absolute() {
+            return path;
+        }
+
+        let base = self
+            .buffer()
+            .path
+            .as_ref()
+            .and_then(|path| path.parent().map(std::path::Path::to_path_buf))
+            .unwrap_or_else(|| self.working_directory());
+        base.join(path)
+    }
+
+    fn is_file_path_char(ch: char) -> bool {
+        ch.is_alphanumeric() || matches!(ch, '_' | '-' | '.' | '/' | '\\' | '~')
     }
 
     /// Check if a character is a word character (alphanumeric or underscore)
@@ -5165,6 +6004,9 @@ impl Editor {
             TextObjectType::AngleBracket => {
                 self.find_bracket_object(text_object.modifier, '<', '>')
             }
+            TextObjectType::Paragraph => self.find_paragraph_object(text_object.modifier),
+            TextObjectType::Sentence => self.find_sentence_object(text_object.modifier),
+            TextObjectType::Tag => self.find_tag_object(text_object.modifier),
         }
     }
 
@@ -5263,6 +6105,315 @@ impl Editor {
         }
 
         Some((line, start, line, end))
+    }
+
+    /// Find paragraph text object boundaries separated by blank lines.
+    fn find_paragraph_object(
+        &self,
+        modifier: TextObjectModifier,
+    ) -> Option<(usize, usize, usize, usize)> {
+        let buffer = &self.buffers[self.current_buffer_idx];
+        let line_count = buffer.len_lines();
+        if line_count == 0 {
+            return None;
+        }
+
+        let is_blank = |line: usize| -> bool {
+            buffer
+                .line(line)
+                .map(|text| text.chars().all(char::is_whitespace))
+                .unwrap_or(true)
+        };
+
+        let cursor_line = self.cursor.line.min(line_count.saturating_sub(1));
+        let line = if is_blank(cursor_line) {
+            let next = (cursor_line + 1..line_count).find(|&line| !is_blank(line));
+            next.or_else(|| (0..cursor_line).rev().find(|&line| !is_blank(line)))?
+        } else {
+            cursor_line
+        };
+
+        let mut start_line = line;
+        while start_line > 0 && !is_blank(start_line - 1) {
+            start_line -= 1;
+        }
+
+        let mut end_line = line;
+        while end_line + 1 < line_count && !is_blank(end_line + 1) {
+            end_line += 1;
+        }
+
+        if modifier == TextObjectModifier::Around {
+            if end_line + 1 < line_count && is_blank(end_line + 1) {
+                end_line += 1;
+            } else if start_line > 0 && is_blank(start_line - 1) {
+                start_line -= 1;
+            }
+        }
+
+        Some((start_line, 0, end_line, buffer.line_len(end_line)))
+    }
+
+    /// Find sentence text object boundaries.
+    fn find_sentence_object(
+        &self,
+        modifier: TextObjectModifier,
+    ) -> Option<(usize, usize, usize, usize)> {
+        let buffer = &self.buffers[self.current_buffer_idx];
+        let chars: Vec<char> = buffer.content().chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let ranges = Self::sentence_object_ranges(&chars);
+        if ranges.is_empty() {
+            return None;
+        }
+
+        let cursor_idx = buffer
+            .line_col_to_char(self.cursor.line, self.cursor.col)
+            .min(chars.len().saturating_sub(1));
+        let &(start, body_end, around_end) = ranges
+            .iter()
+            .find(|(start, _, around_end)| cursor_idx >= *start && cursor_idx <= *around_end)
+            .or_else(|| ranges.iter().find(|(start, _, _)| *start > cursor_idx))
+            .or_else(|| ranges.last())?;
+
+        let end = if modifier == TextObjectModifier::Around {
+            around_end
+        } else {
+            body_end
+        };
+        let (start_line, start_col) = Self::char_index_to_line_col(buffer, start);
+        let (end_line, end_col) = Self::char_index_to_line_col(buffer, end);
+        Some((start_line, start_col, end_line, end_col))
+    }
+
+    fn sentence_object_ranges(chars: &[char]) -> Vec<(usize, usize, usize)> {
+        let mut ranges = Vec::new();
+        let Some(mut start) = Self::skip_sentence_space(chars, 0) else {
+            return ranges;
+        };
+
+        while start < chars.len() {
+            let mut scan = start;
+            let mut body_end = None;
+            while scan < chars.len() {
+                if Self::is_sentence_end(chars[scan]) {
+                    let after_closers = Self::skip_sentence_closers(chars, scan + 1);
+                    if after_closers >= chars.len() || chars[after_closers].is_whitespace() {
+                        body_end = Some(after_closers.saturating_sub(1));
+                        break;
+                    }
+                    scan = after_closers;
+                } else {
+                    scan += 1;
+                }
+            }
+
+            let body_end = body_end.unwrap_or_else(|| {
+                let mut end = chars.len().saturating_sub(1);
+                while end > start && chars[end].is_whitespace() {
+                    end -= 1;
+                }
+                end
+            });
+            let mut around_end = body_end;
+            while around_end + 1 < chars.len() && chars[around_end + 1].is_whitespace() {
+                around_end += 1;
+            }
+            ranges.push((start, body_end, around_end));
+
+            let Some(next_start) = Self::skip_sentence_space(chars, around_end + 1) else {
+                break;
+            };
+            if next_start <= start {
+                break;
+            }
+            start = next_start;
+        }
+
+        ranges
+    }
+
+    fn is_sentence_end(ch: char) -> bool {
+        matches!(ch, '.' | '!' | '?')
+    }
+
+    fn skip_sentence_closers(chars: &[char], mut idx: usize) -> usize {
+        while idx < chars.len() && matches!(chars[idx], '"' | '\'' | ')' | ']' | '}') {
+            idx += 1;
+        }
+        idx
+    }
+
+    fn skip_sentence_space(chars: &[char], mut idx: usize) -> Option<usize> {
+        while idx < chars.len() && chars[idx].is_whitespace() {
+            idx += 1;
+        }
+        (idx < chars.len()).then_some(idx)
+    }
+
+    fn char_index_to_line_col(buffer: &Buffer, char_idx: usize) -> (usize, usize) {
+        let mut remaining = char_idx;
+        for line in 0..buffer.len_lines() {
+            let len = buffer.line_len_including_newline(line);
+            if remaining < len {
+                return (line, remaining.min(buffer.line_len(line)));
+            }
+            remaining = remaining.saturating_sub(len);
+        }
+
+        let last_line = buffer.len_lines().saturating_sub(1);
+        (last_line, buffer.line_len(last_line))
+    }
+
+    /// Find HTML/XML-style tag text object boundaries.
+    fn find_tag_object(
+        &self,
+        modifier: TextObjectModifier,
+    ) -> Option<(usize, usize, usize, usize)> {
+        let buffer = &self.buffers[self.current_buffer_idx];
+        let chars: Vec<char> = buffer.content().chars().collect();
+        if chars.is_empty() {
+            return None;
+        }
+
+        let tokens = Self::tag_tokens(&chars);
+        let pairs = Self::tag_pairs(&tokens);
+        let cursor_idx = buffer
+            .line_col_to_char(self.cursor.line, self.cursor.col)
+            .min(chars.len().saturating_sub(1));
+        let &(open_idx, close_idx) = pairs
+            .iter()
+            .filter(|(open_idx, close_idx)| {
+                cursor_idx >= tokens[*open_idx].start && cursor_idx <= tokens[*close_idx].end
+            })
+            .min_by_key(|(open_idx, close_idx)| {
+                tokens[*close_idx]
+                    .end
+                    .saturating_sub(tokens[*open_idx].start)
+            })?;
+
+        let open = &tokens[open_idx];
+        let close = &tokens[close_idx];
+        let (start, end) = match modifier {
+            TextObjectModifier::Inner => {
+                let start = open.end + 1;
+                let end = close.start.checked_sub(1)?;
+                if start > end {
+                    return None;
+                }
+                (start, end)
+            }
+            TextObjectModifier::Around => (open.start, close.end),
+        };
+
+        let (start_line, start_col) = Self::char_index_to_line_col(buffer, start);
+        let (end_line, end_col) = Self::char_index_to_line_col(buffer, end);
+        Some((start_line, start_col, end_line, end_col))
+    }
+
+    fn tag_pairs(tokens: &[TagToken]) -> Vec<(usize, usize)> {
+        let mut stack: Vec<usize> = Vec::new();
+        let mut pairs = Vec::new();
+
+        for (idx, token) in tokens.iter().enumerate() {
+            match token.kind {
+                TagTokenKind::Open => stack.push(idx),
+                TagTokenKind::SelfClosing => {}
+                TagTokenKind::Close => {
+                    if let Some(open_pos) = stack
+                        .iter()
+                        .rposition(|&open_idx| tokens[open_idx].name == token.name)
+                    {
+                        let open_idx = stack.remove(open_pos);
+                        pairs.push((open_idx, idx));
+                    }
+                }
+            }
+        }
+
+        pairs
+    }
+
+    fn tag_tokens(chars: &[char]) -> Vec<TagToken> {
+        let mut tokens = Vec::new();
+        let mut idx = 0;
+
+        while idx < chars.len() {
+            if chars[idx] != '<' {
+                idx += 1;
+                continue;
+            }
+
+            let Some(end) = (idx + 1..chars.len()).find(|&candidate| chars[candidate] == '>')
+            else {
+                break;
+            };
+
+            if let Some(token) = Self::parse_tag_token(chars, idx, end) {
+                tokens.push(token);
+            }
+            idx = end + 1;
+        }
+
+        tokens
+    }
+
+    fn parse_tag_token(chars: &[char], start: usize, end: usize) -> Option<TagToken> {
+        let mut idx = start + 1;
+        while idx < end && chars[idx].is_whitespace() {
+            idx += 1;
+        }
+
+        if idx >= end || matches!(chars[idx], '!' | '?') {
+            return None;
+        }
+
+        let closing = chars[idx] == '/';
+        if closing {
+            idx += 1;
+            while idx < end && chars[idx].is_whitespace() {
+                idx += 1;
+            }
+        }
+
+        let name_start = idx;
+        while idx < end && Self::is_tag_name_char(chars[idx]) {
+            idx += 1;
+        }
+        if idx == name_start {
+            return None;
+        }
+
+        let name: String = chars[name_start..idx].iter().collect();
+        let kind = if closing {
+            TagTokenKind::Close
+        } else if Self::is_self_closing_tag(chars, start, end) {
+            TagTokenKind::SelfClosing
+        } else {
+            TagTokenKind::Open
+        };
+
+        Some(TagToken {
+            name,
+            start,
+            end,
+            kind,
+        })
+    }
+
+    fn is_tag_name_char(ch: char) -> bool {
+        ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_' | ':')
+    }
+
+    fn is_self_closing_tag(chars: &[char], start: usize, end: usize) -> bool {
+        let mut idx = end;
+        while idx > start && chars[idx - 1].is_whitespace() {
+            idx -= 1;
+        }
+        idx > start && chars[idx - 1] == '/'
     }
 
     /// Find quote text object boundaries
@@ -6148,6 +7299,197 @@ impl Editor {
         }
     }
 
+    /// Auto-indent a range of lines based on surrounding delimiters and syntax when available.
+    pub fn auto_indent_lines(&mut self, start_line: usize, end_line: usize) {
+        let buffer = &self.buffers[self.current_buffer_idx];
+        if buffer.len_lines() == 0 {
+            return;
+        }
+
+        let max_line = buffer.len_lines().saturating_sub(1);
+        let start_line = start_line.min(max_line);
+        let end_line = end_line.min(max_line);
+        if start_line > end_line {
+            return;
+        }
+
+        self.begin_change();
+        let mut changed = false;
+
+        for line_num in start_line..=end_line {
+            let Some(line) = self.buffers[self.current_buffer_idx].line(line_num) else {
+                continue;
+            };
+            let line_str: String = line.chars().collect();
+            let line_without_newline = line_str.trim_end_matches('\n');
+
+            if line_without_newline.trim().is_empty() {
+                continue;
+            }
+
+            let old_indent_len = line_without_newline
+                .chars()
+                .take_while(|ch| *ch == ' ' || *ch == '\t')
+                .count();
+            let old_indent: String = line_without_newline.chars().take(old_indent_len).collect();
+            let new_indent = " ".repeat(self.expected_auto_indent_for_line(line_num));
+
+            if old_indent == new_indent {
+                continue;
+            }
+
+            if !old_indent.is_empty() {
+                self.undo_stack
+                    .record_change(Change::delete(line_num, 0, old_indent.clone()));
+                self.buffers[self.current_buffer_idx].delete_range(
+                    line_num,
+                    0,
+                    line_num,
+                    old_indent_len,
+                );
+            }
+
+            if !new_indent.is_empty() {
+                self.undo_stack
+                    .record_change(Change::insert(line_num, 0, new_indent.clone()));
+                self.buffers[self.current_buffer_idx].insert_str(line_num, 0, &new_indent);
+            }
+
+            changed = true;
+        }
+
+        self.undo_stack
+            .end_undo_group(self.cursor.line, self.cursor.col);
+
+        if changed {
+            self.buffers[self.current_buffer_idx].mark_modified();
+            self.parse_current_buffer();
+        }
+
+        self.cursor.line = start_line;
+        self.cursor.col = self.find_first_non_blank(start_line);
+        self.clamp_cursor();
+    }
+
+    fn expected_auto_indent_for_line(&mut self, line_num: usize) -> usize {
+        let tab_width = self.settings.editor.tab_width;
+        if tab_width == 0 {
+            return 0;
+        }
+
+        let fallback = self.delimiter_auto_indent_for_line(line_num);
+
+        if line_num == 0 {
+            return if self.line_starts_with_closing_delimiter(line_num) {
+                fallback.saturating_sub(tab_width)
+            } else {
+                fallback
+            };
+        }
+
+        self.parse_current_buffer();
+
+        let prev_line = line_num.saturating_sub(1);
+        let prev_col = self.buffers[self.current_buffer_idx].line_len(prev_line);
+        let Some(cursor_byte) = self.syntax.position_to_byte(prev_line, prev_col) else {
+            return fallback;
+        };
+        let Some((tree, source)) = self.syntax.get_tree_and_source() else {
+            return fallback;
+        };
+
+        let mut indent = crate::indent::calculate_indent(tree, source, cursor_byte, tab_width);
+
+        if let Some(bracket) = self.line_start_closing_delimiter(line_num) {
+            if let Some(current_byte) = self.syntax.position_to_byte(line_num, 0) {
+                indent = crate::indent::calculate_closing_bracket_indent(
+                    tree,
+                    source,
+                    current_byte,
+                    bracket,
+                )
+                .unwrap_or_else(|| indent.saturating_sub(tab_width));
+            } else {
+                indent = indent.saturating_sub(tab_width);
+            }
+        }
+
+        if indent == 0 && fallback > 0 {
+            fallback
+        } else {
+            indent
+        }
+    }
+
+    fn delimiter_auto_indent_for_line(&self, line_num: usize) -> usize {
+        let tab_width = self.settings.editor.tab_width;
+        let mut level = 0usize;
+
+        for prev_line in 0..line_num {
+            let Some(line) = self.buffers[self.current_buffer_idx].line(prev_line) else {
+                continue;
+            };
+            let line_str: String = line.chars().collect();
+            for ch in Self::code_portion_before_line_comment(&line_str).chars() {
+                match ch {
+                    '{' | '[' | '(' => level = level.saturating_add(1),
+                    '}' | ']' | ')' => level = level.saturating_sub(1),
+                    _ => {}
+                }
+            }
+        }
+
+        if self.line_starts_with_closing_delimiter(line_num) {
+            level = level.saturating_sub(1);
+        }
+
+        level * tab_width
+    }
+
+    fn line_starts_with_closing_delimiter(&self, line_num: usize) -> bool {
+        self.line_start_closing_delimiter(line_num).is_some()
+    }
+
+    fn line_start_closing_delimiter(&self, line_num: usize) -> Option<char> {
+        let line = self.buffers[self.current_buffer_idx].line(line_num)?;
+        let line_str: String = line.chars().collect();
+        line_str
+            .trim_start()
+            .chars()
+            .next()
+            .and_then(|ch| match ch {
+                '}' | ']' | ')' => Some(ch),
+                _ => None,
+            })
+    }
+
+    fn code_portion_before_line_comment(line: &str) -> &str {
+        line.split_once("//")
+            .map(|(code, _)| code)
+            .unwrap_or(line)
+            .trim_end_matches('\n')
+    }
+
+    /// Auto-indent with motion (={motion}).
+    pub fn auto_indent_motion(&mut self, motion: Motion, count: usize) {
+        let start_line = self.cursor.line;
+        let text_rows = self.text_rows().max(1);
+        let Some((target_line, _)) = apply_motion(
+            &self.buffers[self.current_buffer_idx],
+            motion,
+            self.cursor.line,
+            self.cursor.col,
+            count,
+            text_rows,
+        ) else {
+            return;
+        };
+
+        let range_start = start_line.min(target_line);
+        let range_end = start_line.max(target_line);
+        self.auto_indent_lines(range_start, range_end);
+    }
+
     /// Indent current line and count-1 lines below (>> operation)
     pub fn indent_line(&mut self, count: usize) {
         let start_line = self.cursor.line;
@@ -6155,11 +7497,86 @@ impl Editor {
         self.indent_lines(start_line, end_line);
     }
 
+    /// Auto-indent current line and count-1 lines below (== operation).
+    pub fn auto_indent_line(&mut self, count: usize) {
+        let start_line = self.cursor.line;
+        let end_line = start_line + count.saturating_sub(1);
+        self.auto_indent_lines(start_line, end_line);
+    }
+
+    /// Increase indentation of the current line while preserving insert position.
+    pub fn indent_current_line_in_insert_mode(&mut self) {
+        let tab_width = self.settings.editor.tab_width;
+        if tab_width == 0 {
+            return;
+        }
+
+        let line = self.cursor.line;
+        if line >= self.buffers[self.current_buffer_idx].len_lines() {
+            return;
+        }
+
+        let indent = " ".repeat(tab_width);
+        self.undo_stack
+            .record_change(Change::insert(line, 0, indent.clone()));
+        self.buffers[self.current_buffer_idx].insert_str(line, 0, &indent);
+        self.cursor.col += tab_width;
+        self.scroll_to_cursor();
+    }
+
     /// Dedent current line and count-1 lines below (<< operation)
     pub fn dedent_line(&mut self, count: usize) {
         let start_line = self.cursor.line;
         let end_line = start_line + count.saturating_sub(1);
         self.dedent_lines(start_line, end_line);
+    }
+
+    /// Decrease indentation of the current line while preserving insert position.
+    pub fn dedent_current_line_in_insert_mode(&mut self) {
+        let tab_width = self.settings.editor.tab_width;
+        if tab_width == 0 {
+            return;
+        }
+
+        let line = self.cursor.line;
+        let Some(line_text) = self.buffers[self.current_buffer_idx].line(line) else {
+            return;
+        };
+
+        let mut chars_to_remove = 0;
+        let mut indent_width = 0;
+        for ch in line_text.chars() {
+            if indent_width >= tab_width {
+                break;
+            }
+
+            match ch {
+                ' ' => {
+                    chars_to_remove += 1;
+                    indent_width += 1;
+                }
+                '\t' => {
+                    chars_to_remove += 1;
+                    break;
+                }
+                _ => break,
+            }
+        }
+
+        if chars_to_remove == 0 {
+            return;
+        }
+
+        let deleted_text: String = line_text.chars().take(chars_to_remove).collect();
+        self.undo_stack
+            .record_change(Change::delete(line, 0, deleted_text));
+
+        for _ in 0..chars_to_remove {
+            self.buffers[self.current_buffer_idx].delete_char(line, 0);
+        }
+
+        self.cursor.col = self.cursor.col.saturating_sub(chars_to_remove);
+        self.scroll_to_cursor();
     }
 
     /// Indent text object
@@ -6173,6 +7590,13 @@ impl Editor {
     pub fn dedent_text_object(&mut self, text_object: TextObject) {
         if let Some((start_line, _, end_line, _)) = self.find_text_object_range(text_object) {
             self.dedent_lines(start_line, end_line);
+        }
+    }
+
+    /// Auto-indent text object.
+    pub fn auto_indent_text_object(&mut self, text_object: TextObject) {
+        if let Some((start_line, _, end_line, _)) = self.find_text_object_range(text_object) {
+            self.auto_indent_lines(start_line, end_line);
         }
     }
 
@@ -6754,6 +8178,21 @@ impl Editor {
                 self.clamp_cursor();
                 self.scroll_to_cursor();
             }
+            Motion::DisplayLineDown => {
+                self.move_display_lines(true, count);
+            }
+            Motion::DisplayLineUp => {
+                self.move_display_lines(false, count);
+            }
+            Motion::DisplayLineStart => {
+                self.move_to_display_line_position(DisplayLineTarget::Start);
+            }
+            Motion::DisplayLineEnd => {
+                self.move_to_display_line_position(DisplayLineTarget::End);
+            }
+            Motion::DisplayLineFirstNonBlank => {
+                self.move_to_display_line_position(DisplayLineTarget::FirstNonBlank);
+            }
             _ => {
                 // Use standard motion handling
                 if let Some((new_line, new_col)) = apply_motion(
@@ -6771,6 +8210,189 @@ impl Editor {
                 }
             }
         }
+    }
+
+    fn move_display_lines(&mut self, down: bool, count: usize) {
+        if !self.settings.editor.wrap || self.effective_wrap_width() == 0 {
+            let fallback = if down { Motion::Down } else { Motion::Up };
+            if let Some((new_line, new_col)) = apply_motion(
+                &self.buffers[self.current_buffer_idx],
+                fallback,
+                self.cursor.line,
+                self.cursor.col,
+                count,
+                self.text_rows(),
+            ) {
+                self.cursor.line = new_line;
+                self.cursor.col = new_col;
+                self.clamp_cursor();
+                self.scroll_to_cursor();
+            }
+            return;
+        }
+
+        for _ in 0..count.max(1) {
+            if !self.move_display_line_once(down) {
+                break;
+            }
+        }
+
+        self.clamp_cursor();
+        self.scroll_to_cursor();
+    }
+
+    fn move_display_line_once(&mut self, down: bool) -> bool {
+        let tab_width = self.get_effective_tab_width();
+        let wrap_width = self.effective_wrap_width();
+        let current_line = self.cursor.line;
+        let current_text = self
+            .buffers
+            .get(self.current_buffer_idx)
+            .and_then(|buffer| buffer.line(current_line))
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+        let current_segments = Self::display_line_segments(&current_text, wrap_width, tab_width);
+        let (segment_idx, display_col) = Self::display_segment_for_col(
+            &current_text,
+            &current_segments,
+            self.cursor.col,
+            tab_width,
+        );
+
+        if down {
+            if segment_idx + 1 < current_segments.len() {
+                let target_segment = current_segments[segment_idx + 1];
+                self.cursor.col = Self::display_col_to_buffer_col(
+                    &current_text,
+                    target_segment,
+                    display_col,
+                    tab_width,
+                );
+                return true;
+            }
+
+            let next_line = current_line + 1;
+            if next_line >= self.buffers[self.current_buffer_idx].len_lines() {
+                return false;
+            }
+
+            let next_text = self
+                .buffers
+                .get(self.current_buffer_idx)
+                .and_then(|buffer| buffer.line(next_line))
+                .map(|line| line.to_string())
+                .unwrap_or_default();
+            let next_segments = Self::display_line_segments(&next_text, wrap_width, tab_width);
+            self.cursor.line = next_line;
+            self.cursor.col = Self::display_col_to_buffer_col(
+                &next_text,
+                next_segments[0],
+                display_col,
+                tab_width,
+            );
+            return true;
+        }
+
+        if segment_idx > 0 {
+            let target_segment = current_segments[segment_idx - 1];
+            self.cursor.col = Self::display_col_to_buffer_col(
+                &current_text,
+                target_segment,
+                display_col,
+                tab_width,
+            );
+            return true;
+        }
+
+        let Some(prev_line) = current_line.checked_sub(1) else {
+            return false;
+        };
+
+        let prev_text = self
+            .buffers
+            .get(self.current_buffer_idx)
+            .and_then(|buffer| buffer.line(prev_line))
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+        let prev_segments = Self::display_line_segments(&prev_text, wrap_width, tab_width);
+        let target_segment = prev_segments[prev_segments.len().saturating_sub(1)];
+        self.cursor.line = prev_line;
+        self.cursor.col =
+            Self::display_col_to_buffer_col(&prev_text, target_segment, display_col, tab_width);
+        true
+    }
+
+    fn move_to_display_line_position(&mut self, target: DisplayLineTarget) {
+        if !self.settings.editor.wrap || self.effective_wrap_width() == 0 {
+            let fallback = match target {
+                DisplayLineTarget::Start => Motion::LineStart,
+                DisplayLineTarget::End => Motion::LineEnd,
+                DisplayLineTarget::FirstNonBlank => Motion::FirstNonBlank,
+            };
+            if let Some((new_line, new_col)) = apply_motion(
+                &self.buffers[self.current_buffer_idx],
+                fallback,
+                self.cursor.line,
+                self.cursor.col,
+                1,
+                self.text_rows(),
+            ) {
+                self.cursor.line = new_line;
+                self.cursor.col = new_col;
+                self.clamp_cursor();
+                self.scroll_to_cursor();
+            }
+            return;
+        }
+
+        let tab_width = self.get_effective_tab_width();
+        let wrap_width = self.effective_wrap_width();
+        let current_line = self.cursor.line;
+        let current_text = self
+            .buffers
+            .get(self.current_buffer_idx)
+            .and_then(|buffer| buffer.line(current_line))
+            .map(|line| line.to_string())
+            .unwrap_or_default();
+        let segments = Self::display_line_segments(&current_text, wrap_width, tab_width);
+        let (segment_idx, _) =
+            Self::display_segment_for_col(&current_text, &segments, self.cursor.col, tab_width);
+        let segment = segments[segment_idx];
+
+        self.cursor.col = match target {
+            DisplayLineTarget::Start => segment.start_col,
+            DisplayLineTarget::End => segment.end_col.saturating_sub(1),
+            DisplayLineTarget::FirstNonBlank => {
+                Self::display_line_first_non_blank_col(&current_text, segment, tab_width)
+            }
+        };
+        self.clamp_cursor();
+        self.scroll_to_cursor();
+    }
+
+    fn display_line_first_non_blank_col(
+        line: &str,
+        segment: DisplayLineSegment,
+        tab_width: usize,
+    ) -> usize {
+        if segment.end_col <= segment.start_col {
+            return segment.start_col;
+        }
+
+        line.chars()
+            .enumerate()
+            .skip(segment.start_col)
+            .take(segment.end_col - segment.start_col)
+            .find_map(|(idx, ch)| {
+                if ch == '\n' {
+                    None
+                } else if Self::display_char_width(ch, tab_width) > 0 && !ch.is_whitespace() {
+                    Some(idx)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(segment.start_col)
     }
 
     /// Find first non-blank character on a line
@@ -7223,7 +8845,11 @@ impl Editor {
         if idx >= self.buffers.len() {
             return false;
         }
+        if idx == self.current_buffer_idx {
+            return true;
+        }
 
+        self.remember_current_file_as_alternate();
         self.save_pane_state();
         self.current_buffer_idx = idx;
         self.load_current_undo_stack();
@@ -7452,6 +9078,211 @@ mod tests {
     }
 
     #[test]
+    fn open_url_under_cursor_uses_url_token_without_trailing_punctuation() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("see (https://example.test/docs?q=nevi).\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = "see (https://example".chars().count();
+
+        let mut opened = Vec::new();
+        let opened_url = editor
+            .open_url_under_cursor_with(|url| {
+                opened.push(url.to_string());
+                Ok(())
+            })
+            .expect("open url");
+
+        assert_eq!(opened_url, "https://example.test/docs?q=nevi");
+        assert_eq!(opened, vec!["https://example.test/docs?q=nevi"]);
+    }
+
+    #[test]
+    fn equalize_windows_restores_even_vertical_pane_rects() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("first split");
+        editor.vsplit(None).expect("second split");
+
+        editor.panes[0].rect = super::Rect::new(0, 0, 10, 5);
+        editor.panes[1].rect = super::Rect::new(10, 0, 70, 5);
+        editor.panes[2].rect = super::Rect::new(80, 0, 20, 5);
+
+        editor.equalize_windows();
+
+        let widths: Vec<u16> = editor.panes.iter().map(|pane| pane.rect.width).collect();
+        assert_eq!(widths, vec![33, 33, 34]);
+        assert_eq!(editor.status_message.as_deref(), Some("Windows equalized"));
+    }
+
+    #[test]
+    fn rotate_windows_moves_panes_down_right_and_up_left() {
+        let tmp = unique_temp_dir("nevi_rotate_windows");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        let third = tmp.join("third.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+        std::fs::write(&third, "third\n").expect("write third");
+
+        let mut editor = Editor::default();
+        editor.open_file(first).expect("open first");
+        editor.vsplit(Some(second)).expect("split second");
+        editor.vsplit(Some(third)).expect("split third");
+        editor.prev_pane();
+        let active_buffer = editor.panes[editor.active_pane].buffer_idx;
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+
+        editor.rotate_windows_down_right();
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![2, 0, 1]
+        );
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(editor.status_message.as_deref(), Some("Windows rotated"));
+
+        editor.rotate_windows_up_left();
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Windows rotated reverse")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn display_line_motions_move_within_wrapped_lines() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 12);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 5;
+        editor.settings.editor.line_numbers = false;
+        editor.replace_buffer_content("abcdefghij\nklmno\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 1;
+
+        editor.apply_motion(Motion::DisplayLineDown, 1);
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 6));
+
+        editor.apply_motion(Motion::DisplayLineDown, 1);
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 1));
+
+        editor.apply_motion(Motion::DisplayLineUp, 2);
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+    }
+
+    #[test]
+    fn display_line_horizontal_motions_target_current_wrapped_row() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 12);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 5;
+        editor.settings.editor.line_numbers = false;
+        editor.replace_buffer_content("  abcdefghij\n");
+        editor.cursor.line = 0;
+
+        editor.cursor.col = 6;
+        editor.apply_motion(Motion::DisplayLineStart, 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+
+        editor.cursor.col = 6;
+        editor.apply_motion(Motion::DisplayLineEnd, 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 7));
+
+        editor.cursor.col = 6;
+        editor.apply_motion(Motion::DisplayLineFirstNonBlank, 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+
+        editor.cursor.col = 3;
+        editor.apply_motion(Motion::DisplayLineFirstNonBlank, 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+    }
+
+    #[test]
+    fn exchange_window_swaps_current_with_next_or_previous_at_end() {
+        let tmp = unique_temp_dir("nevi_exchange_window");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        let third = tmp.join("third.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+        std::fs::write(&third, "third\n").expect("write third");
+
+        let mut editor = Editor::default();
+        editor.open_file(first).expect("open first");
+        editor.vsplit(Some(second)).expect("split second");
+        editor.vsplit(Some(third)).expect("split third");
+        editor.prev_pane();
+        let active_buffer = editor.panes[editor.active_pane].buffer_idx;
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+
+        editor.exchange_window_with_next();
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 1]
+        );
+        assert_eq!(editor.active_pane, 2);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(editor.status_message.as_deref(), Some("Windows exchanged"));
+
+        editor.exchange_window_with_next();
+
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+        assert_eq!(editor.active_pane, 1);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(editor.status_message.as_deref(), Some("Windows exchanged"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn undo_history_follows_the_active_buffer() {
         let tmp = unique_temp_dir("nevi_undo_per_buffer");
         std::fs::create_dir_all(&tmp).expect("create temp dir");
@@ -7486,30 +9317,18 @@ mod tests {
         std::fs::write(&markdown, "# Seed\n").expect("write markdown");
 
         let mut editor = Editor::default();
-        editor
-            .open_file(markdown)
-            .expect("open markdown buffer");
+        editor.open_file(markdown).expect("open markdown buffer");
         editor.replace_buffer_content("# Before\n");
 
         editor.open_markdown_preview().expect("open preview");
         assert_eq!(
-            editor
-                .markdown_preview
-                .as_ref()
-                .expect("preview")
-                .lines[0]
-                .plain_text(),
+            editor.markdown_preview.as_ref().expect("preview").lines[0].plain_text(),
             "Before"
         );
 
         editor.replace_buffer_content("# After\n");
         assert_eq!(
-            editor
-                .markdown_preview
-                .as_ref()
-                .expect("preview")
-                .lines[0]
-                .plain_text(),
+            editor.markdown_preview.as_ref().expect("preview").lines[0].plain_text(),
             "Before"
         );
 
@@ -7542,9 +9361,7 @@ mod tests {
         std::fs::write(&markdown, "# Seed\n").expect("write markdown");
 
         let mut editor = Editor::default();
-        editor
-            .open_file(markdown)
-            .expect("open markdown buffer");
+        editor.open_file(markdown).expect("open markdown buffer");
         editor.replace_buffer_content(&(0..20).map(|i| format!("line {i}\n")).collect::<String>());
         editor.open_markdown_preview().expect("open preview");
 

--- a/src/editor/register.rs
+++ b/src/editor/register.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use arboard::Clipboard;
+use std::collections::HashMap;
 
 /// Type of register content
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,9 +59,7 @@ impl Registers {
         match name {
             None | Some('"') => self.unnamed.as_ref(),
             Some('-') => self.small_delete.as_ref(),
-            Some(c @ 'a'..='z') | Some(c @ 'A'..='Z') => {
-                self.named.get(&c.to_ascii_lowercase())
-            }
+            Some(c @ 'a'..='z') | Some(c @ 'A'..='Z') => self.named.get(&c.to_ascii_lowercase()),
             Some(c @ '1'..='9') => {
                 let idx = c.to_digit(10).unwrap() as usize - 1;
                 self.numbered[idx].as_ref()

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -420,7 +420,11 @@ impl FileExplorer {
         }
     }
 
-    fn flatten_tree_into(flat_view: &mut Vec<FlatNode>, node: &TreeNode, expanded: &HashSet<PathBuf>) {
+    fn flatten_tree_into(
+        flat_view: &mut Vec<FlatNode>,
+        node: &TreeNode,
+        expanded: &HashSet<PathBuf>,
+    ) {
         let is_expanded = expanded.contains(&node.path);
 
         flat_view.push(FlatNode {
@@ -444,7 +448,12 @@ impl FileExplorer {
         // Expand all parent directories
         let mut current = path.parent();
         while let Some(parent) = current {
-            if self.root.as_ref().map(|r| parent.starts_with(r)).unwrap_or(false) {
+            if self
+                .root
+                .as_ref()
+                .map(|r| parent.starts_with(r))
+                .unwrap_or(false)
+            {
                 self.expanded.insert(parent.to_path_buf());
                 self.load_children_for(parent);
             }
@@ -485,33 +494,33 @@ impl IconColor {
 }
 
 // Common icon colors
-const COLOR_FOLDER: IconColor = IconColor::new(86, 182, 194);    // Cyan
-const COLOR_RUST: IconColor = IconColor::new(222, 165, 132);     // Rust orange
-const COLOR_JS: IconColor = IconColor::new(241, 224, 90);        // JavaScript yellow
-const COLOR_TS: IconColor = IconColor::new(49, 120, 198);        // TypeScript blue
-const COLOR_REACT: IconColor = IconColor::new(97, 218, 251);     // React cyan
-const COLOR_PYTHON: IconColor = IconColor::new(55, 118, 171);    // Python blue
-const COLOR_GO: IconColor = IconColor::new(0, 173, 216);         // Go cyan
-const COLOR_HTML: IconColor = IconColor::new(228, 79, 38);       // HTML orange
-const COLOR_CSS: IconColor = IconColor::new(86, 61, 124);        // CSS purple
-const COLOR_JSON: IconColor = IconColor::new(241, 224, 90);      // JSON yellow
-const COLOR_MARKDOWN: IconColor = IconColor::new(66, 165, 245);  // Markdown blue
-const COLOR_GIT: IconColor = IconColor::new(240, 80, 50);        // Git orange-red
-const COLOR_CONFIG: IconColor = IconColor::new(140, 140, 140);   // Config gray
-const COLOR_LOCK: IconColor = IconColor::new(255, 213, 79);      // Lock yellow
-const COLOR_ENV: IconColor = IconColor::new(255, 213, 79);       // Env yellow
-const COLOR_DOCKER: IconColor = IconColor::new(33, 150, 243);    // Docker blue
-const COLOR_RUBY: IconColor = IconColor::new(204, 52, 45);       // Ruby red
-const COLOR_PHP: IconColor = IconColor::new(119, 123, 180);      // PHP purple
-const COLOR_JAVA: IconColor = IconColor::new(176, 114, 25);      // Java brown
-const COLOR_SWIFT: IconColor = IconColor::new(240, 81, 57);      // Swift orange
-const COLOR_C: IconColor = IconColor::new(85, 85, 255);          // C blue
-const COLOR_LUA: IconColor = IconColor::new(0, 0, 128);          // Lua dark blue
-const COLOR_SHELL: IconColor = IconColor::new(137, 224, 81);     // Shell green
-const COLOR_IMAGE: IconColor = IconColor::new(168, 128, 194);    // Image purple
-const COLOR_ARCHIVE: IconColor = IconColor::new(175, 180, 43);   // Archive olive
-const COLOR_LICENSE: IconColor = IconColor::new(203, 166, 93);   // License gold
-const COLOR_DEFAULT: IconColor = IconColor::new(165, 165, 165);  // Default gray
+const COLOR_FOLDER: IconColor = IconColor::new(86, 182, 194); // Cyan
+const COLOR_RUST: IconColor = IconColor::new(222, 165, 132); // Rust orange
+const COLOR_JS: IconColor = IconColor::new(241, 224, 90); // JavaScript yellow
+const COLOR_TS: IconColor = IconColor::new(49, 120, 198); // TypeScript blue
+const COLOR_REACT: IconColor = IconColor::new(97, 218, 251); // React cyan
+const COLOR_PYTHON: IconColor = IconColor::new(55, 118, 171); // Python blue
+const COLOR_GO: IconColor = IconColor::new(0, 173, 216); // Go cyan
+const COLOR_HTML: IconColor = IconColor::new(228, 79, 38); // HTML orange
+const COLOR_CSS: IconColor = IconColor::new(86, 61, 124); // CSS purple
+const COLOR_JSON: IconColor = IconColor::new(241, 224, 90); // JSON yellow
+const COLOR_MARKDOWN: IconColor = IconColor::new(66, 165, 245); // Markdown blue
+const COLOR_GIT: IconColor = IconColor::new(240, 80, 50); // Git orange-red
+const COLOR_CONFIG: IconColor = IconColor::new(140, 140, 140); // Config gray
+const COLOR_LOCK: IconColor = IconColor::new(255, 213, 79); // Lock yellow
+const COLOR_ENV: IconColor = IconColor::new(255, 213, 79); // Env yellow
+const COLOR_DOCKER: IconColor = IconColor::new(33, 150, 243); // Docker blue
+const COLOR_RUBY: IconColor = IconColor::new(204, 52, 45); // Ruby red
+const COLOR_PHP: IconColor = IconColor::new(119, 123, 180); // PHP purple
+const COLOR_JAVA: IconColor = IconColor::new(176, 114, 25); // Java brown
+const COLOR_SWIFT: IconColor = IconColor::new(240, 81, 57); // Swift orange
+const COLOR_C: IconColor = IconColor::new(85, 85, 255); // C blue
+const COLOR_LUA: IconColor = IconColor::new(0, 0, 128); // Lua dark blue
+const COLOR_SHELL: IconColor = IconColor::new(137, 224, 81); // Shell green
+const COLOR_IMAGE: IconColor = IconColor::new(168, 128, 194); // Image purple
+const COLOR_ARCHIVE: IconColor = IconColor::new(175, 180, 43); // Archive olive
+const COLOR_LICENSE: IconColor = IconColor::new(203, 166, 93); // License gold
+const COLOR_DEFAULT: IconColor = IconColor::new(165, 165, 165); // Default gray
 
 /// Get the color for a file icon based on file type
 pub fn get_icon_color(name: &str, is_dir: bool) -> IconColor {
@@ -528,8 +537,8 @@ pub fn get_icon_color(name: &str, is_dir: bool) -> IconColor {
         "Makefile" | "CMakeLists.txt" => COLOR_CONFIG,
         "Dockerfile" | "docker-compose.yml" | "docker-compose.yaml" => COLOR_DOCKER,
         ".gitignore" | ".gitattributes" | ".gitmodules" => COLOR_GIT,
-        ".editorconfig" | ".prettierrc" | ".prettierrc.json" | ".prettierrc.js"
-        | ".eslintrc" | ".eslintrc.json" | ".eslintrc.js" => COLOR_CONFIG,
+        ".editorconfig" | ".prettierrc" | ".prettierrc.json" | ".prettierrc.js" | ".eslintrc"
+        | ".eslintrc.json" | ".eslintrc.js" => COLOR_CONFIG,
         "README.md" | "README" | "readme.md" => COLOR_MARKDOWN,
         "LICENSE" | "LICENSE.md" | "LICENSE.txt" => COLOR_LICENSE,
         "CHANGELOG.md" | "CHANGELOG" => COLOR_MARKDOWN,
@@ -549,14 +558,14 @@ pub fn get_icon_color(name: &str, is_dir: bool) -> IconColor {
                 "html" | "htm" => COLOR_HTML,
                 "css" => COLOR_CSS,
                 "scss" | "sass" | "less" => COLOR_CSS,
-                "vue" => IconColor::new(65, 184, 131),  // Vue green
+                "vue" => IconColor::new(65, 184, 131), // Vue green
                 "svelte" => IconColor::new(255, 62, 0), // Svelte orange
                 "json" | "jsonc" => COLOR_JSON,
                 "toml" | "yaml" | "yml" | "xml" => COLOR_CONFIG,
-                "csv" => IconColor::new(77, 175, 80),   // CSV green
+                "csv" => IconColor::new(77, 175, 80), // CSV green
                 "md" | "markdown" => COLOR_MARKDOWN,
                 "txt" => COLOR_DEFAULT,
-                "pdf" => IconColor::new(244, 67, 54),   // PDF red
+                "pdf" => IconColor::new(244, 67, 54), // PDF red
                 "py" | "pyi" => COLOR_PYTHON,
                 "go" => COLOR_GO,
                 "rb" => COLOR_RUBY,
@@ -566,7 +575,7 @@ pub fn get_icon_color(name: &str, is_dir: bool) -> IconColor {
                 "swift" => COLOR_SWIFT,
                 "c" | "h" => COLOR_C,
                 "cpp" | "cc" | "cxx" | "hpp" => IconColor::new(0, 89, 156), // C++ darker blue
-                "cs" => IconColor::new(104, 33, 122),  // C# purple
+                "cs" => IconColor::new(104, 33, 122),                       // C# purple
                 "lua" => COLOR_LUA,
                 "zig" => IconColor::new(247, 164, 29), // Zig orange
                 "sh" | "bash" | "zsh" | "fish" => COLOR_SHELL,
@@ -586,48 +595,137 @@ pub fn get_icon_color(name: &str, is_dir: bool) -> IconColor {
 
 /// Get the appropriate icon for a file or directory
 /// Checks exact filename first, then extension, with Nerd Font and Unicode variants
-pub fn get_file_icon(name: &str, is_dir: bool, is_expanded: bool, use_nerd_fonts: bool) -> &'static str {
+pub fn get_file_icon(
+    name: &str,
+    is_dir: bool,
+    is_expanded: bool,
+    use_nerd_fonts: bool,
+) -> &'static str {
     if is_dir {
         if use_nerd_fonts {
             if is_expanded {
-                "\u{f07c}"  // nf-fa-folder_open
+                "\u{f07c}" // nf-fa-folder_open
             } else {
-                "\u{f07b}"  // nf-fa-folder
+                "\u{f07b}" // nf-fa-folder
             }
         } else {
             // Unicode fallback
             if is_expanded {
-                "\u{1F4C2}"  // 📂 Open folder
+                "\u{1F4C2}" // 📂 Open folder
             } else {
-                "\u{1F4C1}"  // 📁 Closed folder
+                "\u{1F4C1}" // 📁 Closed folder
             }
         }
     } else {
         // Check exact filename first
         let icon = match name {
             // Config files
-            "Cargo.toml" | "Cargo.lock" => if use_nerd_fonts { "\u{e7a8}" } else { "\u{1F4E6}" },  // Rust icon / 📦
-            "package.json" | "package-lock.json" => if use_nerd_fonts { "\u{e74e}" } else { "\u{1F4E6}" },  // JS / 📦
-            "tsconfig.json" | "jsconfig.json" => if use_nerd_fonts { "\u{e628}" } else { "\u{2699}" },  // TS / ⚙
-            "webpack.config.js" | "vite.config.js" | "vite.config.ts" => if use_nerd_fonts { "\u{f0ad}" } else { "\u{2699}" },  // wrench / ⚙
-            "Makefile" | "CMakeLists.txt" => if use_nerd_fonts { "\u{f0ad}" } else { "\u{2699}" },  // wrench / ⚙
-            "Dockerfile" | "docker-compose.yml" | "docker-compose.yaml" => if use_nerd_fonts { "\u{f308}" } else { "\u{1F433}" },  // docker / 🐳
+            "Cargo.toml" | "Cargo.lock" => {
+                if use_nerd_fonts {
+                    "\u{e7a8}"
+                } else {
+                    "\u{1F4E6}"
+                }
+            } // Rust icon / 📦
+            "package.json" | "package-lock.json" => {
+                if use_nerd_fonts {
+                    "\u{e74e}"
+                } else {
+                    "\u{1F4E6}"
+                }
+            } // JS / 📦
+            "tsconfig.json" | "jsconfig.json" => {
+                if use_nerd_fonts {
+                    "\u{e628}"
+                } else {
+                    "\u{2699}"
+                }
+            } // TS / ⚙
+            "webpack.config.js" | "vite.config.js" | "vite.config.ts" => {
+                if use_nerd_fonts {
+                    "\u{f0ad}"
+                } else {
+                    "\u{2699}"
+                }
+            } // wrench / ⚙
+            "Makefile" | "CMakeLists.txt" => {
+                if use_nerd_fonts {
+                    "\u{f0ad}"
+                } else {
+                    "\u{2699}"
+                }
+            } // wrench / ⚙
+            "Dockerfile" | "docker-compose.yml" | "docker-compose.yaml" => {
+                if use_nerd_fonts {
+                    "\u{f308}"
+                } else {
+                    "\u{1F433}"
+                }
+            } // docker / 🐳
 
             // Git files
-            ".gitignore" | ".gitattributes" | ".gitmodules" => if use_nerd_fonts { "\u{f1d3}" } else { "\u{E0A0}" },  // git / branch
+            ".gitignore" | ".gitattributes" | ".gitmodules" => {
+                if use_nerd_fonts {
+                    "\u{f1d3}"
+                } else {
+                    "\u{E0A0}"
+                }
+            } // git / branch
 
             // Editor/IDE config
-            ".editorconfig" => if use_nerd_fonts { "\u{e615}" } else { "\u{2699}" },  // config / ⚙
-            ".prettierrc" | ".prettierrc.json" | ".prettierrc.js" => if use_nerd_fonts { "\u{e615}" } else { "\u{2699}" },
-            ".eslintrc" | ".eslintrc.json" | ".eslintrc.js" => if use_nerd_fonts { "\u{e615}" } else { "\u{2699}" },
+            ".editorconfig" => {
+                if use_nerd_fonts {
+                    "\u{e615}"
+                } else {
+                    "\u{2699}"
+                }
+            } // config / ⚙
+            ".prettierrc" | ".prettierrc.json" | ".prettierrc.js" => {
+                if use_nerd_fonts {
+                    "\u{e615}"
+                } else {
+                    "\u{2699}"
+                }
+            }
+            ".eslintrc" | ".eslintrc.json" | ".eslintrc.js" => {
+                if use_nerd_fonts {
+                    "\u{e615}"
+                } else {
+                    "\u{2699}"
+                }
+            }
 
             // Readme/docs
-            "README.md" | "README" | "readme.md" => if use_nerd_fonts { "\u{f48a}" } else { "\u{1F4D6}" },  // book / 📖
-            "LICENSE" | "LICENSE.md" | "LICENSE.txt" => if use_nerd_fonts { "\u{f0219}" } else { "\u{1F4DC}" },  // certificate / 📜
-            "CHANGELOG.md" | "CHANGELOG" => if use_nerd_fonts { "\u{f543}" } else { "\u{1F4CB}" },  // list / 📋
+            "README.md" | "README" | "readme.md" => {
+                if use_nerd_fonts {
+                    "\u{f48a}"
+                } else {
+                    "\u{1F4D6}"
+                }
+            } // book / 📖
+            "LICENSE" | "LICENSE.md" | "LICENSE.txt" => {
+                if use_nerd_fonts {
+                    "\u{f0219}"
+                } else {
+                    "\u{1F4DC}"
+                }
+            } // certificate / 📜
+            "CHANGELOG.md" | "CHANGELOG" => {
+                if use_nerd_fonts {
+                    "\u{f543}"
+                } else {
+                    "\u{1F4CB}"
+                }
+            } // list / 📋
 
             // Environment
-            ".env" | ".env.local" | ".env.development" | ".env.production" => if use_nerd_fonts { "\u{f023}" } else { "\u{1F510}" },  // lock / 🔐
+            ".env" | ".env.local" | ".env.development" | ".env.production" => {
+                if use_nerd_fonts {
+                    "\u{f023}"
+                } else {
+                    "\u{1F510}"
+                }
+            } // lock / 🔐
 
             _ => {
                 // Fall back to extension matching
@@ -638,74 +736,326 @@ pub fn get_file_icon(name: &str, is_dir: bool, is_expanded: bool, use_nerd_fonts
 
                 match ext {
                     // Rust
-                    "rs" => if use_nerd_fonts { "\u{e7a8}" } else { "\u{1F980}" },  // rust / 🦀
+                    "rs" => {
+                        if use_nerd_fonts {
+                            "\u{e7a8}"
+                        } else {
+                            "\u{1F980}"
+                        }
+                    } // rust / 🦀
 
                     // JavaScript/TypeScript
-                    "js" | "mjs" | "cjs" => if use_nerd_fonts { "\u{e74e}" } else { "\u{1F4DC}" },  // js / 📜
-                    "jsx" => if use_nerd_fonts { "\u{e7ba}" } else { "\u{269B}" },  // react / ⚛
-                    "ts" | "mts" | "cts" => if use_nerd_fonts { "\u{e628}" } else { "\u{1F4DC}" },  // ts / 📜
-                    "tsx" => if use_nerd_fonts { "\u{e7ba}" } else { "\u{269B}" },  // react / ⚛
+                    "js" | "mjs" | "cjs" => {
+                        if use_nerd_fonts {
+                            "\u{e74e}"
+                        } else {
+                            "\u{1F4DC}"
+                        }
+                    } // js / 📜
+                    "jsx" => {
+                        if use_nerd_fonts {
+                            "\u{e7ba}"
+                        } else {
+                            "\u{269B}"
+                        }
+                    } // react / ⚛
+                    "ts" | "mts" | "cts" => {
+                        if use_nerd_fonts {
+                            "\u{e628}"
+                        } else {
+                            "\u{1F4DC}"
+                        }
+                    } // ts / 📜
+                    "tsx" => {
+                        if use_nerd_fonts {
+                            "\u{e7ba}"
+                        } else {
+                            "\u{269B}"
+                        }
+                    } // react / ⚛
 
                     // Web
-                    "html" | "htm" => if use_nerd_fonts { "\u{e736}" } else { "\u{1F310}" },  // html5 / 🌐
-                    "css" => if use_nerd_fonts { "\u{e749}" } else { "\u{1F3A8}" },  // css3 / 🎨
-                    "scss" | "sass" | "less" => if use_nerd_fonts { "\u{e603}" } else { "\u{1F3A8}" },  // sass / 🎨
-                    "vue" => if use_nerd_fonts { "\u{e6a0}" } else { "\u{1F7E2}" },  // vue / 🟢
-                    "svelte" => if use_nerd_fonts { "\u{e697}" } else { "\u{1F525}" },  // svelte / 🔥
+                    "html" | "htm" => {
+                        if use_nerd_fonts {
+                            "\u{e736}"
+                        } else {
+                            "\u{1F310}"
+                        }
+                    } // html5 / 🌐
+                    "css" => {
+                        if use_nerd_fonts {
+                            "\u{e749}"
+                        } else {
+                            "\u{1F3A8}"
+                        }
+                    } // css3 / 🎨
+                    "scss" | "sass" | "less" => {
+                        if use_nerd_fonts {
+                            "\u{e603}"
+                        } else {
+                            "\u{1F3A8}"
+                        }
+                    } // sass / 🎨
+                    "vue" => {
+                        if use_nerd_fonts {
+                            "\u{e6a0}"
+                        } else {
+                            "\u{1F7E2}"
+                        }
+                    } // vue / 🟢
+                    "svelte" => {
+                        if use_nerd_fonts {
+                            "\u{e697}"
+                        } else {
+                            "\u{1F525}"
+                        }
+                    } // svelte / 🔥
 
                     // Data/Config
-                    "json" | "jsonc" => if use_nerd_fonts { "\u{e60b}" } else { "\u{1F4CB}" },  // json / 📋
-                    "toml" => if use_nerd_fonts { "\u{e6b2}" } else { "\u{2699}" },  // settings / ⚙
-                    "yaml" | "yml" => if use_nerd_fonts { "\u{e6a8}" } else { "\u{2699}" },  // yaml / ⚙
-                    "xml" => if use_nerd_fonts { "\u{e619}" } else { "\u{1F4CB}" },  // code / 📋
-                    "csv" => if use_nerd_fonts { "\u{f0ce}" } else { "\u{1F4CA}" },  // table / 📊
+                    "json" | "jsonc" => {
+                        if use_nerd_fonts {
+                            "\u{e60b}"
+                        } else {
+                            "\u{1F4CB}"
+                        }
+                    } // json / 📋
+                    "toml" => {
+                        if use_nerd_fonts {
+                            "\u{e6b2}"
+                        } else {
+                            "\u{2699}"
+                        }
+                    } // settings / ⚙
+                    "yaml" | "yml" => {
+                        if use_nerd_fonts {
+                            "\u{e6a8}"
+                        } else {
+                            "\u{2699}"
+                        }
+                    } // yaml / ⚙
+                    "xml" => {
+                        if use_nerd_fonts {
+                            "\u{e619}"
+                        } else {
+                            "\u{1F4CB}"
+                        }
+                    } // code / 📋
+                    "csv" => {
+                        if use_nerd_fonts {
+                            "\u{f0ce}"
+                        } else {
+                            "\u{1F4CA}"
+                        }
+                    } // table / 📊
 
                     // Documentation
-                    "md" | "markdown" => if use_nerd_fonts { "\u{e73e}" } else { "\u{1F4DD}" },  // markdown / 📝
-                    "txt" => if use_nerd_fonts { "\u{f15c}" } else { "\u{1F4C4}" },  // file-text / 📄
-                    "pdf" => if use_nerd_fonts { "\u{f1c1}" } else { "\u{1F4D5}" },  // file-pdf / 📕
+                    "md" | "markdown" => {
+                        if use_nerd_fonts {
+                            "\u{e73e}"
+                        } else {
+                            "\u{1F4DD}"
+                        }
+                    } // markdown / 📝
+                    "txt" => {
+                        if use_nerd_fonts {
+                            "\u{f15c}"
+                        } else {
+                            "\u{1F4C4}"
+                        }
+                    } // file-text / 📄
+                    "pdf" => {
+                        if use_nerd_fonts {
+                            "\u{f1c1}"
+                        } else {
+                            "\u{1F4D5}"
+                        }
+                    } // file-pdf / 📕
 
                     // Programming languages
-                    "py" | "pyi" => if use_nerd_fonts { "\u{e73c}" } else { "\u{1F40D}" },  // python / 🐍
-                    "go" => if use_nerd_fonts { "\u{e626}" } else { "\u{1F535}" },  // go / 🔵
-                    "rb" => if use_nerd_fonts { "\u{e791}" } else { "\u{1F48E}" },  // ruby / 💎
-                    "php" => if use_nerd_fonts { "\u{e73d}" } else { "\u{1F418}" },  // php / 🐘
-                    "java" => if use_nerd_fonts { "\u{e738}" } else { "\u{2615}" },  // java / ☕
-                    "kt" | "kts" => if use_nerd_fonts { "\u{e634}" } else { "\u{1F7E3}" },  // kotlin / 🟣
-                    "swift" => if use_nerd_fonts { "\u{e755}" } else { "\u{1F34E}" },  // swift / 🍎
-                    "c" => if use_nerd_fonts { "\u{e61e}" } else { "\u{00A9}" },  // c / ©
-                    "cpp" | "cc" | "cxx" => if use_nerd_fonts { "\u{e61d}" } else { "\u{00A9}" },  // c++ / ©
-                    "h" | "hpp" => if use_nerd_fonts { "\u{e61e}" } else { "\u{00A9}" },  // c / ©
-                    "cs" => if use_nerd_fonts { "\u{f031b}" } else { "#" },  // c# / #
-                    "lua" => if use_nerd_fonts { "\u{e620}" } else { "\u{1F319}" },  // lua / 🌙
-                    "zig" => if use_nerd_fonts { "\u{e6a9}" } else { "\u{26A1}" },  // zig / ⚡
+                    "py" | "pyi" => {
+                        if use_nerd_fonts {
+                            "\u{e73c}"
+                        } else {
+                            "\u{1F40D}"
+                        }
+                    } // python / 🐍
+                    "go" => {
+                        if use_nerd_fonts {
+                            "\u{e626}"
+                        } else {
+                            "\u{1F535}"
+                        }
+                    } // go / 🔵
+                    "rb" => {
+                        if use_nerd_fonts {
+                            "\u{e791}"
+                        } else {
+                            "\u{1F48E}"
+                        }
+                    } // ruby / 💎
+                    "php" => {
+                        if use_nerd_fonts {
+                            "\u{e73d}"
+                        } else {
+                            "\u{1F418}"
+                        }
+                    } // php / 🐘
+                    "java" => {
+                        if use_nerd_fonts {
+                            "\u{e738}"
+                        } else {
+                            "\u{2615}"
+                        }
+                    } // java / ☕
+                    "kt" | "kts" => {
+                        if use_nerd_fonts {
+                            "\u{e634}"
+                        } else {
+                            "\u{1F7E3}"
+                        }
+                    } // kotlin / 🟣
+                    "swift" => {
+                        if use_nerd_fonts {
+                            "\u{e755}"
+                        } else {
+                            "\u{1F34E}"
+                        }
+                    } // swift / 🍎
+                    "c" => {
+                        if use_nerd_fonts {
+                            "\u{e61e}"
+                        } else {
+                            "\u{00A9}"
+                        }
+                    } // c / ©
+                    "cpp" | "cc" | "cxx" => {
+                        if use_nerd_fonts {
+                            "\u{e61d}"
+                        } else {
+                            "\u{00A9}"
+                        }
+                    } // c++ / ©
+                    "h" | "hpp" => {
+                        if use_nerd_fonts {
+                            "\u{e61e}"
+                        } else {
+                            "\u{00A9}"
+                        }
+                    } // c / ©
+                    "cs" => {
+                        if use_nerd_fonts {
+                            "\u{f031b}"
+                        } else {
+                            "#"
+                        }
+                    } // c# / #
+                    "lua" => {
+                        if use_nerd_fonts {
+                            "\u{e620}"
+                        } else {
+                            "\u{1F319}"
+                        }
+                    } // lua / 🌙
+                    "zig" => {
+                        if use_nerd_fonts {
+                            "\u{e6a9}"
+                        } else {
+                            "\u{26A1}"
+                        }
+                    } // zig / ⚡
 
                     // Shell/Scripts
-                    "sh" | "bash" | "zsh" | "fish" => if use_nerd_fonts { "\u{f489}" } else { "\u{1F5A5}" },  // terminal / 🖥
-                    "ps1" | "psm1" => if use_nerd_fonts { "\u{e683}" } else { "\u{1F5A5}" },  // powershell / 🖥
+                    "sh" | "bash" | "zsh" | "fish" => {
+                        if use_nerd_fonts {
+                            "\u{f489}"
+                        } else {
+                            "\u{1F5A5}"
+                        }
+                    } // terminal / 🖥
+                    "ps1" | "psm1" => {
+                        if use_nerd_fonts {
+                            "\u{e683}"
+                        } else {
+                            "\u{1F5A5}"
+                        }
+                    } // powershell / 🖥
 
                     // Build/Lock files
-                    "lock" => if use_nerd_fonts { "\u{f023}" } else { "\u{1F512}" },  // lock / 🔒
+                    "lock" => {
+                        if use_nerd_fonts {
+                            "\u{f023}"
+                        } else {
+                            "\u{1F512}"
+                        }
+                    } // lock / 🔒
 
                     // Images
-                    "png" | "jpg" | "jpeg" | "gif" | "bmp" | "ico" | "webp" => if use_nerd_fonts { "\u{f1c5}" } else { "\u{1F5BC}" },  // file-image / 🖼
-                    "svg" => if use_nerd_fonts { "\u{f1c5}" } else { "\u{1F5BC}" },  // file-image / 🖼
+                    "png" | "jpg" | "jpeg" | "gif" | "bmp" | "ico" | "webp" => {
+                        if use_nerd_fonts {
+                            "\u{f1c5}"
+                        } else {
+                            "\u{1F5BC}"
+                        }
+                    } // file-image / 🖼
+                    "svg" => {
+                        if use_nerd_fonts {
+                            "\u{f1c5}"
+                        } else {
+                            "\u{1F5BC}"
+                        }
+                    } // file-image / 🖼
 
                     // Archives
-                    "zip" | "tar" | "gz" | "bz2" | "xz" | "7z" | "rar" => if use_nerd_fonts { "\u{f1c6}" } else { "\u{1F4E6}" },  // file-archive / 📦
+                    "zip" | "tar" | "gz" | "bz2" | "xz" | "7z" | "rar" => {
+                        if use_nerd_fonts {
+                            "\u{f1c6}"
+                        } else {
+                            "\u{1F4E6}"
+                        }
+                    } // file-archive / 📦
 
                     // Binary/Executable
-                    "exe" | "dll" | "so" | "dylib" => if use_nerd_fonts { "\u{f013}" } else { "\u{2699}" },  // gear / ⚙
-                    "wasm" => if use_nerd_fonts { "\u{e6a1}" } else { "\u{1F527}" },  // wasm / 🔧
+                    "exe" | "dll" | "so" | "dylib" => {
+                        if use_nerd_fonts {
+                            "\u{f013}"
+                        } else {
+                            "\u{2699}"
+                        }
+                    } // gear / ⚙
+                    "wasm" => {
+                        if use_nerd_fonts {
+                            "\u{e6a1}"
+                        } else {
+                            "\u{1F527}"
+                        }
+                    } // wasm / 🔧
 
                     // Fonts
-                    "ttf" | "otf" | "woff" | "woff2" => if use_nerd_fonts { "\u{f031}" } else { "\u{1F524}" },  // font / 🔤
+                    "ttf" | "otf" | "woff" | "woff2" => {
+                        if use_nerd_fonts {
+                            "\u{f031}"
+                        } else {
+                            "\u{1F524}"
+                        }
+                    } // font / 🔤
 
                     // Git
-                    "git" => if use_nerd_fonts { "\u{f1d3}" } else { "\u{E0A0}" },  // git / branch
+                    "git" => {
+                        if use_nerd_fonts {
+                            "\u{f1d3}"
+                        } else {
+                            "\u{E0A0}"
+                        }
+                    } // git / branch
 
                     // Default
-                    _ => if use_nerd_fonts { "\u{f15b}" } else { "\u{1F4C4}" },  // file / 📄
+                    _ => {
+                        if use_nerd_fonts {
+                            "\u{f15b}"
+                        } else {
+                            "\u{1F4C4}"
+                        }
+                    } // file / 📄
                 }
             }
         };
@@ -765,7 +1115,10 @@ impl FileExplorer {
             if node.is_dir {
                 node.path.clone()
             } else {
-                node.path.parent().map(|p| p.to_path_buf()).unwrap_or_default()
+                node.path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_default()
             }
         })
     }
@@ -874,7 +1227,9 @@ impl FileExplorer {
                 ClipboardOp::Copy => "Copy",
                 ClipboardOp::Cut => "Cut",
             };
-            let name = cb.path.file_name()
+            let name = cb
+                .path
+                .file_name()
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_else(|| cb.path.to_string_lossy().to_string());
             format!("{}: {}", op, name)

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -313,14 +313,20 @@ vim_default = true
             .iter()
             .filter(|item| item.display.contains(":GitChanges"))
             .count();
-        assert_eq!(gitchanges, 1, "exactly one :GitChanges row, from the registry");
+        assert_eq!(
+            gitchanges, 1,
+            "exactly one :GitChanges row, from the registry"
+        );
         // FindFiles is in both the registry and the (now-excluded) TOML commands
         // section — it must appear exactly once, proving no duplication.
         let findfiles = items
             .iter()
             .filter(|item| item.display.contains(":FindFiles"))
             .count();
-        assert_eq!(findfiles, 1, ":FindFiles should appear once (registry only)");
+        assert_eq!(
+            findfiles, 1,
+            ":FindFiles should appear once (registry only)"
+        );
     }
 
     #[test]
@@ -347,7 +353,9 @@ vim_default = true
         }];
         let items = keymap_finder_items(&keymap);
         assert!(
-            items.iter().any(|item| item.display.contains("remapped to ^")),
+            items
+                .iter()
+                .any(|item| item.display.contains("remapped to ^")),
             "the user's H -> ^ remap should appear in the cheatsheet"
         );
     }
@@ -364,6 +372,17 @@ vim_default = true
     }
 
     #[test]
+    fn picker_includes_leader_popup_trigger() {
+        let items = keymap_finder_items(&KeymapSettings::default());
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("<leader>") && item.display.contains("Show leader key popup")
+            }),
+            "leader popup trigger should appear in :Keymaps"
+        );
+    }
+
+    #[test]
     fn leader_rows_get_leader_prefix() {
         let entries = parse_keybinds(SAMPLE);
         let ff = entries.iter().find(|e| e.key == "ff").unwrap();
@@ -374,8 +393,15 @@ vim_default = true
     #[test]
     fn embedded_file_parses_and_is_fully_described() {
         let entries = load_keybinds();
-        assert!(entries.len() > 250, "expected a substantial keymap, got {}", entries.len());
-        assert!(entries.iter().all(|e| !e.desc.is_empty()), "every entry needs a description");
+        assert!(
+            entries.len() > 250,
+            "expected a substantial keymap, got {}",
+            entries.len()
+        );
+        assert!(
+            entries.iter().all(|e| !e.desc.is_empty()),
+            "every entry needs a description"
+        );
         assert!(entries.iter().any(|e| e.status == "implemented"));
     }
 }

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -37,6 +37,17 @@
 # ============================================================================
 
 # ----------------------------------------------------------------------------
+# Help / discoverability
+# ----------------------------------------------------------------------------
+
+[[normal.help]]
+key = "<leader>"
+action = "show_leader_popup"
+desc = "Show leader key popup"
+status = "implemented"
+vim_default = false
+
+# ----------------------------------------------------------------------------
 # Movement - Basic cursor movement
 # ----------------------------------------------------------------------------
 
@@ -187,8 +198,6 @@ desc = "Move to bottom of screen"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.movement]]
 key = "ge"
 action = "word_end_backward"
@@ -207,63 +216,63 @@ vim_default = true
 key = "("
 action = "sentence_backward"
 desc = "Move to previous sentence"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = ")"
 action = "sentence_forward"
 desc = "Move to next sentence"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "+"
 action = "next_line_first_non_blank"
 desc = "Move to first non-blank of next line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "-"
 action = "prev_line_first_non_blank"
 desc = "Move to first non-blank of previous line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "gj"
 action = "display_line_down"
 desc = "Move down by display line (for wrapped lines)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "gk"
 action = "display_line_up"
 desc = "Move up by display line (for wrapped lines)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "g0"
 action = "display_line_start"
 desc = "Move to start of display line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "g$"
 action = "display_line_end"
 desc = "Move to end of display line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.movement]]
 key = "g^"
 action = "display_line_first_non_blank"
 desc = "Move to first non-blank of display line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ----------------------------------------------------------------------------
@@ -383,48 +392,46 @@ desc = "Jump to newer position in jump list"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.jumps]]
 key = "''"
 action = "jump_to_previous_position"
-desc = "Jump to position before last jump"
-status = "planned"
+desc = "Jump to line before last jump"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
 key = "``"
 action = "jump_to_previous_position_exact"
 desc = "Jump to exact position before last jump"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
 key = "'."
 action = "jump_to_last_change"
 desc = "Jump to line of last change"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
 key = "`."
 action = "jump_to_last_change_exact"
 desc = "Jump to exact position of last change"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
 key = "'^"
 action = "jump_to_last_insert"
 desc = "Jump to line of last insert"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
 key = "`^"
 action = "jump_to_last_insert_exact"
 desc = "Jump to exact position of last insert"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.jumps]]
@@ -564,20 +571,18 @@ desc = "Redo last undone change"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.editing]]
 key = "gp"
 action = "paste_after_move"
 desc = "Paste after and move cursor after text"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.editing]]
 key = "gP"
 action = "paste_before_move"
 desc = "Paste before and move cursor after text"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.editing]]
@@ -619,20 +624,18 @@ desc = "Dedent with motion"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.indent]]
 key = "={motion}"
 action = "auto_indent"
 desc = "Auto-indent with motion"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.indent]]
 key = "=="
 action = "auto_indent_line"
 desc = "Auto-indent current line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ----------------------------------------------------------------------------
@@ -734,13 +737,6 @@ desc = "Jump to exact position of global mark"
 status = "implemented"
 vim_default = true
 
-[[normal.marks]]
-key = "''"
-action = "jump_previous_position"
-desc = "Jump to position before last jump (toggles)"
-status = "implemented"
-vim_default = true
-
 # ----------------------------------------------------------------------------
 # Macros
 # ----------------------------------------------------------------------------
@@ -819,20 +815,18 @@ desc = "Search word under cursor backward"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.search]]
 key = "gn"
 action = "search_and_select"
 desc = "Search forward and select match"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.search]]
 key = "gN"
 action = "search_and_select_backward"
 desc = "Search backward and select match"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ----------------------------------------------------------------------------
@@ -870,6 +864,22 @@ status = "implemented"
 vim_default = false
 
 [[normal.lsp]]
+key = "gD"
+action = "goto_declaration"
+desc = "Go to declaration"
+status = "implemented"
+vim_default = false
+note = "LSP feature, common neovim mapping"
+
+[[normal.lsp]]
+key = "gI"
+action = "goto_implementation"
+desc = "Go to implementation"
+status = "implemented"
+vim_default = false
+note = "Using gI to avoid conflict with vim's gi"
+
+[[normal.lsp]]
 key = "]d"
 action = "next_diagnostic"
 desc = "Go to next diagnostic"
@@ -882,23 +892,6 @@ action = "prev_diagnostic"
 desc = "Go to previous diagnostic"
 status = "implemented"
 vim_default = false
-
-# --- NOT IMPLEMENTED YET ---
-
-[[normal.lsp]]
-key = "gD"
-action = "goto_declaration"
-desc = "Go to declaration"
-status = "planned"
-vim_default = false
-
-[[normal.lsp]]
-key = "gI"
-action = "goto_implementation"
-desc = "Go to implementation"
-status = "planned"
-vim_default = false
-note = "Using gI to avoid conflict with vim's gi"
 
 # ----------------------------------------------------------------------------
 # Surround (vim-surround style) - ALL IMPLEMENTED
@@ -954,14 +947,14 @@ vim_default = false
 key = "gf"
 action = "goto_file"
 desc = "Go to file under cursor"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.g_commands]]
 key = "gx"
 action = "open_url"
 desc = "Open URL under cursor"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.g_commands]]
@@ -1180,34 +1173,32 @@ desc = "Move to window on right"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[normal.window]]
 key = "<C-w>="
 action = "equalize_windows"
 desc = "Make all windows equal size"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.window]]
 key = "<C-w>r"
 action = "rotate_windows"
 desc = "Rotate windows down/right"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.window]]
 key = "<C-w>R"
 action = "rotate_windows_reverse"
 desc = "Rotate windows up/left"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[normal.window]]
 key = "<C-w>x"
 action = "exchange_window"
 desc = "Exchange current window with next"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ============================================================================
@@ -1250,8 +1241,6 @@ desc = "Insert tab/spaces"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[insert.editing]]
 key = "<C-w>"
 action = "delete_word_before"
@@ -1267,38 +1256,38 @@ status = "implemented"
 vim_default = true
 
 [[insert.editing]]
-key = "<C-o>"
-action = "insert_normal_once"
-desc = "Execute one normal mode command"
-status = "planned"
-vim_default = true
-
-[[insert.editing]]
-key = "<C-r>{reg}"
-action = "insert_register"
-desc = "Insert contents of register"
-status = "planned"
-vim_default = true
-
-[[insert.editing]]
 key = "<C-t>"
 action = "indent_line"
 desc = "Increase indent of current line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[insert.editing]]
 key = "<C-d>"
 action = "dedent_line"
 desc = "Decrease indent of current line"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[insert.editing]]
 key = "<C-a>"
 action = "insert_last_inserted"
 desc = "Insert previously inserted text"
-status = "planned"
+status = "implemented"
+vim_default = true
+
+[[insert.editing]]
+key = "<C-r>{reg}"
+action = "insert_register"
+desc = "Insert contents of register"
+status = "implemented"
+vim_default = true
+
+[[insert.editing]]
+key = "<C-o>"
+action = "insert_normal_once"
+desc = "Execute one normal mode command"
+status = "implemented"
 vim_default = true
 
 # ----------------------------------------------------------------------------
@@ -1401,13 +1390,11 @@ desc = "Surround selection with pair"
 status = "implemented"
 vim_default = false
 
-# --- NOT IMPLEMENTED YET ---
-
 [[visual.editing]]
 key = "O"
 action = "swap_selection_corner"
 desc = "Go to other corner (block mode)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ============================================================================
@@ -1652,14 +1639,14 @@ note = "Only in finder normal mode"
 key = "<C-d>"
 action = "scroll_preview_down"
 desc = "Scroll preview down"
-status = "planned"
+status = "implemented"
 vim_default = false
 
 [[finder.preview]]
 key = "<C-u>"
 action = "scroll_preview_up"
 desc = "Scroll preview up"
-status = "planned"
+status = "implemented"
 vim_default = false
 
 # ============================================================================
@@ -1821,48 +1808,46 @@ desc = "Around angle brackets"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[text_objects]]
 key = "ip"
 action = "inner_paragraph"
 desc = "Inner paragraph"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[text_objects]]
 key = "ap"
 action = "around_paragraph"
 desc = "Around paragraph"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[text_objects]]
 key = "is"
 action = "inner_sentence"
 desc = "Inner sentence"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[text_objects]]
 key = "as"
 action = "around_sentence"
 desc = "Around sentence"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[text_objects]]
 key = "it"
 action = "inner_tag"
 desc = "Inner HTML/XML tag"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[text_objects]]
 key = "at"
 action = "around_tag"
 desc = "Around HTML/XML tag"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ============================================================================
@@ -1911,35 +1896,35 @@ desc = "Use last yank register"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[registers]]
 key = "\"."
 action = "last_inserted_text"
 desc = "Last inserted text (read-only)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[registers]]
 key = "\"%"
 action = "current_filename"
 desc = "Current filename (read-only)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[registers]]
 key = "\":"
 action = "last_command"
 desc = "Last command (read-only)"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 [[registers]]
 key = "\"#"
 action = "alternate_file"
 desc = "Alternate file name (read-only)"
-status = "planned"
+status = "implemented"
 vim_default = true
+
+# --- NOT IMPLEMENTED YET ---
 
 [[registers]]
 key = "\"="
@@ -2068,8 +2053,15 @@ vim_default = true
 [[commands.buffer]]
 key = ":bd"
 action = "buffer_delete"
-desc = "Delete (close) buffer (not wired to the command parser yet)"
-status = "planned"
+desc = "Close current buffer (fails if unsaved)"
+status = "implemented"
+vim_default = true
+
+[[commands.buffer]]
+key = ":bd!"
+action = "buffer_delete_force"
+desc = "Force close current buffer"
+status = "implemented"
 vim_default = true
 
 # ----------------------------------------------------------------------------

--- a/src/finder/matcher.rs
+++ b/src/finder/matcher.rs
@@ -1,5 +1,5 @@
-use nucleo::Matcher;
 use nucleo::pattern::{CaseMatching, Normalization, Pattern};
+use nucleo::Matcher;
 use nucleo::Utf32Str;
 
 /// Fuzzy matcher wrapper using nucleo

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -1,12 +1,12 @@
 mod file_picker;
 mod grep;
-mod matcher;
 mod keybinds;
+mod matcher;
 
 pub use file_picker::FilePicker;
 pub use grep::GrepSearcher;
-pub use matcher::FuzzyMatcher;
 pub use keybinds::keymap_finder_items;
+pub use matcher::FuzzyMatcher;
 
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -761,12 +761,8 @@ impl FuzzyFinder {
                                 (0, item.display.as_str())
                             };
                             matcher.match_score(&query, match_text).map(|score| {
-                                let indices = offset_match_indices(
-                                    matcher,
-                                    &query,
-                                    match_text,
-                                    match_start,
-                                );
+                                let indices =
+                                    offset_match_indices(matcher, &query, match_text, match_start);
                                 (idx, score, indices)
                             })
                         })
@@ -1178,14 +1174,23 @@ mod tests {
     fn open_keymaps_sets_mode_and_loads_items() {
         let mut finder = FuzzyFinder::new();
         finder.open_keymaps(vec![
-            FinderItem::new("n       h                  Move cursor left".to_string(), PathBuf::new()),
-            FinderItem::new("leader  <leader>ff         Find files".to_string(), PathBuf::new()),
+            FinderItem::new(
+                "n       h                  Move cursor left".to_string(),
+                PathBuf::new(),
+            ),
+            FinderItem::new(
+                "leader  <leader>ff         Find files".to_string(),
+                PathBuf::new(),
+            ),
         ]);
 
         assert_eq!(finder.mode, FinderMode::Keymaps);
         assert_eq!(finder.items.len(), 2);
         assert!(finder.populated);
-        assert!(!finder.mode_supports_preview(), "keymaps mode has no preview pane");
+        assert!(
+            !finder.mode_supports_preview(),
+            "keymaps mode has no preview pane"
+        );
     }
 
     #[test]
@@ -1193,7 +1198,11 @@ mod tests {
         let items = crate::finder::keymap_finder_items(&crate::config::KeymapSettings::default());
         assert!(!items.is_empty(), "expected some implemented keybindings");
         for item in &items {
-            assert_eq!(item.path, std::path::PathBuf::new(), "keymap items must have no path");
+            assert_eq!(
+                item.path,
+                std::path::PathBuf::new(),
+                "keymap items must have no path"
+            );
             assert!(item.buffer_idx.is_none());
             assert!(item.terminal_session_position.is_none());
             assert!(item.git_status.is_none());
@@ -1244,13 +1253,11 @@ mod tests {
     #[test]
     fn git_changes_finder_highlights_path_matches_in_display_text() {
         let mut finder = FuzzyFinder::new();
-        finder.open_git_changes(vec![
-            FinderItem::new(
-                "M src/lib/types.ts".to_string(),
-                PathBuf::from("/repo/src/lib/types.ts"),
-            )
-            .with_git_status(crate::git::GitFileStatus::Modified),
-        ]);
+        finder.open_git_changes(vec![FinderItem::new(
+            "M src/lib/types.ts".to_string(),
+            PathBuf::from("/repo/src/lib/types.ts"),
+        )
+        .with_git_status(crate::git::GitFileStatus::Modified)]);
 
         for ch in "type".chars() {
             finder.insert_char(ch);

--- a/src/formatter/mod.rs
+++ b/src/formatter/mod.rs
@@ -19,7 +19,10 @@ pub enum FormatterError {
     /// Formatter command not found
     CommandNotFound(String),
     /// Formatter process failed with non-zero exit code
-    CommandFailed { stderr: String, exit_code: Option<i32> },
+    CommandFailed {
+        stderr: String,
+        exit_code: Option<i32>,
+    },
     /// Formatter output was not valid UTF-8
     InvalidUtf8,
     /// Formatter timed out
@@ -42,7 +45,9 @@ impl std::fmt::Display for FormatterError {
             }
             FormatterError::InvalidUtf8 => write!(f, "Formatter output was not valid UTF-8"),
             FormatterError::Timeout => write!(f, "Formatter timed out"),
-            FormatterError::StdinWriteFailed(e) => write!(f, "Failed to send content to formatter: {}", e),
+            FormatterError::StdinWriteFailed(e) => {
+                write!(f, "Failed to send content to formatter: {}", e)
+            }
         }
     }
 }

--- a/src/frecency/mod.rs
+++ b/src/frecency/mod.rs
@@ -65,10 +65,13 @@ impl FrecencyDb {
             .map(|d| d.as_secs())
             .unwrap_or(0);
 
-        let entry = self.entries.entry(label.to_string()).or_insert(FrecencyEntry {
-            count: 0,
-            last_used: now,
-        });
+        let entry = self
+            .entries
+            .entry(label.to_string())
+            .or_insert(FrecencyEntry {
+                count: 0,
+                last_used: now,
+            });
         entry.count += 1;
         entry.last_used = now;
     }
@@ -122,9 +125,8 @@ impl FrecencyDb {
             .unwrap_or(0);
 
         let max_age_secs = max_age_days * 24 * 60 * 60;
-        self.entries.retain(|_, entry| {
-            now.saturating_sub(entry.last_used) < max_age_secs
-        });
+        self.entries
+            .retain(|_, entry| now.saturating_sub(entry.last_used) < max_age_secs);
     }
 }
 

--- a/src/harpoon.rs
+++ b/src/harpoon.rs
@@ -46,7 +46,9 @@ impl Harpoon {
 
     /// Get the harpoon data file path
     fn data_file_path(&self) -> Option<PathBuf> {
-        self.project_root.as_ref().map(|root| root.join(".nevi").join("harpoon.json"))
+        self.project_root
+            .as_ref()
+            .map(|root| root.join(".nevi").join("harpoon.json"))
     }
 
     /// Load harpoon data from disk
@@ -62,9 +64,7 @@ impl Harpoon {
         match std::fs::read_to_string(&path) {
             Ok(content) => {
                 if let Ok(data) = serde_json::from_str::<HarpoonData>(&content) {
-                    self.files = data.files.into_iter()
-                        .map(PathBuf::from)
-                        .collect();
+                    self.files = data.files.into_iter().map(PathBuf::from).collect();
                 }
             }
             Err(_) => {}
@@ -83,7 +83,9 @@ impl Harpoon {
         }
 
         let data = HarpoonData {
-            files: self.files.iter()
+            files: self
+                .files
+                .iter()
                 .map(|p| p.to_string_lossy().to_string())
                 .collect(),
         };

--- a/src/indent/mod.rs
+++ b/src/indent/mod.rs
@@ -34,19 +34,17 @@ const INDENT_NODES: &[&str] = &[
     "switch_case",
     "switch_default",
     "parenthesized_expression",
-
     // === CSS/SCSS ===
-    "block",              // selector { ... }
-    "declaration_list",   // same as block in some grammars
+    "block",            // selector { ... }
+    "declaration_list", // same as block in some grammars
     "media_statement",
     "keyframe_block_list",
     "feature_query",
-
     // === JSON ===
     // "object" and "array" already included above
 
     // === TOML ===
-    "inline_table",       // { key = value }
+    "inline_table", // { key = value }
     // "array" already included above
 
     // === HTML ===
@@ -65,12 +63,7 @@ const INDENT_NODES: &[&str] = &[
 ///
 /// # Returns
 /// The number of spaces to indent the new line
-pub fn calculate_indent(
-    tree: &Tree,
-    source: &str,
-    cursor_byte: usize,
-    tab_width: usize,
-) -> usize {
+pub fn calculate_indent(tree: &Tree, source: &str, cursor_byte: usize, tab_width: usize) -> usize {
     // Get the base indent from the current line
     let line_indent = get_line_indent_at_byte(source, cursor_byte);
     let base_level = line_indent / tab_width;
@@ -147,9 +140,18 @@ pub fn calculate_closing_bracket_indent(
     // Walk up to find the matching container
     let mut current = Some(node);
     let container_kinds = match bracket {
-        '}' => vec!["statement_block", "class_body", "object", "object_pattern",
-                   "switch_body", "enum_body", "interface_body", "object_type",
-                   "named_imports", "export_clause"],
+        '}' => vec![
+            "statement_block",
+            "class_body",
+            "object",
+            "object_pattern",
+            "switch_body",
+            "enum_body",
+            "interface_body",
+            "object_type",
+            "named_imports",
+            "export_clause",
+        ],
         ']' => vec!["array", "array_pattern"],
         ')' => vec!["arguments", "formal_parameters", "parenthesized_expression"],
         _ => return None,
@@ -202,7 +204,9 @@ pub fn should_dedent_closing_bracket(
     let current_indent = line_before.len();
 
     // Get the expected indent for this closing bracket
-    if let Some(expected_indent) = calculate_closing_bracket_indent(tree, source, cursor_byte, bracket) {
+    if let Some(expected_indent) =
+        calculate_closing_bracket_indent(tree, source, cursor_byte, bracket)
+    {
         // Dedent if current indent is more than expected
         return current_indent > expected_indent;
     }
@@ -229,7 +233,9 @@ pub fn get_dedent_amount(
 
     let current_indent = line_before.len();
 
-    if let Some(expected_indent) = calculate_closing_bracket_indent(tree, source, cursor_byte, bracket) {
+    if let Some(expected_indent) =
+        calculate_closing_bracket_indent(tree, source, cursor_byte, bracket)
+    {
         if current_indent > expected_indent {
             return current_indent - expected_indent;
         }
@@ -290,10 +296,7 @@ fn get_line_before_cursor(source: &str, cursor_byte: usize) -> &str {
 /// Get the indentation (in spaces) at the start of the line containing the given byte
 fn get_line_indent_at_byte(source: &str, byte: usize) -> usize {
     // Find the start of the line
-    let line_start = source[..byte]
-        .rfind('\n')
-        .map(|pos| pos + 1)
-        .unwrap_or(0);
+    let line_start = source[..byte].rfind('\n').map(|pos| pos + 1).unwrap_or(0);
 
     // Count leading whitespace
     let line = &source[line_start..];
@@ -327,13 +330,17 @@ mod tests {
 
     fn parse_js(source: &str) -> Tree {
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_javascript::LANGUAGE.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_javascript::LANGUAGE.into())
+            .unwrap();
         parser.parse(source, None).unwrap()
     }
 
     fn parse_ts(source: &str) -> Tree {
         let mut parser = tree_sitter::Parser::new();
-        parser.set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()).unwrap();
+        parser
+            .set_language(&tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into())
+            .unwrap();
         parser.parse(source, None).unwrap()
     }
 
@@ -381,7 +388,13 @@ mod tests {
     fn test_closing_bracket_dedent() {
         let source = "function foo() {\n    return bar;\n    ";
         let tree = parse_js(source);
-        assert!(should_dedent_closing_bracket(&tree, source, source.len(), '}', 4));
+        assert!(should_dedent_closing_bracket(
+            &tree,
+            source,
+            source.len(),
+            '}',
+            4
+        ));
     }
 
     #[test]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -74,11 +74,12 @@ pub struct InputState {
 /// Operators that can be combined with motions
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Operator {
-    Delete, // d
-    Change, // c
-    Yank,   // y
-    Indent, // >
-    Dedent, // <
+    Delete,     // d
+    Change,     // c
+    Yank,       // y
+    Indent,     // >
+    Dedent,     // <
+    AutoIndent, // =
 }
 
 /// Case transformation operators
@@ -108,6 +109,9 @@ pub enum TextObjectType {
     Brace,        // { } B
     Bracket,      // [ ]
     AngleBracket, // < >
+    Paragraph,    // p
+    Sentence,     // s
+    Tag,          // t
 }
 
 /// A complete text object specification
@@ -160,6 +164,10 @@ pub enum KeyAction {
     PasteAfter(usize),
     /// Paste before cursor
     PasteBefore(usize),
+    /// Paste after cursor and leave cursor after pasted text
+    PasteAfterMove(usize),
+    /// Paste before cursor and leave cursor after pasted text
+    PasteBeforeMove(usize),
     /// Undo
     Undo,
     /// Redo
@@ -178,6 +186,10 @@ pub enum KeyAction {
     SearchWordForward,
     /// Search word under cursor backward (#)
     SearchWordBackward,
+    /// Search forward and select the match (gn)
+    SearchSelectNext(usize),
+    /// Search backward and select the match (gN)
+    SearchSelectPrev(usize),
     /// Enter visual mode
     EnterVisual,
     /// Enter visual line mode
@@ -201,8 +213,20 @@ pub enum KeyAction {
     WindowRight,
     WindowUp,
     WindowDown,
+    WindowEqualize,
+    WindowRotateDownRight,
+    WindowRotateUpLeft,
+    WindowExchangeNext,
     /// Go to definition (gd)
     GotoDefinition,
+    /// Go to declaration (gD)
+    GotoDeclaration,
+    /// Go to implementation (gI)
+    GotoImplementation,
+    /// Open file under cursor (gf)
+    GotoFile,
+    /// Open URL under cursor (gx)
+    OpenUrl,
     /// Show hover documentation (K)
     Hover,
     /// Jump back in jump list (Ctrl+o)
@@ -211,6 +235,16 @@ pub enum KeyAction {
     JumpForward,
     /// Jump to position before last jump ('')
     JumpToPreviousPosition,
+    /// Jump to exact position before last jump (``)
+    JumpToPreviousPositionExact,
+    /// Jump to line of last change ('.)
+    JumpToLastChange,
+    /// Jump to exact position of last change (`.)
+    JumpToLastChangeExact,
+    /// Jump to line of last insert ('^)
+    JumpToLastInsert,
+    /// Jump to exact position of last insert (`^)
+    JumpToLastInsertExact,
     /// Go to older change position (g;)
     ChangeListOlder,
     /// Go to newer change position (g,)
@@ -305,6 +339,33 @@ impl InputState {
         Self::default()
     }
 
+    /// Returns true when the input parser is waiting for more keys to finish a command.
+    pub fn has_pending_sequence(&self) -> bool {
+        self.count.is_some()
+            || self.pending_operator.is_some()
+            || self.partial_key.is_some()
+            || self.pending_text_object.is_some()
+            || self.pending_find_char.is_some()
+            || self.pending_register_select
+            || self.selected_register.is_some()
+            || self.pending_replace
+            || self.pending_window_cmd
+            || self.pending_surround_delete
+            || self.pending_surround_change.is_some()
+            || self.pending_surround_add
+            || self.surround_add_object.is_some()
+            || self.surround_add_motion.is_some()
+            || self.surround_add_line
+            || self.pending_visual_surround
+            || self.pending_comment
+            || self.pending_case_operator.is_some()
+            || self.pending_set_mark
+            || self.pending_goto_mark_line
+            || self.pending_goto_mark_exact
+            || self.pending_record_macro
+            || self.pending_play_macro
+    }
+
     /// Reset input state (preserves last_find_char for ; and , repeats)
     pub fn reset(&mut self) {
         self.count = None;
@@ -378,7 +439,7 @@ impl InputState {
         if self.pending_register_select {
             self.pending_register_select = false;
             if let KeyCode::Char(c) = key.code {
-                // Valid register names: a-z, A-Z, 0-9, ", -, +, *, _, /
+                // Valid register names: a-z, A-Z, 0-9, ", -, +, *, _, /, %, :, #, .
                 if c.is_ascii_alphabetic()
                     || c.is_ascii_digit()
                     || c == '"'
@@ -387,6 +448,10 @@ impl InputState {
                     || c == '*'
                     || c == '_'
                     || c == '/'
+                    || c == '%'
+                    || c == ':'
+                    || c == '#'
+                    || c == '.'
                 {
                     self.selected_register = Some(c);
                     return KeyAction::Pending;
@@ -590,6 +655,16 @@ impl InputState {
                     self.reset();
                     return KeyAction::JumpToPreviousPosition;
                 }
+                if c == '.' {
+                    // '. - jump to line of last change
+                    self.reset();
+                    return KeyAction::JumpToLastChange;
+                }
+                if c == '^' {
+                    // '^ - jump to line of last insert
+                    self.reset();
+                    return KeyAction::JumpToLastInsert;
+                }
                 if c.is_ascii_alphabetic() {
                     self.reset();
                     return KeyAction::GotoMarkLine(c);
@@ -601,6 +676,21 @@ impl InputState {
 
         if self.pending_goto_mark_exact {
             if let KeyCode::Char(c) = key.code {
+                if c == '`' {
+                    // `` - jump to exact position before last jump
+                    self.reset();
+                    return KeyAction::JumpToPreviousPositionExact;
+                }
+                if c == '.' {
+                    // `. - jump to exact position of last change
+                    self.reset();
+                    return KeyAction::JumpToLastChangeExact;
+                }
+                if c == '^' {
+                    // `^ - jump to exact position of last insert
+                    self.reset();
+                    return KeyAction::JumpToLastInsertExact;
+                }
                 if c.is_ascii_alphabetic() {
                     self.reset();
                     return KeyAction::GotoMarkExact(c);
@@ -745,6 +835,18 @@ impl InputState {
                     KeyAction::Pending
                 }
             }
+            // Auto-indent operator
+            (KeyModifiers::NONE, KeyCode::Char('=')) => {
+                if self.pending_operator == Some(Operator::AutoIndent) {
+                    // == - auto-indent line
+                    let final_count = self.combined_count();
+                    self.reset();
+                    KeyAction::OperatorLine(Operator::AutoIndent, final_count)
+                } else {
+                    self.set_operator(Operator::AutoIndent);
+                    KeyAction::Pending
+                }
+            }
 
             // Marks
             (KeyModifiers::NONE, KeyCode::Char('m')) => {
@@ -816,10 +918,20 @@ impl InputState {
             }
             (_, KeyCode::Char('^')) => self.motion_or_operator(Motion::FirstNonBlank, count),
             (_, KeyCode::Char('$')) => self.motion_or_operator(Motion::LineEnd, count),
+            (_, KeyCode::Char('+')) => {
+                self.motion_or_operator(Motion::NextLineFirstNonBlank, count)
+            }
+            (_, KeyCode::Char('-')) => {
+                self.motion_or_operator(Motion::PrevLineFirstNonBlank, count)
+            }
 
             // Paragraph motions
             (_, KeyCode::Char('}')) => self.motion_or_operator(Motion::ParagraphForward, count),
             (_, KeyCode::Char('{')) => self.motion_or_operator(Motion::ParagraphBackward, count),
+
+            // Sentence motions
+            (_, KeyCode::Char(')')) => self.motion_or_operator(Motion::SentenceForward, count),
+            (_, KeyCode::Char('(')) => self.motion_or_operator(Motion::SentenceBackward, count),
 
             // Bracket matching
             (_, KeyCode::Char('%')) => self.motion_or_operator(Motion::MatchingBracket, count),
@@ -1169,6 +1281,76 @@ impl InputState {
                 self.reset();
                 KeyAction::GotoDefinition
             }
+            // gD - go to declaration (LSP)
+            ('g', KeyModifiers::SHIFT, KeyCode::Char('D')) => {
+                self.reset();
+                KeyAction::GotoDeclaration
+            }
+            // gI - go to implementation (LSP)
+            ('g', KeyModifiers::SHIFT, KeyCode::Char('I')) => {
+                self.reset();
+                KeyAction::GotoImplementation
+            }
+            // gf - open file under cursor
+            ('g', KeyModifiers::NONE, KeyCode::Char('f')) => {
+                self.reset();
+                KeyAction::GotoFile
+            }
+            // gx - open URL under cursor
+            ('g', KeyModifiers::NONE, KeyCode::Char('x')) => {
+                self.reset();
+                KeyAction::OpenUrl
+            }
+            // gj - move down one display line
+            ('g', KeyModifiers::NONE, KeyCode::Char('j')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineDown, count);
+                self.reset();
+                action
+            }
+            // gk - move up one display line
+            ('g', KeyModifiers::NONE, KeyCode::Char('k')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineUp, count);
+                self.reset();
+                action
+            }
+            // g0 - move to start of current display line
+            ('g', KeyModifiers::NONE, KeyCode::Char('0')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineStart, count);
+                self.reset();
+                action
+            }
+            // g$ - move to end of current display line
+            ('g', KeyModifiers::NONE, KeyCode::Char('$')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineEnd, count);
+                self.reset();
+                action
+            }
+            // g^ - move to first non-blank of current display line
+            ('g', KeyModifiers::NONE, KeyCode::Char('^')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineFirstNonBlank, count);
+                self.reset();
+                action
+            }
+            // gn - search forward and select match
+            ('g', KeyModifiers::NONE, KeyCode::Char('n')) => {
+                self.reset();
+                KeyAction::SearchSelectNext(count)
+            }
+            // gN - search backward and select match
+            ('g', KeyModifiers::SHIFT, KeyCode::Char('N')) => {
+                self.reset();
+                KeyAction::SearchSelectPrev(count)
+            }
+            // gp - paste after and leave cursor after pasted text
+            ('g', KeyModifiers::NONE, KeyCode::Char('p')) => {
+                self.reset();
+                KeyAction::PasteAfterMove(count)
+            }
+            // gP - paste before and leave cursor after pasted text
+            ('g', KeyModifiers::SHIFT, KeyCode::Char('P')) => {
+                self.reset();
+                KeyAction::PasteBeforeMove(count)
+            }
             // gr - find references (LSP)
             ('g', KeyModifiers::NONE, KeyCode::Char('r')) => {
                 self.reset();
@@ -1314,6 +1496,9 @@ impl InputState {
             (KeyModifiers::SHIFT, KeyCode::Char('B')) => Some(TextObjectType::Brace),
             (_, KeyCode::Char('[')) | (_, KeyCode::Char(']')) => Some(TextObjectType::Bracket),
             (_, KeyCode::Char('<')) | (_, KeyCode::Char('>')) => Some(TextObjectType::AngleBracket),
+            (KeyModifiers::NONE, KeyCode::Char('p')) => Some(TextObjectType::Paragraph),
+            (KeyModifiers::NONE, KeyCode::Char('s')) => Some(TextObjectType::Sentence),
+            (KeyModifiers::NONE, KeyCode::Char('t')) => Some(TextObjectType::Tag),
             _ => None,
         };
 
@@ -1371,6 +1556,9 @@ impl InputState {
             KeyCode::Char('<') | KeyCode::Char('>') | KeyCode::Char('a') => {
                 Some(TextObjectType::AngleBracket)
             }
+            KeyCode::Char('p') => Some(TextObjectType::Paragraph),
+            KeyCode::Char('s') => Some(TextObjectType::Sentence),
+            KeyCode::Char('t') => Some(TextObjectType::Tag),
             _ => None,
         }
     }
@@ -1389,8 +1577,12 @@ impl InputState {
             (KeyModifiers::NONE, KeyCode::Char('0')) => Motion::LineStart,
             (_, KeyCode::Char('^')) => Motion::FirstNonBlank,
             (_, KeyCode::Char('$')) => Motion::LineEnd,
+            (_, KeyCode::Char('+')) => Motion::NextLineFirstNonBlank,
+            (_, KeyCode::Char('-')) => Motion::PrevLineFirstNonBlank,
             (_, KeyCode::Char('}')) => Motion::ParagraphForward,
             (_, KeyCode::Char('{')) => Motion::ParagraphBackward,
+            (_, KeyCode::Char(')')) => Motion::SentenceForward,
+            (_, KeyCode::Char('(')) => Motion::SentenceBackward,
             (_, KeyCode::Char('%')) => Motion::MatchingBracket,
             (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
                 if self.count.is_some() {
@@ -1455,6 +1647,13 @@ impl InputState {
             // Close
             (KeyModifiers::NONE, KeyCode::Char('q')) => KeyAction::WindowClose,
             (KeyModifiers::NONE, KeyCode::Char('o')) => KeyAction::WindowCloseOthers,
+            // Equalize
+            (KeyModifiers::NONE, KeyCode::Char('=')) => KeyAction::WindowEqualize,
+            // Rotate
+            (KeyModifiers::NONE, KeyCode::Char('r')) => KeyAction::WindowRotateDownRight,
+            (KeyModifiers::SHIFT, KeyCode::Char('R')) => KeyAction::WindowRotateUpLeft,
+            // Exchange
+            (KeyModifiers::NONE, KeyCode::Char('x')) => KeyAction::WindowExchangeNext,
             // Escape cancels
             (_, KeyCode::Esc) => KeyAction::Pending,
             _ => KeyAction::Unknown,
@@ -1517,6 +1716,14 @@ impl InputState {
                 self.reset();
                 KeyAction::ToggleCommentMotion(Motion::FirstNonBlank, count)
             }
+            (_, KeyCode::Char('+')) => {
+                self.reset();
+                KeyAction::ToggleCommentMotion(Motion::NextLineFirstNonBlank, count)
+            }
+            (_, KeyCode::Char('-')) => {
+                self.reset();
+                KeyAction::ToggleCommentMotion(Motion::PrevLineFirstNonBlank, count)
+            }
             // Paragraph motions
             (_, KeyCode::Char('}')) => {
                 self.reset();
@@ -1525,6 +1732,15 @@ impl InputState {
             (_, KeyCode::Char('{')) => {
                 self.reset();
                 KeyAction::ToggleCommentMotion(Motion::ParagraphBackward, count)
+            }
+            // Sentence motions
+            (_, KeyCode::Char(')')) => {
+                self.reset();
+                KeyAction::ToggleCommentMotion(Motion::SentenceForward, count)
+            }
+            (_, KeyCode::Char('(')) => {
+                self.reset();
+                KeyAction::ToggleCommentMotion(Motion::SentenceBackward, count)
             }
             // File motions
             (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
@@ -1634,6 +1850,14 @@ impl InputState {
                 self.reset();
                 KeyAction::CaseMotion(case_op, Motion::FirstNonBlank, count)
             }
+            (_, KeyCode::Char('+')) => {
+                self.reset();
+                KeyAction::CaseMotion(case_op, Motion::NextLineFirstNonBlank, count)
+            }
+            (_, KeyCode::Char('-')) => {
+                self.reset();
+                KeyAction::CaseMotion(case_op, Motion::PrevLineFirstNonBlank, count)
+            }
             // Paragraph motions
             (_, KeyCode::Char('}')) => {
                 self.reset();
@@ -1642,6 +1866,15 @@ impl InputState {
             (_, KeyCode::Char('{')) => {
                 self.reset();
                 KeyAction::CaseMotion(case_op, Motion::ParagraphBackward, count)
+            }
+            // Sentence motions
+            (_, KeyCode::Char(')')) => {
+                self.reset();
+                KeyAction::CaseMotion(case_op, Motion::SentenceForward, count)
+            }
+            (_, KeyCode::Char('(')) => {
+                self.reset();
+                KeyAction::CaseMotion(case_op, Motion::SentenceBackward, count)
             }
             // File motions
             (KeyModifiers::SHIFT, KeyCode::Char('G')) => {
@@ -1808,6 +2041,12 @@ mod tests {
         assert_motion(&[key('k')], Motion::Up, 1);
         assert_motion(&[key('l')], Motion::Right, 1);
         assert_motion(&[key('3'), key('j')], Motion::Down, 3);
+        assert_motion(&[key('g'), key('j')], Motion::DisplayLineDown, 1);
+        assert_motion(&[key('g'), key('k')], Motion::DisplayLineUp, 1);
+        assert_motion(&[key('3'), key('g'), key('j')], Motion::DisplayLineDown, 3);
+        assert_motion(&[key('g'), key('0')], Motion::DisplayLineStart, 1);
+        assert_motion(&[key('g'), key('$')], Motion::DisplayLineEnd, 1);
+        assert_motion(&[key('g'), key('^')], Motion::DisplayLineFirstNonBlank, 1);
 
         assert_motion(&[key('w')], Motion::WordForward, 1);
         assert_motion(&[shift('W')], Motion::BigWordForward, 1);
@@ -1821,8 +2060,15 @@ mod tests {
         assert_motion(&[key('0')], Motion::LineStart, 1);
         assert_motion(&[key('^')], Motion::FirstNonBlank, 1);
         assert_motion(&[key('$')], Motion::LineEnd, 1);
+        assert_motion(&[key('+')], Motion::NextLineFirstNonBlank, 1);
+        assert_motion(&[key('-')], Motion::PrevLineFirstNonBlank, 1);
+        assert_motion(&[key('3'), key('+')], Motion::NextLineFirstNonBlank, 3);
+        assert_motion(&[key('3'), key('-')], Motion::PrevLineFirstNonBlank, 3);
         assert_motion(&[key('{')], Motion::ParagraphBackward, 1);
         assert_motion(&[key('}')], Motion::ParagraphForward, 1);
+        assert_motion(&[key('(')], Motion::SentenceBackward, 1);
+        assert_motion(&[key(')')], Motion::SentenceForward, 1);
+        assert_motion(&[key('2'), key(')')], Motion::SentenceForward, 2);
 
         assert_motion(&[key('g'), key('g')], Motion::FileStart, 1);
         assert_motion(&[shift('G')], Motion::FileEnd, 1);
@@ -1911,6 +2157,9 @@ mod tests {
         assert_operator_motion(&[key('>'), key('j')], Operator::Indent, Motion::Down, 1);
         assert_operator_line(&[key('<'), key('<')], Operator::Dedent, 1);
         assert_operator_motion(&[key('<'), key('j')], Operator::Dedent, Motion::Down, 1);
+        assert_operator_line(&[key('='), key('=')], Operator::AutoIndent, 1);
+        assert_operator_motion(&[key('='), key('j')], Operator::AutoIndent, Motion::Down, 1);
+        assert_operator_line(&[key('2'), key('='), key('=')], Operator::AutoIndent, 2);
 
         match run(&[key('x')]) {
             KeyAction::DeleteChar(1) => {}
@@ -1932,6 +2181,14 @@ mod tests {
         match run(&[shift('P')]) {
             KeyAction::PasteBefore(1) => {}
             other => panic!("expected PasteBefore, got {:?}", other),
+        }
+        match run(&[key('g'), key('p')]) {
+            KeyAction::PasteAfterMove(1) => {}
+            other => panic!("expected PasteAfterMove, got {:?}", other),
+        }
+        match run(&[key('g'), shift('P')]) {
+            KeyAction::PasteBeforeMove(1) => {}
+            other => panic!("expected PasteBeforeMove, got {:?}", other),
         }
         match run(&[key('r'), key('x')]) {
             KeyAction::ReplaceChar('x', 1) => {}
@@ -2031,6 +2288,14 @@ mod tests {
             KeyAction::SearchWordBackward => {}
             other => panic!("expected SearchWordBackward, got {:?}", other),
         }
+        match run(&[key('g'), key('n')]) {
+            KeyAction::SearchSelectNext(1) => {}
+            other => panic!("expected SearchSelectNext, got {:?}", other),
+        }
+        match run(&[key('g'), shift('N')]) {
+            KeyAction::SearchSelectPrev(1) => {}
+            other => panic!("expected SearchSelectPrev, got {:?}", other),
+        }
 
         match run(&[key('v')]) {
             KeyAction::EnterVisual => {}
@@ -2052,6 +2317,19 @@ mod tests {
         match run(&[key('g'), key('d')]) {
             KeyAction::GotoDefinition => {}
             other => panic!("expected GotoDefinition, got {:?}", other),
+        }
+        assert_eq!(
+            format!("{:?}", run(&[key('g'), shift('D')])),
+            "GotoDeclaration"
+        );
+        assert_eq!(
+            format!("{:?}", run(&[key('g'), shift('I')])),
+            "GotoImplementation"
+        );
+        assert_eq!(format!("{:?}", run(&[key('g'), key('x')])), "OpenUrl");
+        match run(&[key('g'), key('f')]) {
+            KeyAction::GotoFile => {}
+            other => panic!("expected GotoFile, got {:?}", other),
         }
         match run(&[key('g'), key('r')]) {
             KeyAction::FindReferences => {}
@@ -2141,6 +2419,26 @@ mod tests {
             KeyAction::JumpToPreviousPosition => {}
             other => panic!("expected JumpToPreviousPosition, got {:?}", other),
         }
+        match run(&[key('`'), key('`')]) {
+            KeyAction::JumpToPreviousPositionExact => {}
+            other => panic!("expected JumpToPreviousPositionExact, got {:?}", other),
+        }
+        match run(&[key('\''), key('.')]) {
+            KeyAction::JumpToLastChange => {}
+            other => panic!("expected JumpToLastChange, got {:?}", other),
+        }
+        match run(&[key('`'), key('.')]) {
+            KeyAction::JumpToLastChangeExact => {}
+            other => panic!("expected JumpToLastChangeExact, got {:?}", other),
+        }
+        match run(&[key('\''), key('^')]) {
+            KeyAction::JumpToLastInsert => {}
+            other => panic!("expected JumpToLastInsert, got {:?}", other),
+        }
+        match run(&[key('`'), key('^')]) {
+            KeyAction::JumpToLastInsertExact => {}
+            other => panic!("expected JumpToLastInsertExact, got {:?}", other),
+        }
 
         match run(&[key('q'), key('a')]) {
             KeyAction::StartRecordMacro('a') => {}
@@ -2170,6 +2468,22 @@ mod tests {
         match run(&[ctrl('w'), key('o')]) {
             KeyAction::WindowCloseOthers => {}
             other => panic!("expected WindowCloseOthers, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('=')]) {
+            KeyAction::WindowEqualize => {}
+            other => panic!("expected WindowEqualize, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('r')]) {
+            KeyAction::WindowRotateDownRight => {}
+            other => panic!("expected WindowRotateDownRight, got {:?}", other),
+        }
+        match run(&[ctrl('w'), shift('R')]) {
+            KeyAction::WindowRotateUpLeft => {}
+            other => panic!("expected WindowRotateUpLeft, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('x')]) {
+            KeyAction::WindowExchangeNext => {}
+            other => panic!("expected WindowExchangeNext, got {:?}", other),
         }
         match run(&[ctrl('w'), key('w')]) {
             KeyAction::WindowNext => {}

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -8,48 +8,59 @@ pub enum Motion {
     Right,
     Up,
     Down,
+    DisplayLineUp,            // gk - up one display line when wrap is enabled
+    DisplayLineDown,          // gj - down one display line when wrap is enabled
+    DisplayLineStart,         // g0 - start of current display line
+    DisplayLineEnd,           // g$ - end of current display line
+    DisplayLineFirstNonBlank, // g^ - first non-blank of current display line
 
     // Word motions
-    WordForward,       // w
-    WordBackward,      // b
-    WordEnd,           // e
-    WordEndBackward,   // ge
-    BigWordForward,    // W
-    BigWordBackward,   // B
-    BigWordEnd,        // E
-    BigWordEndBackward,// gE
+    WordForward,        // w
+    WordBackward,       // b
+    WordEnd,            // e
+    WordEndBackward,    // ge
+    BigWordForward,     // W
+    BigWordBackward,    // B
+    BigWordEnd,         // E
+    BigWordEndBackward, // gE
 
     // Line motions
-    LineStart,        // 0
-    FirstNonBlank,    // ^
-    LineEnd,          // $
+    LineStart,             // 0
+    FirstNonBlank,         // ^
+    LineEnd,               // $
+    NextLineFirstNonBlank, // +
+    PrevLineFirstNonBlank, // -
 
     // File motions
-    FileStart,        // gg
-    FileEnd,          // G
-    GotoLine(usize),  // {count}G
+    FileStart,       // gg
+    FileEnd,         // G
+    GotoLine(usize), // {count}G
 
     // Screen motions
-    HalfPageDown,     // Ctrl-d
-    HalfPageUp,       // Ctrl-u
-    PageDown,         // Ctrl-f
-    PageUp,           // Ctrl-b
-    ScreenTop,        // H - top of screen
-    ScreenMiddle,     // M - middle of screen
-    ScreenBottom,     // L - bottom of screen
+    HalfPageDown, // Ctrl-d
+    HalfPageUp,   // Ctrl-u
+    PageDown,     // Ctrl-f
+    PageUp,       // Ctrl-b
+    ScreenTop,    // H - top of screen
+    ScreenMiddle, // M - middle of screen
+    ScreenBottom, // L - bottom of screen
 
     // Find char motions
-    FindChar(char),       // f{char}
-    FindCharBack(char),   // F{char}
-    TillChar(char),       // t{char}
-    TillCharBack(char),   // T{char}
+    FindChar(char),     // f{char}
+    FindCharBack(char), // F{char}
+    TillChar(char),     // t{char}
+    TillCharBack(char), // T{char}
 
     // Paragraph motions
-    ParagraphForward,     // }
-    ParagraphBackward,    // {
+    ParagraphForward,  // }
+    ParagraphBackward, // {
+
+    // Sentence motions
+    SentenceForward,  // )
+    SentenceBackward, // (
 
     // Bracket matching
-    MatchingBracket,      // %
+    MatchingBracket, // %
 }
 
 /// Check if a character is a "word" character (alphanumeric or underscore)
@@ -67,8 +78,8 @@ fn is_keyword_char(ch: char) -> bool {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum CharClass {
     Whitespace,
-    Word,      // alphanumeric + underscore
-    Keyword,   // punctuation, symbols
+    Word,    // alphanumeric + underscore
+    Keyword, // punctuation, symbols
 }
 
 fn classify_char(ch: char) -> CharClass {
@@ -94,9 +105,7 @@ pub fn apply_motion(
     let count = count.max(1);
 
     match motion {
-        Motion::Left => {
-            Some((line, col.saturating_sub(count)))
-        }
+        Motion::Left => Some((line, col.saturating_sub(count))),
 
         Motion::Right => {
             let line_len = buffer.line_len(line);
@@ -104,14 +113,32 @@ pub fn apply_motion(
             Some((line, new_col))
         }
 
-        Motion::Up => {
-            Some((line.saturating_sub(count), col))
-        }
+        Motion::Up => Some((line.saturating_sub(count), col)),
 
         Motion::Down => {
             let max_line = buffer.len_lines().saturating_sub(1);
             let new_line = (line + count).min(max_line);
             Some((new_line, col))
+        }
+
+        Motion::DisplayLineUp => Some((line.saturating_sub(count), col)),
+
+        Motion::DisplayLineDown => {
+            let max_line = buffer.len_lines().saturating_sub(1);
+            let new_line = (line + count).min(max_line);
+            Some((new_line, col))
+        }
+
+        Motion::DisplayLineStart => Some((line, 0)),
+
+        Motion::DisplayLineEnd => {
+            let line_len = buffer.line_len(line);
+            Some((line, line_len.saturating_sub(1)))
+        }
+
+        Motion::DisplayLineFirstNonBlank => {
+            let first_non_blank = find_first_non_blank(buffer, line);
+            Some((line, first_non_blank))
         }
 
         Motion::WordForward => {
@@ -226,9 +253,7 @@ pub fn apply_motion(
             Some((l, c))
         }
 
-        Motion::LineStart => {
-            Some((line, 0))
-        }
+        Motion::LineStart => Some((line, 0)),
 
         Motion::FirstNonBlank => {
             let first_non_blank = find_first_non_blank(buffer, line);
@@ -240,9 +265,20 @@ pub fn apply_motion(
             Some((line, line_len.saturating_sub(1)))
         }
 
-        Motion::FileStart => {
-            Some((0, 0))
+        Motion::NextLineFirstNonBlank => {
+            let max_line = buffer.len_lines().saturating_sub(1);
+            let target_line = (line + count).min(max_line);
+            let first_non_blank = find_first_non_blank(buffer, target_line);
+            Some((target_line, first_non_blank))
         }
+
+        Motion::PrevLineFirstNonBlank => {
+            let target_line = line.saturating_sub(count);
+            let first_non_blank = find_first_non_blank(buffer, target_line);
+            Some((target_line, first_non_blank))
+        }
+
+        Motion::FileStart => Some((0, 0)),
 
         Motion::FileEnd => {
             let last_line = buffer.len_lines().saturating_sub(1);
@@ -250,7 +286,9 @@ pub fn apply_motion(
         }
 
         Motion::GotoLine(target) => {
-            let target_line = target.saturating_sub(1).min(buffer.len_lines().saturating_sub(1));
+            let target_line = target
+                .saturating_sub(1)
+                .min(buffer.len_lines().saturating_sub(1));
             Some((target_line, 0))
         }
 
@@ -278,21 +316,13 @@ pub fn apply_motion(
             Some((new_line, col))
         }
 
-        Motion::FindChar(target) => {
-            find_char_forward(buffer, line, col, target, count, false)
-        }
+        Motion::FindChar(target) => find_char_forward(buffer, line, col, target, count, false),
 
-        Motion::FindCharBack(target) => {
-            find_char_backward(buffer, line, col, target, count, false)
-        }
+        Motion::FindCharBack(target) => find_char_backward(buffer, line, col, target, count, false),
 
-        Motion::TillChar(target) => {
-            find_char_forward(buffer, line, col, target, count, true)
-        }
+        Motion::TillChar(target) => find_char_forward(buffer, line, col, target, count, true),
 
-        Motion::TillCharBack(target) => {
-            find_char_backward(buffer, line, col, target, count, true)
-        }
+        Motion::TillCharBack(target) => find_char_backward(buffer, line, col, target, count, true),
 
         Motion::ScreenTop => {
             // H - move to top of screen
@@ -364,6 +394,14 @@ pub fn apply_motion(
             Some((l, 0))
         }
 
+        Motion::SentenceForward => {
+            find_sentence_start(buffer, line, col, count, SentenceDirection::Forward)
+        }
+
+        Motion::SentenceBackward => {
+            find_sentence_start(buffer, line, col, count, SentenceDirection::Backward)
+        }
+
         Motion::MatchingBracket => {
             // % - jump to matching bracket
             find_matching_bracket(buffer, line, col)
@@ -385,6 +423,111 @@ fn is_blank_line(buffer: &Buffer, line: usize) -> bool {
         }
     }
     true
+}
+
+enum SentenceDirection {
+    Forward,
+    Backward,
+}
+
+fn find_sentence_start(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    count: usize,
+    direction: SentenceDirection,
+) -> Option<(usize, usize)> {
+    let content = buffer.content();
+    let chars: Vec<char> = content.chars().collect();
+    if chars.is_empty() {
+        return Some((0, 0));
+    }
+
+    let current_idx = buffer
+        .line_col_to_char(line, col)
+        .min(chars.len().saturating_sub(1));
+    let starts = sentence_starts(&chars);
+    if starts.is_empty() {
+        return Some(char_index_to_line_col(buffer, current_idx));
+    }
+
+    let mut idx = current_idx;
+    for _ in 0..count {
+        match direction {
+            SentenceDirection::Forward => {
+                if let Some(next) = starts.iter().copied().find(|start| *start > idx) {
+                    idx = next;
+                }
+            }
+            SentenceDirection::Backward => {
+                if let Some(prev) = starts.iter().rev().copied().find(|start| *start < idx) {
+                    idx = prev;
+                } else {
+                    idx = starts[0];
+                }
+            }
+        }
+    }
+
+    Some(char_index_to_line_col(buffer, idx))
+}
+
+fn sentence_starts(chars: &[char]) -> Vec<usize> {
+    let mut starts = Vec::new();
+    if let Some(first) = skip_sentence_space(chars, 0) {
+        starts.push(first);
+    }
+
+    for idx in 0..chars.len() {
+        if !is_sentence_end(chars[idx]) {
+            continue;
+        }
+
+        let after_closers = skip_sentence_closers(chars, idx + 1);
+        if after_closers < chars.len() && !chars[after_closers].is_whitespace() {
+            continue;
+        }
+
+        if let Some(start) = skip_sentence_space(chars, after_closers) {
+            if starts.last().copied() != Some(start) {
+                starts.push(start);
+            }
+        }
+    }
+
+    starts
+}
+
+fn is_sentence_end(ch: char) -> bool {
+    matches!(ch, '.' | '!' | '?')
+}
+
+fn skip_sentence_closers(chars: &[char], mut idx: usize) -> usize {
+    while idx < chars.len() && matches!(chars[idx], '"' | '\'' | ')' | ']' | '}') {
+        idx += 1;
+    }
+    idx
+}
+
+fn skip_sentence_space(chars: &[char], mut idx: usize) -> Option<usize> {
+    while idx < chars.len() && chars[idx].is_whitespace() {
+        idx += 1;
+    }
+    (idx < chars.len()).then_some(idx)
+}
+
+fn char_index_to_line_col(buffer: &Buffer, char_idx: usize) -> (usize, usize) {
+    let mut remaining = char_idx;
+    for line in 0..buffer.len_lines() {
+        let len = buffer.line_len_including_newline(line);
+        if remaining < len {
+            return (line, remaining.min(buffer.line_len(line)));
+        }
+        remaining = remaining.saturating_sub(len);
+    }
+
+    let last_line = buffer.len_lines().saturating_sub(1);
+    (last_line, buffer.line_len(last_line).saturating_sub(1))
 }
 
 /// Find the matching bracket for the character at (line, col)
@@ -436,7 +579,13 @@ fn is_bracket(ch: char) -> bool {
 }
 
 /// Search forward for matching bracket
-fn find_matching_forward(buffer: &Buffer, start_line: usize, start_col: usize, open: char, close: char) -> Option<(usize, usize)> {
+fn find_matching_forward(
+    buffer: &Buffer,
+    start_line: usize,
+    start_col: usize,
+    open: char,
+    close: char,
+) -> Option<(usize, usize)> {
     let total_lines = buffer.len_lines();
     let mut depth = 0;
 
@@ -461,12 +610,22 @@ fn find_matching_forward(buffer: &Buffer, start_line: usize, start_col: usize, o
 }
 
 /// Search backward for matching bracket
-fn find_matching_backward(buffer: &Buffer, start_line: usize, start_col: usize, close: char, open: char) -> Option<(usize, usize)> {
+fn find_matching_backward(
+    buffer: &Buffer,
+    start_line: usize,
+    start_col: usize,
+    close: char,
+    open: char,
+) -> Option<(usize, usize)> {
     let mut depth = 0;
 
     for l in (0..=start_line).rev() {
         let line_len = buffer.line_len(l);
-        let end_c = if l == start_line { start_col } else { line_len.saturating_sub(1) };
+        let end_c = if l == start_line {
+            start_col
+        } else {
+            line_len.saturating_sub(1)
+        };
 
         if line_len == 0 {
             continue;
@@ -489,7 +648,12 @@ fn find_matching_backward(buffer: &Buffer, start_line: usize, start_col: usize, 
 }
 
 /// Find the start of the next word (w motion)
-fn find_word_forward(buffer: &Buffer, line: usize, col: usize, big_word: bool) -> Option<(usize, usize)> {
+fn find_word_forward(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    big_word: bool,
+) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
     let total_lines = buffer.len_lines();
@@ -516,7 +680,8 @@ fn find_word_forward(buffer: &Buffer, line: usize, col: usize, big_word: bool) -
             let class = classify_char(ch);
             let same_class = if big_word {
                 // For WORD, only whitespace breaks
-                class != CharClass::Whitespace && start_class.map_or(false, |sc| sc != CharClass::Whitespace)
+                class != CharClass::Whitespace
+                    && start_class.map_or(false, |sc| sc != CharClass::Whitespace)
             } else {
                 // For word, same class continues
                 Some(class) == start_class && class != CharClass::Whitespace
@@ -570,7 +735,12 @@ fn find_word_forward(buffer: &Buffer, line: usize, col: usize, big_word: bool) -
 }
 
 /// Find the start of the previous word (b motion)
-fn find_word_backward(buffer: &Buffer, line: usize, col: usize, big_word: bool) -> Option<(usize, usize)> {
+fn find_word_backward(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    big_word: bool,
+) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
 
@@ -648,7 +818,12 @@ fn find_word_backward(buffer: &Buffer, line: usize, col: usize, big_word: bool) 
 }
 
 /// Find the end of the current/next word (e motion)
-fn find_word_end(buffer: &Buffer, line: usize, col: usize, big_word: bool) -> Option<(usize, usize)> {
+fn find_word_end(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    big_word: bool,
+) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
     let total_lines = buffer.len_lines();
@@ -662,7 +837,12 @@ fn find_word_end(buffer: &Buffer, line: usize, col: usize, big_word: bool) -> Op
     }
 
     if l >= total_lines {
-        return Some((total_lines.saturating_sub(1), buffer.line_len(total_lines.saturating_sub(1)).saturating_sub(1)));
+        return Some((
+            total_lines.saturating_sub(1),
+            buffer
+                .line_len(total_lines.saturating_sub(1))
+                .saturating_sub(1),
+        ));
     }
 
     // Phase 1: Skip whitespace
@@ -814,7 +994,12 @@ fn find_char_backward(
 }
 
 /// Find the end of the previous word (ge/gE motion)
-fn find_word_end_backward(buffer: &Buffer, line: usize, col: usize, big_word: bool) -> Option<(usize, usize)> {
+fn find_word_end_backward(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    big_word: bool,
+) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,17 +17,21 @@ pub mod syntax;
 pub mod terminal;
 pub mod theme;
 
-pub use config::{load_config, Settings, KeymapLookup, LeaderAction, AutosaveMode, CopilotSettings};
-pub use config::{load_languages_config, LanguagesConfig, FormatterConfig};
-pub use copilot::{CopilotManager, CopilotStatus, GhostTextState};
+pub use config::{
+    load_config, AutosaveMode, CopilotSettings, KeymapLookup, LeaderAction, Settings,
+};
+pub use config::{load_languages_config, FormatterConfig, LanguagesConfig};
 pub use copilot::types::CopilotNotification;
-pub use editor::{Editor, Mode, Buffer, Cursor, LspAction, CopilotAction, CopilotGhostText, ThemePicker};
-pub use floating_terminal::FloatingTerminal;
-pub use harpoon::Harpoon;
+pub use copilot::{CopilotManager, CopilotStatus, GhostTextState};
+pub use editor::{
+    Buffer, CopilotAction, CopilotGhostText, Cursor, Editor, LspAction, Mode, ThemePicker,
+};
 pub use explorer::FileExplorer;
-pub use finder::{FuzzyFinder, FinderMode, FloatingWindow};
+pub use finder::{FinderMode, FloatingWindow, FuzzyFinder};
+pub use floating_terminal::FloatingTerminal;
 pub use frecency::FrecencyDb;
-pub use lsp::{LspManager, LspNotification, LspStatus, MultiLspManager, LanguageId};
+pub use harpoon::Harpoon;
+pub use lsp::{LanguageId, LspManager, LspNotification, LspStatus, MultiLspManager};
 pub use markdown_preview::{
     render_markdown, MarkdownPreview, MarkdownPreviewState, PreviewLine, PreviewLineKind,
     PreviewSpan, PreviewSpanStyle,

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -11,6 +11,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
+use lsp_types::request::{GotoDeclarationParams, GotoImplementationParams};
 use lsp_types::{
     ClientCapabilities, DidChangeTextDocumentParams, DidCloseTextDocumentParams,
     DidOpenTextDocumentParams, GotoDefinitionParams, HoverParams, InitializeParams,
@@ -22,7 +23,8 @@ use serde_json::{json, Value};
 
 use super::types::{
     CodeActionItem, CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity, Location,
-    LspNotification, ParameterInfo, RequestKind, SignatureHelpResult, SignatureInfo, TextEdit,
+    LspNavigationTargetKind, LspNotification, ParameterInfo, RequestKind, SignatureHelpResult,
+    SignatureInfo, TextEdit,
 };
 #[cfg(test)]
 use super::watched_files::WATCHED_FILES_METHOD;
@@ -147,6 +149,14 @@ fn client_capabilities() -> ClientCapabilities {
                 ..Default::default()
             }),
             definition: Some(lsp_types::GotoCapability {
+                link_support: Some(false),
+                ..Default::default()
+            }),
+            declaration: Some(lsp_types::GotoCapability {
+                link_support: Some(false),
+                ..Default::default()
+            }),
+            implementation: Some(lsp_types::GotoCapability {
                 link_support: Some(false),
                 ..Default::default()
             }),
@@ -393,6 +403,52 @@ impl LspClient {
             "textDocument/definition",
             serde_json::to_value(params)?,
             RequestKind::Definition {
+                uri: uri.to_string(),
+                line,
+                character,
+            },
+        )
+    }
+
+    /// Request go-to-declaration
+    pub fn goto_declaration(&mut self, uri: &str, line: u32, character: u32) -> Result<u64> {
+        let params = GotoDeclarationParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: lsp_types::Url::parse(uri)?,
+                },
+                position: lsp_types::Position { line, character },
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        self.send_request(
+            "textDocument/declaration",
+            serde_json::to_value(params)?,
+            RequestKind::Declaration {
+                uri: uri.to_string(),
+                line,
+                character,
+            },
+        )
+    }
+
+    /// Request go-to-implementation
+    pub fn goto_implementation(&mut self, uri: &str, line: u32, character: u32) -> Result<u64> {
+        let params = GotoImplementationParams {
+            text_document_position_params: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: lsp_types::Url::parse(uri)?,
+                },
+                position: lsp_types::Position { line, character },
+            },
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+        };
+        self.send_request(
+            "textDocument/implementation",
+            serde_json::to_value(params)?,
+            RequestKind::Implementation {
                 uri: uri.to_string(),
                 line,
                 character,
@@ -909,9 +965,40 @@ fn handle_message(
             line: _,
             character: _,
         } => match msg.result {
-            Some(result) if !result.is_null() => handle_definition_response(result, uri),
+            Some(result) if !result.is_null() => {
+                handle_definition_response(result, uri, LspNavigationTargetKind::Definition)
+            }
             _ => Some(LspNotification::Definition {
                 locations: vec![],
+                target_kind: LspNavigationTargetKind::Definition,
+                request_uri: uri,
+            }),
+        },
+        RequestKind::Declaration {
+            uri,
+            line: _,
+            character: _,
+        } => match msg.result {
+            Some(result) if !result.is_null() => {
+                handle_definition_response(result, uri, LspNavigationTargetKind::Declaration)
+            }
+            _ => Some(LspNotification::Definition {
+                locations: vec![],
+                target_kind: LspNavigationTargetKind::Declaration,
+                request_uri: uri,
+            }),
+        },
+        RequestKind::Implementation {
+            uri,
+            line: _,
+            character: _,
+        } => match msg.result {
+            Some(result) if !result.is_null() => {
+                handle_definition_response(result, uri, LspNavigationTargetKind::Implementation)
+            }
+            _ => Some(LspNotification::Definition {
+                locations: vec![],
+                target_kind: LspNavigationTargetKind::Implementation,
                 request_uri: uri,
             }),
         },
@@ -1507,7 +1594,11 @@ fn handle_completion_response(
 }
 
 /// Handle definition response - returns all locations for multi-definition support
-fn handle_definition_response(result: Value, request_uri: String) -> Option<LspNotification> {
+fn handle_definition_response(
+    result: Value,
+    request_uri: String,
+    target_kind: LspNavigationTargetKind,
+) -> Option<LspNotification> {
     // Can be a single Location, array of Locations, or array of LocationLinks
     let locations_json = if result.is_array() {
         result.as_array()?.clone()
@@ -1536,6 +1627,7 @@ fn handle_definition_response(result: Value, request_uri: String) -> Option<LspN
 
     Some(LspNotification::Definition {
         locations,
+        target_kind,
         request_uri,
     })
 }
@@ -2130,6 +2222,80 @@ mod tests {
         assert!(register_response.contains("\"result\":null"));
         assert!(unregister_response.contains("\"result\":null"));
         assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn declaration_response_notification_preserves_navigation_kind() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        pending.lock().unwrap().insert(
+            42,
+            RequestKind::Declaration {
+                uri: "file:///tmp/source.rs".to_string(),
+                line: 3,
+                character: 7,
+            },
+        );
+
+        let response = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(JsonRpcId::Num(42)),
+            result: Some(json!({
+                "uri": "file:///tmp/target.rs",
+                "range": {
+                    "start": {"line": 1, "character": 2},
+                    "end": {"line": 1, "character": 6}
+                }
+            })),
+            error: None,
+            method: None,
+            params: None,
+        };
+
+        let (notification, server_response) = handle_message(response, &pending, None);
+
+        assert!(server_response.is_none());
+        let notification = notification.expect("declaration notification");
+        assert!(
+            format!("{notification:?}").contains("Declaration"),
+            "expected declaration kind in notification, got {notification:?}"
+        );
+    }
+
+    #[test]
+    fn implementation_response_notification_preserves_navigation_kind() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        pending.lock().unwrap().insert(
+            42,
+            RequestKind::Implementation {
+                uri: "file:///tmp/source.rs".to_string(),
+                line: 3,
+                character: 7,
+            },
+        );
+
+        let response = JsonRpcResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(JsonRpcId::Num(42)),
+            result: Some(json!({
+                "uri": "file:///tmp/target.rs",
+                "range": {
+                    "start": {"line": 1, "character": 2},
+                    "end": {"line": 1, "character": 6}
+                }
+            })),
+            error: None,
+            method: None,
+            params: None,
+        };
+
+        let (notification, server_response) = handle_message(response, &pending, None);
+
+        assert!(server_response.is_none());
+        let notification = notification.expect("implementation notification");
+        assert!(
+            format!("{notification:?}").contains("Implementation"),
+            "expected implementation kind in notification, got {notification:?}"
+        );
     }
 
     #[test]

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -184,6 +184,36 @@ impl LspManager {
         })
     }
 
+    /// Request go-to-declaration
+    pub fn goto_declaration(
+        &self,
+        path: &PathBuf,
+        line: u32,
+        character: u32,
+    ) -> anyhow::Result<()> {
+        let uri = path_to_uri(path);
+        self.send(LspRequest::GotoDeclaration {
+            uri,
+            line,
+            character,
+        })
+    }
+
+    /// Request go-to-implementation
+    pub fn goto_implementation(
+        &self,
+        path: &PathBuf,
+        line: u32,
+        character: u32,
+    ) -> anyhow::Result<()> {
+        let uri = path_to_uri(path);
+        self.send(LspRequest::GotoImplementation {
+            uri,
+            line,
+            character,
+        })
+    }
+
     /// Request hover
     pub fn hover(&self, path: &PathBuf, line: u32, character: u32) -> anyhow::Result<()> {
         let uri = path_to_uri(path);
@@ -439,6 +469,28 @@ fn run_lsp_thread(
                         if let Err(e) = client.goto_definition(&uri, line, character) {
                             let _ = notification_tx.send(LspNotification::Error {
                                 message: format!("Failed to request definition: {}", e),
+                            });
+                        }
+                    }
+                    LspRequest::GotoDeclaration {
+                        uri,
+                        line,
+                        character,
+                    } => {
+                        if let Err(e) = client.goto_declaration(&uri, line, character) {
+                            let _ = notification_tx.send(LspNotification::Error {
+                                message: format!("Failed to request declaration: {}", e),
+                            });
+                        }
+                    }
+                    LspRequest::GotoImplementation {
+                        uri,
+                        line,
+                        character,
+                    } => {
+                        if let Err(e) = client.goto_implementation(&uri, line, character) {
+                            let _ = notification_tx.send(LspNotification::Error {
+                                message: format!("Failed to request implementation: {}", e),
                             });
                         }
                     }

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -617,6 +617,46 @@ impl MultiLspManager {
         Ok(())
     }
 
+    /// Request go-to-declaration for a file
+    pub fn goto_declaration(
+        &mut self,
+        path: &PathBuf,
+        line: u32,
+        character: u32,
+    ) -> anyhow::Result<()> {
+        let lang = self
+            .language_for_path(path)
+            .ok_or_else(|| anyhow::anyhow!("Unknown language for {:?}", path))?;
+
+        if let Some(instance) = self.get_instance_mut(lang) {
+            if instance.ready {
+                instance.manager.goto_declaration(path, line, character)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Request go-to-implementation for a file
+    pub fn goto_implementation(
+        &mut self,
+        path: &PathBuf,
+        line: u32,
+        character: u32,
+    ) -> anyhow::Result<()> {
+        let lang = self
+            .language_for_path(path)
+            .ok_or_else(|| anyhow::anyhow!("Unknown language for {:?}", path))?;
+
+        if let Some(instance) = self.get_instance_mut(lang) {
+            if instance.ready {
+                instance
+                    .manager
+                    .goto_implementation(path, line, character)?;
+            }
+        }
+        Ok(())
+    }
+
     /// Request references for a symbol
     pub fn references(&mut self, path: &PathBuf, line: u32, character: u32) -> anyhow::Result<()> {
         let lang = self

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -34,6 +34,16 @@ pub enum RequestKind {
         line: u32,
         character: u32,
     },
+    Declaration {
+        uri: String,
+        line: u32,
+        character: u32,
+    },
+    Implementation {
+        uri: String,
+        line: u32,
+        character: u32,
+    },
     Hover {
         uri: String,
         line: u32,
@@ -127,6 +137,18 @@ pub enum LspRequest {
         line: u32,
         character: u32,
     },
+    /// Request go-to-declaration
+    GotoDeclaration {
+        uri: String,
+        line: u32,
+        character: u32,
+    },
+    /// Request go-to-implementation
+    GotoImplementation {
+        uri: String,
+        line: u32,
+        character: u32,
+    },
 
     /// Request hover information
     Hover {
@@ -207,6 +229,7 @@ pub enum LspNotification {
     /// Definition location result (may have multiple locations for traits, etc.)
     Definition {
         locations: Vec<Location>,
+        target_kind: LspNavigationTargetKind,
         /// Request context for validation
         request_uri: String,
     },
@@ -295,6 +318,23 @@ pub enum LspNotification {
         percentage: Option<u64>,
         done: bool,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LspNavigationTargetKind {
+    Definition,
+    Declaration,
+    Implementation,
+}
+
+impl LspNavigationTargetKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Definition => "definition",
+            Self::Declaration => "declaration",
+            Self::Implementation => "implementation",
+        }
+    }
 }
 
 /// A code action item from LSP

--- a/src/main.rs
+++ b/src/main.rs
@@ -575,6 +575,12 @@ fn main() -> anyhow::Result<()> {
                                         LspAction::GotoDefinition => {
                                             let _ = mlsp.goto_definition(&path, line, col);
                                         }
+                                        LspAction::GotoDeclaration => {
+                                            let _ = mlsp.goto_declaration(&path, line, col);
+                                        }
+                                        LspAction::GotoImplementation => {
+                                            let _ = mlsp.goto_implementation(&path, line, col);
+                                        }
                                         LspAction::Hover => {
                                             let _ = mlsp.hover(&path, line, col);
                                         }
@@ -1132,6 +1138,7 @@ fn main() -> anyhow::Result<()> {
                         }
                         LspNotification::Definition {
                             locations,
+                            target_kind,
                             request_uri,
                         } => {
                             // Validate response is for current file
@@ -1144,7 +1151,7 @@ fn main() -> anyhow::Result<()> {
                             // Handle go-to-definition with support for multiple locations
                             match locations.len() {
                                 0 => {
-                                    editor.set_status("No definition found");
+                                    editor.set_status(format!("No {} found", target_kind.label()));
                                 }
                                 1 => {
                                     // Single result - jump directly
@@ -1155,7 +1162,10 @@ fn main() -> anyhow::Result<()> {
                                         editor.open_file(path)?;
                                         editor.goto_line(loc.line + 1); // LSP is 0-indexed
                                         editor.cursor.col = loc.col;
-                                        editor.set_status("Jumped to definition");
+                                        editor.set_status(format!(
+                                            "Jumped to {}",
+                                            target_kind.label()
+                                        ));
                                     }
                                 }
                                 n => {
@@ -1169,7 +1179,8 @@ fn main() -> anyhow::Result<()> {
                                         editor.goto_line(loc.line + 1);
                                         editor.cursor.col = loc.col;
                                         editor.set_status(format!(
-                                            "Jumped to definition (1 of {})",
+                                            "Jumped to {} (1 of {})",
+                                            target_kind.label(),
                                             n
                                         ));
                                     }

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -4,9 +4,9 @@ mod theme;
 pub use highlighter::HighlightSpan;
 pub use theme::{HighlightGroup, SyntaxStyle, Theme};
 
+use std::cell::{Cell, RefCell};
 use std::path::Path;
 use tree_sitter::{Parser, Query, Tree};
-use std::cell::{Cell, RefCell};
 
 use crate::editor::Buffer;
 
@@ -395,7 +395,8 @@ impl SyntaxManager {
             self.query = None;
             self.parse_version = buffer.version();
             self.cache_version.set(self.parse_version);
-            self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+            self.highlight_cache
+                .replace(vec![None; self.line_start_bytes.len()]);
             return;
         }
 
@@ -427,7 +428,8 @@ impl SyntaxManager {
         self.tree = self.parser.parse(&self.source_cache, None);
         self.parse_version = buffer.version();
         self.cache_version.set(self.parse_version);
-        self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+        self.highlight_cache
+            .replace(vec![None; self.line_start_bytes.len()]);
     }
 
     /// Parse string content directly (for preview panels, etc.)
@@ -450,7 +452,8 @@ impl SyntaxManager {
             self.query = None;
             self.parse_version = self.parse_version.wrapping_add(1);
             self.cache_version.set(self.parse_version);
-            self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+            self.highlight_cache
+                .replace(vec![None; self.line_start_bytes.len()]);
             return;
         }
 
@@ -482,7 +485,8 @@ impl SyntaxManager {
         self.tree = self.parser.parse(&self.source_cache, None);
         self.parse_version = self.parse_version.wrapping_add(1);
         self.cache_version.set(self.parse_version);
-        self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+        self.highlight_cache
+            .replace(vec![None; self.line_start_bytes.len()]);
     }
 
     /// Check if syntax highlighting is available
@@ -494,10 +498,12 @@ impl SyntaxManager {
     pub fn get_line_highlights(&self, line: usize) -> Vec<HighlightSpan> {
         if self.language.as_deref() == Some("yaml") {
             if self.cache_version.get() != self.parse_version {
-                self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+                self.highlight_cache
+                    .replace(vec![None; self.line_start_bytes.len()]);
                 self.cache_version.set(self.parse_version);
             } else if self.highlight_cache.borrow().len() != self.line_start_bytes.len() {
-                self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+                self.highlight_cache
+                    .replace(vec![None; self.line_start_bytes.len()]);
                 self.cache_version.set(self.parse_version);
             }
 
@@ -525,10 +531,12 @@ impl SyntaxManager {
         match (&self.tree, &self.query) {
             (Some(tree), Some(query)) => {
                 if self.cache_version.get() != self.parse_version {
-                    self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+                    self.highlight_cache
+                        .replace(vec![None; self.line_start_bytes.len()]);
                     self.cache_version.set(self.parse_version);
                 } else if self.highlight_cache.borrow().len() != self.line_start_bytes.len() {
-                    self.highlight_cache.replace(vec![None; self.line_start_bytes.len()]);
+                    self.highlight_cache
+                        .replace(vec![None; self.line_start_bytes.len()]);
                     self.cache_version.set(self.parse_version);
                 }
 
@@ -591,7 +599,8 @@ impl SyntaxManager {
         let line_start = self.line_start_bytes[line];
 
         // Get the line content and convert character offset to byte offset
-        let line_end = self.line_start_bytes
+        let line_end = self
+            .line_start_bytes
             .get(line + 1)
             .copied()
             .unwrap_or(self.source_cache.len());
@@ -644,9 +653,9 @@ pub fn get_comment_string(language: Option<&str>) -> &'static str {
     match language {
         Some("rust") => "// ",
         Some("javascript") | Some("typescript") | Some("tsx") => "// ",
-        Some("css") | Some("scss") => "/* ",  // CSS only has block comments, but we use line-style
-        Some("json") => "// ",  // JSON doesn't support comments, but some tools allow //
-        Some("markdown") => "<!-- ",  // HTML-style for markdown
+        Some("css") | Some("scss") => "/* ", // CSS only has block comments, but we use line-style
+        Some("json") => "// ", // JSON doesn't support comments, but some tools allow //
+        Some("markdown") => "<!-- ", // HTML-style for markdown
         Some("python") => "# ",
         Some("bash") | Some("shell") => "# ",
         Some("lua") => "-- ",
@@ -654,7 +663,7 @@ pub fn get_comment_string(language: Option<&str>) -> &'static str {
         Some("go") | Some("c") | Some("cpp") | Some("java") | Some("swift") => "// ",
         Some("ruby") | Some("perl") => "# ",
         Some("html") | Some("xml") => "<!-- ",
-        _ => "// ",  // Default fallback
+        _ => "// ", // Default fallback
     }
 }
 

--- a/src/syntax/theme.rs
+++ b/src/syntax/theme.rs
@@ -11,7 +11,11 @@ pub struct SyntaxStyle {
 
 impl SyntaxStyle {
     pub fn new(fg: Color) -> Self {
-        Self { fg, bold: false, italic: false }
+        Self {
+            fg,
+            bold: false,
+            italic: false,
+        }
     }
 
     pub fn with_italic(mut self) -> Self {
@@ -103,27 +107,168 @@ impl Theme {
         let mut styles = HashMap::new();
 
         // One Dark inspired colors
-        styles.insert(HighlightGroup::Keyword, SyntaxStyle::new(Color::Rgb { r: 198, g: 120, b: 221 }));    // Purple
-        styles.insert(HighlightGroup::Function, SyntaxStyle::new(Color::Rgb { r: 97, g: 175, b: 239 }));    // Blue
-        styles.insert(HighlightGroup::Type, SyntaxStyle::new(Color::Rgb { r: 229, g: 192, b: 123 }));       // Yellow
-        styles.insert(HighlightGroup::String, SyntaxStyle::new(Color::Rgb { r: 152, g: 195, b: 121 }));     // Green
-        styles.insert(HighlightGroup::Number, SyntaxStyle::new(Color::Rgb { r: 209, g: 154, b: 102 }));     // Orange
-        styles.insert(HighlightGroup::Comment, SyntaxStyle::new(Color::Rgb { r: 92, g: 99, b: 112 }).with_italic());  // Gray, italic
-        styles.insert(HighlightGroup::Operator, SyntaxStyle::new(Color::Rgb { r: 86, g: 182, b: 194 }));    // Cyan
-        styles.insert(HighlightGroup::Punctuation, SyntaxStyle::new(Color::Rgb { r: 171, g: 178, b: 191 })); // Light gray
-        styles.insert(HighlightGroup::Variable, SyntaxStyle::new(Color::Rgb { r: 224, g: 108, b: 117 }));   // Red
-        styles.insert(HighlightGroup::Constant, SyntaxStyle::new(Color::Rgb { r: 209, g: 154, b: 102 }));   // Orange
-        styles.insert(HighlightGroup::Attribute, SyntaxStyle::new(Color::Rgb { r: 229, g: 192, b: 123 }));  // Yellow
-        styles.insert(HighlightGroup::Namespace, SyntaxStyle::new(Color::Rgb { r: 97, g: 175, b: 239 }));   // Blue
-        styles.insert(HighlightGroup::Label, SyntaxStyle::new(Color::Rgb { r: 224, g: 108, b: 117 }));      // Red
-        styles.insert(HighlightGroup::Property, SyntaxStyle::new(Color::Rgb { r: 224, g: 108, b: 117 }));   // Red
-        styles.insert(HighlightGroup::Tag, SyntaxStyle::new(Color::Rgb { r: 224, g: 108, b: 117 }));        // Red (JSX/HTML tags)
-        styles.insert(HighlightGroup::Embedded, SyntaxStyle::new(Color::Rgb { r: 86, g: 182, b: 194 }));    // Cyan (template string interpolations)
-        // New groups for improved Rust highlighting
-        styles.insert(HighlightGroup::Macro, SyntaxStyle::new(Color::Rgb { r: 86, g: 182, b: 194 }));       // Cyan
-        styles.insert(HighlightGroup::Method, SyntaxStyle::new(Color::Rgb { r: 97, g: 175, b: 239 }));      // Blue
-        styles.insert(HighlightGroup::Constructor, SyntaxStyle::new(Color::Rgb { r: 86, g: 182, b: 194 })); // Cyan
-        styles.insert(HighlightGroup::Boolean, SyntaxStyle::new(Color::Rgb { r: 209, g: 154, b: 102 }));    // Orange
+        styles.insert(
+            HighlightGroup::Keyword,
+            SyntaxStyle::new(Color::Rgb {
+                r: 198,
+                g: 120,
+                b: 221,
+            }),
+        ); // Purple
+        styles.insert(
+            HighlightGroup::Function,
+            SyntaxStyle::new(Color::Rgb {
+                r: 97,
+                g: 175,
+                b: 239,
+            }),
+        ); // Blue
+        styles.insert(
+            HighlightGroup::Type,
+            SyntaxStyle::new(Color::Rgb {
+                r: 229,
+                g: 192,
+                b: 123,
+            }),
+        ); // Yellow
+        styles.insert(
+            HighlightGroup::String,
+            SyntaxStyle::new(Color::Rgb {
+                r: 152,
+                g: 195,
+                b: 121,
+            }),
+        ); // Green
+        styles.insert(
+            HighlightGroup::Number,
+            SyntaxStyle::new(Color::Rgb {
+                r: 209,
+                g: 154,
+                b: 102,
+            }),
+        ); // Orange
+        styles.insert(
+            HighlightGroup::Comment,
+            SyntaxStyle::new(Color::Rgb {
+                r: 92,
+                g: 99,
+                b: 112,
+            })
+            .with_italic(),
+        ); // Gray, italic
+        styles.insert(
+            HighlightGroup::Operator,
+            SyntaxStyle::new(Color::Rgb {
+                r: 86,
+                g: 182,
+                b: 194,
+            }),
+        ); // Cyan
+        styles.insert(
+            HighlightGroup::Punctuation,
+            SyntaxStyle::new(Color::Rgb {
+                r: 171,
+                g: 178,
+                b: 191,
+            }),
+        ); // Light gray
+        styles.insert(
+            HighlightGroup::Variable,
+            SyntaxStyle::new(Color::Rgb {
+                r: 224,
+                g: 108,
+                b: 117,
+            }),
+        ); // Red
+        styles.insert(
+            HighlightGroup::Constant,
+            SyntaxStyle::new(Color::Rgb {
+                r: 209,
+                g: 154,
+                b: 102,
+            }),
+        ); // Orange
+        styles.insert(
+            HighlightGroup::Attribute,
+            SyntaxStyle::new(Color::Rgb {
+                r: 229,
+                g: 192,
+                b: 123,
+            }),
+        ); // Yellow
+        styles.insert(
+            HighlightGroup::Namespace,
+            SyntaxStyle::new(Color::Rgb {
+                r: 97,
+                g: 175,
+                b: 239,
+            }),
+        ); // Blue
+        styles.insert(
+            HighlightGroup::Label,
+            SyntaxStyle::new(Color::Rgb {
+                r: 224,
+                g: 108,
+                b: 117,
+            }),
+        ); // Red
+        styles.insert(
+            HighlightGroup::Property,
+            SyntaxStyle::new(Color::Rgb {
+                r: 224,
+                g: 108,
+                b: 117,
+            }),
+        ); // Red
+        styles.insert(
+            HighlightGroup::Tag,
+            SyntaxStyle::new(Color::Rgb {
+                r: 224,
+                g: 108,
+                b: 117,
+            }),
+        ); // Red (JSX/HTML tags)
+        styles.insert(
+            HighlightGroup::Embedded,
+            SyntaxStyle::new(Color::Rgb {
+                r: 86,
+                g: 182,
+                b: 194,
+            }),
+        ); // Cyan (template string interpolations)
+           // New groups for improved Rust highlighting
+        styles.insert(
+            HighlightGroup::Macro,
+            SyntaxStyle::new(Color::Rgb {
+                r: 86,
+                g: 182,
+                b: 194,
+            }),
+        ); // Cyan
+        styles.insert(
+            HighlightGroup::Method,
+            SyntaxStyle::new(Color::Rgb {
+                r: 97,
+                g: 175,
+                b: 239,
+            }),
+        ); // Blue
+        styles.insert(
+            HighlightGroup::Constructor,
+            SyntaxStyle::new(Color::Rgb {
+                r: 86,
+                g: 182,
+                b: 194,
+            }),
+        ); // Cyan
+        styles.insert(
+            HighlightGroup::Boolean,
+            SyntaxStyle::new(Color::Rgb {
+                r: 209,
+                g: 154,
+                b: 102,
+            }),
+        ); // Orange
 
         Self {
             name: "default".to_string(),
@@ -143,14 +288,12 @@ impl Theme {
 
     /// Get the style for a capture name
     pub fn get_style_for_capture(&self, capture_name: &str) -> Option<SyntaxStyle> {
-        HighlightGroup::from_capture_name(capture_name)
-            .and_then(|group| self.get_style(group))
+        HighlightGroup::from_capture_name(capture_name).and_then(|group| self.get_style(group))
     }
 
     /// Get the color for a capture name (for backwards compatibility)
     pub fn get_color_for_capture(&self, capture_name: &str) -> Option<Color> {
-        HighlightGroup::from_capture_name(capture_name)
-            .and_then(|group| self.get_color(group))
+        HighlightGroup::from_capture_name(capture_name).and_then(|group| self.get_color(group))
     }
 }
 
@@ -179,11 +322,20 @@ impl Theme {
         styles.insert(HighlightGroup::Number, convert(&ui_theme.syntax.number));
         styles.insert(HighlightGroup::Comment, convert(&ui_theme.syntax.comment));
         styles.insert(HighlightGroup::Operator, convert(&ui_theme.syntax.operator));
-        styles.insert(HighlightGroup::Punctuation, convert(&ui_theme.syntax.punctuation));
+        styles.insert(
+            HighlightGroup::Punctuation,
+            convert(&ui_theme.syntax.punctuation),
+        );
         styles.insert(HighlightGroup::Variable, convert(&ui_theme.syntax.variable));
         styles.insert(HighlightGroup::Constant, convert(&ui_theme.syntax.constant));
-        styles.insert(HighlightGroup::Attribute, convert(&ui_theme.syntax.attribute));
-        styles.insert(HighlightGroup::Namespace, convert(&ui_theme.syntax.namespace));
+        styles.insert(
+            HighlightGroup::Attribute,
+            convert(&ui_theme.syntax.attribute),
+        );
+        styles.insert(
+            HighlightGroup::Namespace,
+            convert(&ui_theme.syntax.namespace),
+        );
         styles.insert(HighlightGroup::Label, convert(&ui_theme.syntax.label));
         styles.insert(HighlightGroup::Property, convert(&ui_theme.syntax.property));
         styles.insert(HighlightGroup::Tag, convert(&ui_theme.syntax.tag));
@@ -191,7 +343,10 @@ impl Theme {
         // New groups
         styles.insert(HighlightGroup::Macro, convert(&ui_theme.syntax.macro_));
         styles.insert(HighlightGroup::Method, convert(&ui_theme.syntax.method));
-        styles.insert(HighlightGroup::Constructor, convert(&ui_theme.syntax.constructor));
+        styles.insert(
+            HighlightGroup::Constructor,
+            convert(&ui_theme.syntax.constructor),
+        );
         styles.insert(HighlightGroup::Boolean, convert(&ui_theme.syntax.boolean));
 
         Self {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6,9 +6,7 @@ use crossterm::{
         PushKeyboardEnhancementFlags,
     },
     execute, queue,
-    style::{
-        Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor,
-    },
+    style::{Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor},
     terminal::{self, ClearType},
 };
 use std::io::{self, Stdout, Write};
@@ -477,7 +475,9 @@ fn calculate_wrap_segments(
                 take_count += 1;
             }
 
-            let text: String = chars[current_col..current_col + take_count].iter().collect();
+            let text: String = chars[current_col..current_col + take_count]
+                .iter()
+                .collect();
 
             segments.push(WrapSegment {
                 start_col: current_col,
@@ -504,6 +504,7 @@ fn calculate_wrap_segments(
 pub struct Terminal {
     stdout: Stdout,
     mouse_capture_enabled: bool,
+    leader_popup_rect: Option<(u16, u16)>,
 }
 
 impl Terminal {
@@ -523,6 +524,7 @@ impl Terminal {
         Ok(Self {
             stdout,
             mouse_capture_enabled: false,
+            leader_popup_rect: None,
         })
     }
 
@@ -650,6 +652,14 @@ impl Terminal {
             self.render_command_line(editor)?;
         }
 
+        if self.leader_popup_rect.is_some() && editor.leader_popup_items().is_empty() {
+            if skip_background {
+                self.clear_leader_popup_area(editor)?;
+            } else {
+                self.leader_popup_rect = None;
+            }
+        }
+
         // Render finder if in finder mode
         if editor.mode == Mode::Finder {
             self.render_finder(editor)?;
@@ -697,6 +707,10 @@ impl Terminal {
             self.render_theme_picker(editor)?;
         }
 
+        if !editor.leader_popup_items().is_empty() {
+            self.render_leader_popup(editor)?;
+        }
+
         // Position cursor
         if editor.floating_terminal.is_visible() {
             self.render_floating_terminal(editor)?;
@@ -707,6 +721,138 @@ impl Terminal {
         }
 
         self.stdout.flush()?;
+        Ok(())
+    }
+
+    /// Render available leader-key continuations above the status line.
+    fn render_leader_popup(&mut self, editor: &Editor) -> anyhow::Result<()> {
+        let Some(prefix) = editor.leader_sequence.as_deref() else {
+            self.clear_leader_popup_area(editor)?;
+            return Ok(());
+        };
+
+        let items = editor.leader_popup_items();
+        if items.is_empty() {
+            self.clear_leader_popup_area(editor)?;
+            return Ok(());
+        }
+
+        let status_row = editor.term_height.saturating_sub(2);
+        if status_row == 0 {
+            return Ok(());
+        }
+
+        let term_width = editor.term_width as usize;
+        if term_width < 12 {
+            return Ok(());
+        }
+
+        let available_rows = status_row as usize;
+        if available_rows < 2 {
+            return Ok(());
+        }
+
+        let item_rows = items.len().min(8).min(available_rows.saturating_sub(1));
+        if item_rows == 0 {
+            self.clear_leader_popup_area(editor)?;
+            return Ok(());
+        }
+
+        let popup_top_row = status_row.saturating_sub((item_rows + 1) as u16);
+        self.leader_popup_rect = Some((popup_top_row, (item_rows + 1) as u16));
+
+        let prefix_label = if prefix.is_empty() {
+            "<leader>".to_string()
+        } else {
+            format!("<leader>{prefix}")
+        };
+        let header_text = format!("[LEADER {prefix_label}] Esc:cancel");
+
+        let key_col_width = term_width.saturating_sub(4).min(16).max(8);
+        let desc_col_width = term_width.saturating_sub(key_col_width + 3);
+
+        let theme = editor.theme();
+        let popup_fg = theme.ui.foreground;
+        let popup_bg = theme.ui.popup_bg;
+        let header_fg = theme.ui.statusline_mode_normal;
+        let header_bg = theme.ui.statusline_bg;
+
+        execute!(
+            self.stdout,
+            cursor::MoveTo(0, popup_top_row),
+            terminal::Clear(ClearType::CurrentLine),
+            SetForegroundColor(header_fg),
+            SetBackgroundColor(header_bg)
+        )?;
+        let mut header_line = Self::truncate_inline(&header_text, term_width);
+        let header_len = header_line.chars().count();
+        if header_len < term_width {
+            header_line.push_str(&" ".repeat(term_width - header_len));
+        }
+        print!("{}", header_line);
+        execute!(self.stdout, ResetColor)?;
+
+        for (row_offset, item) in items.iter().take(item_rows).enumerate() {
+            let row = popup_top_row + row_offset as u16 + 1;
+            execute!(
+                self.stdout,
+                cursor::MoveTo(0, row),
+                terminal::Clear(ClearType::CurrentLine),
+                SetForegroundColor(popup_fg),
+                SetBackgroundColor(popup_bg)
+            )?;
+
+            let key_raw = if item.has_children {
+                format!("{} +", item.key)
+            } else {
+                item.key.clone()
+            };
+            let mut desc_raw = if item.description == "prefix" {
+                "more...".to_string()
+            } else {
+                item.description.clone()
+            };
+            if item.is_exact && item.has_children && !desc_raw.is_empty() {
+                desc_raw.push_str(" (more)");
+            }
+
+            let key_text = Self::truncate_inline(&key_raw, key_col_width);
+            let desc_text = Self::truncate_inline(&desc_raw, desc_col_width);
+            let mut line = format!(
+                "  {:key_width$} {}",
+                key_text,
+                desc_text,
+                key_width = key_col_width
+            );
+
+            let printed = line.chars().count();
+            if printed < term_width {
+                line.push_str(&" ".repeat(term_width - printed));
+            } else if printed > term_width {
+                line = line.chars().take(term_width).collect();
+            }
+            print!("{}", line);
+            execute!(self.stdout, ResetColor)?;
+        }
+
+        Ok(())
+    }
+
+    fn clear_leader_popup_area(&mut self, editor: &Editor) -> anyhow::Result<()> {
+        let Some((top_row, rows)) = self.leader_popup_rect.take() else {
+            return Ok(());
+        };
+
+        let max_row = editor.term_height.saturating_sub(1);
+        let end_row = top_row.saturating_add(rows).min(max_row);
+        for row in top_row..end_row {
+            execute!(
+                self.stdout,
+                cursor::MoveTo(0, row),
+                terminal::Clear(ClearType::CurrentLine)
+            )?;
+        }
+        execute!(self.stdout, ResetColor)?;
         Ok(())
     }
 
@@ -1724,11 +1870,7 @@ impl Terminal {
                 current_italic = desired_italic;
             }
             if desired_underline_color != current_underline_color {
-                apply_diagnostic_underline(
-                    &mut self.stdout,
-                    desired_underline_color,
-                    desired_fg,
-                )?;
+                apply_diagnostic_underline(&mut self.stdout, desired_underline_color, desired_fg)?;
                 current_underline_color = desired_underline_color;
             }
 
@@ -2407,6 +2549,7 @@ impl Terminal {
                     Operator::Yank => 'y',
                     Operator::Indent => '>',
                     Operator::Dedent => '<',
+                    Operator::AutoIndent => '=',
                 });
             }
             if !s.is_empty() {
@@ -3712,7 +3855,10 @@ impl Terminal {
             "0/0".to_string()
         } else {
             let start = scroll.saturating_add(1).min(total_rows);
-            let end = scroll.saturating_add(visible_rows).min(total_rows).max(start);
+            let end = scroll
+                .saturating_add(visible_rows)
+                .min(total_rows)
+                .max(start);
             if start == end {
                 format!("{start}/{total_rows}")
             } else {
@@ -3772,8 +3918,7 @@ impl Terminal {
         let content_width = (popup_width - 4) as usize;
 
         // Position at the active pane's text area, below the cursor line.
-        let (popup_x, popup_y) =
-            Self::diagnostic_float_position(editor, popup_width, popup_height);
+        let (popup_x, popup_y) = Self::diagnostic_float_position(editor, popup_width, popup_height);
 
         // Colors
         let border_color = Color::Rgb {
@@ -4030,7 +4175,12 @@ impl Terminal {
             SetAttribute(Attribute::Reset),
             SetForegroundColor(theme.ui.foreground)
         )?;
-        write!(output, "{:width$}", "", width = width.saturating_sub(written))?;
+        write!(
+            output,
+            "{:width$}",
+            "",
+            width = width.saturating_sub(written)
+        )?;
         Ok(())
     }
 
@@ -5735,11 +5885,7 @@ impl Terminal {
                 current_italic = desired_italic;
             }
             if desired_underline_color != current_underline_color {
-                apply_diagnostic_underline(
-                    &mut self.stdout,
-                    desired_underline_color,
-                    desired_fg,
-                )?;
+                apply_diagnostic_underline(&mut self.stdout, desired_underline_color, desired_fg)?;
                 current_underline_color = desired_underline_color;
             }
 
@@ -6146,6 +6292,18 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
         editor.macros.record_key(key);
     }
 
+    if editor.pending_insert_normal_once && editor.mode == Mode::Normal {
+        handle_normal_mode(editor, key);
+        if !editor.input_state.has_pending_sequence() {
+            if editor.mode == Mode::Normal {
+                editor.finish_insert_normal_once();
+            } else {
+                editor.pending_insert_normal_once = false;
+            }
+        }
+        return;
+    }
+
     match editor.mode {
         Mode::Normal => handle_normal_mode(editor, key),
         Mode::Insert => handle_insert_mode(editor, key),
@@ -6295,6 +6453,7 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
                 Operator::Yank => editor.yank_motion(motion, count, register),
                 Operator::Indent => editor.indent_motion(motion, count),
                 Operator::Dedent => editor.dedent_motion(motion, count),
+                Operator::AutoIndent => editor.auto_indent_motion(motion, count),
             }
         }
 
@@ -6309,6 +6468,7 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
                 Operator::Yank => editor.yank_line(count, register),
                 Operator::Indent => editor.indent_line(count),
                 Operator::Dedent => editor.dedent_line(count),
+                Operator::AutoIndent => editor.auto_indent_line(count),
             }
         }
 
@@ -6323,6 +6483,7 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
                 Operator::Yank => editor.yank_text_object(text_object, register),
                 Operator::Indent => editor.indent_text_object(text_object),
                 Operator::Dedent => editor.dedent_text_object(text_object),
+                Operator::AutoIndent => editor.auto_indent_text_object(text_object),
             }
         }
 
@@ -6452,6 +6613,22 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.paste_before_count(register, count);
         }
 
+        KeyAction::PasteAfterMove(count) => {
+            let register = editor
+                .input_state
+                .take_register()
+                .or(register_before_action);
+            editor.paste_after_move_count(register, count);
+        }
+
+        KeyAction::PasteBeforeMove(count) => {
+            let register = editor
+                .input_state
+                .take_register()
+                .or(register_before_action);
+            editor.paste_before_move_count(register, count);
+        }
+
         KeyAction::Undo => {
             editor.undo();
         }
@@ -6518,6 +6695,14 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
 
         KeyAction::SearchWordBackward => {
             editor.search_word_backward();
+        }
+
+        KeyAction::SearchSelectNext(count) => {
+            editor.search_select_next(count);
+        }
+
+        KeyAction::SearchSelectPrev(count) => {
+            editor.search_select_prev(count);
         }
 
         KeyAction::EnterVisual => {
@@ -6594,9 +6779,43 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.move_to_pane_direction(PaneDirection::Down);
         }
 
+        KeyAction::WindowEqualize => {
+            editor.equalize_windows();
+        }
+
+        KeyAction::WindowRotateDownRight => {
+            editor.rotate_windows_down_right();
+        }
+
+        KeyAction::WindowRotateUpLeft => {
+            editor.rotate_windows_up_left();
+        }
+
+        KeyAction::WindowExchangeNext => {
+            editor.exchange_window_with_next();
+        }
+
         KeyAction::GotoDefinition => {
             editor.pending_lsp_action = Some(crate::editor::LspAction::GotoDefinition);
         }
+
+        KeyAction::GotoDeclaration => {
+            editor.pending_lsp_action = Some(crate::editor::LspAction::GotoDeclaration);
+        }
+
+        KeyAction::GotoImplementation => {
+            editor.pending_lsp_action = Some(crate::editor::LspAction::GotoImplementation);
+        }
+
+        KeyAction::GotoFile => match editor.open_file_under_cursor() {
+            Ok(path) => editor.set_status(format!("Opened {}", path.display())),
+            Err(err) => editor.set_status(err),
+        },
+
+        KeyAction::OpenUrl => match editor.open_url_under_cursor() {
+            Ok(url) => editor.set_status(format!("Opened {}", url)),
+            Err(err) => editor.set_status(err),
+        },
 
         KeyAction::Hover => {
             editor.pending_lsp_action = Some(crate::editor::LspAction::Hover);
@@ -6628,8 +6847,38 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
         }
 
         KeyAction::JumpToPreviousPosition => {
-            if !editor.jump_to_previous_position() {
+            if !editor.jump_to_previous_position_line() {
                 editor.set_status("No previous jump position");
+            }
+        }
+
+        KeyAction::JumpToPreviousPositionExact => {
+            if !editor.jump_to_previous_position_exact() {
+                editor.set_status("No previous jump position");
+            }
+        }
+
+        KeyAction::JumpToLastChange => {
+            if !editor.jump_to_last_change_line() {
+                editor.set_status("No last change position");
+            }
+        }
+
+        KeyAction::JumpToLastChangeExact => {
+            if !editor.jump_to_last_change_exact() {
+                editor.set_status("No last change position");
+            }
+        }
+
+        KeyAction::JumpToLastInsert => {
+            if !editor.jump_to_last_insert_line() {
+                editor.set_status("No previous insert position");
+            }
+        }
+
+        KeyAction::JumpToLastInsertExact => {
+            if !editor.jump_to_last_insert_exact() {
+                editor.set_status("No previous insert position");
             }
         }
 
@@ -6856,6 +7105,18 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
     // Apply custom keymap remapping for insert mode
     let key = editor.keymap.remap_insert(key);
 
+    if editor.pending_insert_register {
+        editor.pending_insert_register = false;
+        match (key.modifiers, key.code) {
+            (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {}
+            (_, KeyCode::Char(register)) => {
+                editor.insert_register_text(register);
+            }
+            _ => {}
+        }
+        return;
+    }
+
     // If completion popup is active, handle completion keys first
     if editor.completion.active {
         match (key.modifiers, key.code) {
@@ -7006,6 +7267,31 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
         // Delete to start of line (Ctrl+u)
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
             editor.delete_to_line_start();
+        }
+
+        // Increase indentation of current line (Ctrl+t)
+        (KeyModifiers::CONTROL, KeyCode::Char('t')) => {
+            editor.indent_current_line_in_insert_mode();
+        }
+
+        // Decrease indentation of current line (Ctrl+d)
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+            editor.dedent_current_line_in_insert_mode();
+        }
+
+        // Insert previously inserted text (Ctrl+a)
+        (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
+            editor.insert_last_inserted_text();
+        }
+
+        // Insert the contents of a register (Ctrl+r {register})
+        (KeyModifiers::CONTROL, KeyCode::Char('r')) => {
+            editor.pending_insert_register = true;
+        }
+
+        // Execute one normal-mode command, then return to insert mode (Ctrl+o)
+        (KeyModifiers::CONTROL, KeyCode::Char('o')) => {
+            editor.enter_insert_normal_once();
         }
 
         // Backspace
@@ -7470,6 +7756,9 @@ fn handle_visual_mode(editor: &mut Editor, key: KeyEvent) {
             (KeyModifiers::SHIFT, KeyCode::Char('B')) => Some(TextObjectType::Brace),
             (_, KeyCode::Char('[')) | (_, KeyCode::Char(']')) => Some(TextObjectType::Bracket),
             (_, KeyCode::Char('<')) | (_, KeyCode::Char('>')) => Some(TextObjectType::AngleBracket),
+            (KeyModifiers::NONE, KeyCode::Char('p')) => Some(TextObjectType::Paragraph),
+            (KeyModifiers::NONE, KeyCode::Char('s')) => Some(TextObjectType::Sentence),
+            (KeyModifiers::NONE, KeyCode::Char('t')) => Some(TextObjectType::Tag),
             _ => None,
         };
 
@@ -7623,6 +7912,12 @@ fn handle_visual_mode(editor: &mut Editor, key: KeyEvent) {
             editor.cursor.col = old_anchor_col;
             editor.scroll_to_cursor();
         }
+        (KeyModifiers::SHIFT, KeyCode::Char('O')) if editor.mode == Mode::VisualBlock => {
+            let old_anchor_col = editor.visual.anchor_col;
+            editor.visual.anchor_col = editor.cursor.col;
+            editor.cursor.col = old_anchor_col;
+            editor.scroll_to_cursor();
+        }
 
         // Text object selection (i = inner, a = around)
         (KeyModifiers::NONE, KeyCode::Char('i')) => {
@@ -7679,6 +7974,17 @@ fn execute_visual_keymap_action(editor: &mut Editor, action: &LeaderAction) {
     }
 }
 
+fn finder_preview_scroll_amount(editor: &Editor) -> usize {
+    let preview_enabled = editor.finder.preview_enabled && editor.finder.mode_supports_preview();
+    let win = crate::finder::FloatingWindow::centered_with_preview(
+        editor.term_width,
+        editor.term_height,
+        preview_enabled,
+    );
+    let visible_rows = win.height.saturating_sub(4) as usize;
+    (visible_rows / 2).max(1)
+}
+
 fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
     let t_start = Instant::now();
 
@@ -7709,6 +8015,18 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
                 // Mark preview as needing immediate update (skip debounce on toggle)
                 editor.update_finder_preview();
             }
+        }
+
+        // Scroll preview panel down - Ctrl+d (works in both modes)
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+            let amount = finder_preview_scroll_amount(editor);
+            editor.finder.scroll_preview_down(amount);
+        }
+
+        // Scroll preview panel up - Ctrl+u (works in both modes)
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            let amount = finder_preview_scroll_amount(editor);
+            editor.finder.scroll_preview_up(amount);
         }
 
         // Cancel finder - Ctrl+c always closes
@@ -8781,6 +9099,15 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
+        Command::BufferDelete(force) => {
+            if !force && editor.has_unsaved_changes() {
+                CommandResult::Error("No write since last change (add ! to override)".to_string())
+            } else {
+                editor.close_current_buffer();
+                CommandResult::Message("Buffer deleted".to_string())
+            }
+        }
+
         Command::Set(option, _value) => CommandResult::Error(format!("Unknown option: {}", option)),
 
         Command::LazyGit => CommandResult::RunExternal("lazygit".to_string()),
@@ -9184,6 +9511,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
 
 /// Execute a leader key action
 pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
+    editor.leader_sequence = None;
+    editor.leader_sequence_start = None;
+    editor.leader_pending_action = None;
+
     match action {
         LeaderAction::Command(cmd_str) => {
             // Parse and execute the command
@@ -9203,12 +9534,13 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 mod tests {
     use super::{
         apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
-        Terminal,
+        execute_leader_action, finder_preview_match_ranges, handle_insert_mode, handle_key,
+        replace_completion_text, Terminal,
     };
     use crate::commands::Command;
     use crate::config::{KeymapEntry, Settings};
     use crate::editor::{Editor, Mode, RegisterContent};
+    use crate::finder::FinderMode;
     use crate::input::Motion;
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -9230,6 +9562,10 @@ mod tests {
 
     fn esc_key() -> KeyEvent {
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+    }
+
+    fn numbered_lines(count: usize) -> Vec<String> {
+        (1..=count).map(|line| format!("line {}", line)).collect()
     }
 
     #[test]
@@ -9456,7 +9792,10 @@ mod tests {
         editor.replace_buffer_content(&(0..30).map(|i| format!("line {i}\n")).collect::<String>());
         editor.open_markdown_preview().expect("open preview");
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE),
+        );
         assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 1);
 
         handle_key(
@@ -9465,7 +9804,10 @@ mod tests {
         );
         assert!(editor.markdown_preview.as_ref().unwrap().scroll > 1);
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE),
+        );
         assert!(editor.markdown_preview.is_none());
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -9484,7 +9826,10 @@ mod tests {
         editor.replace_buffer_content(&(0..50).map(|i| format!("line {i}\n")).collect::<String>());
         editor.open_markdown_preview().expect("open preview");
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::NONE),
+        );
         let visible_rows = Terminal::markdown_preview_visible_rows(&editor).max(1);
         let max_scroll = editor
             .markdown_preview
@@ -9493,7 +9838,10 @@ mod tests {
             .max_scroll(visible_rows);
         assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, max_scroll);
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE),
+        );
         assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 0);
 
         let _ = std::fs::remove_dir_all(&tmp);
@@ -9570,6 +9918,53 @@ mod tests {
 
         assert_eq!(popup_x, active_pane.rect.x + 2 + line_num_width + 1 + 4);
         assert_eq!(popup_y, active_pane.rect.y + 2);
+    }
+
+    #[test]
+    fn normal_ctrl_w_equal_equalizes_windows() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("split");
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('='));
+
+        assert_eq!(editor.panes().len(), 2);
+        assert_eq!(editor.status_message.as_deref(), Some("Windows equalized"));
+    }
+
+    #[test]
+    fn normal_ctrl_w_r_and_shift_r_rotate_windows() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("first split");
+        editor.vsplit(None).expect("second split");
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('r'));
+
+        assert_eq!(editor.status_message.as_deref(), Some("Windows rotated"));
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, shift_key('R'));
+
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Windows rotated reverse")
+        );
+    }
+
+    #[test]
+    fn normal_ctrl_w_x_exchanges_window() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("first split");
+        editor.vsplit(None).expect("second split");
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('x'));
+
+        assert_eq!(editor.status_message.as_deref(), Some("Windows exchanged"));
     }
 
     #[test]
@@ -9654,6 +10049,44 @@ mod tests {
     }
 
     #[test]
+    fn buffer_delete_closes_clean_buffer_and_refuses_dirty_buffer_without_force() {
+        let tmp = unique_temp_dir("nevi_buffer_delete");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let dirty = tmp.join("dirty.rs");
+        let clean = tmp.join("clean.rs");
+        std::fs::write(&dirty, "fn dirty() {}\n").expect("write dirty");
+        std::fs::write(&clean, "fn clean() {}\n").expect("write clean");
+
+        let mut editor = Editor::default();
+        editor.open_file(dirty.clone()).expect("open dirty");
+        editor.buffer_mut().insert_char(0, 0, 'x');
+        editor.open_file(clean.clone()).expect("open clean");
+        assert_eq!(editor.buffer_count(), 2);
+
+        execute_command(&mut editor, Command::BufferDelete(false));
+
+        assert_eq!(editor.buffer_count(), 1);
+        assert_eq!(editor.buffer().path.as_ref(), Some(&dirty));
+
+        execute_command(&mut editor, Command::BufferDelete(false));
+
+        assert_eq!(editor.buffer_count(), 1);
+        assert_eq!(editor.buffer().path.as_ref(), Some(&dirty));
+        assert!(editor
+            .status_message
+            .as_deref()
+            .unwrap_or_default()
+            .contains("No write since last change"));
+
+        execute_command(&mut editor, Command::BufferDelete(true));
+
+        assert_eq!(editor.buffer_count(), 1);
+        assert!(editor.buffer().path.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn active_completion_prefix_changes_request_lsp_refresh() {
         let mut editor = Editor::default();
         editor.replace_buffer_content("us\n");
@@ -9669,6 +10102,36 @@ mod tests {
         assert_eq!(editor.buffer().content(), "usE\n");
         assert_eq!(editor.completion.filter_text, "usE");
         assert!(editor.needs_completion_refresh);
+    }
+
+    #[test]
+    fn insert_ctrl_t_indents_current_line_and_keeps_insert_position() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("  alpha\nbeta\n");
+        editor.mode = Mode::Insert;
+        editor.cursor.line = 0;
+        editor.cursor.col = 7;
+
+        handle_insert_mode(&mut editor, ctrl_key('t'));
+
+        assert_eq!(editor.buffer().content(), "      alpha\nbeta\n");
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 11));
+    }
+
+    #[test]
+    fn insert_ctrl_d_dedents_current_line_and_keeps_insert_position() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("      alpha\nbeta\n");
+        editor.mode = Mode::Insert;
+        editor.cursor.line = 0;
+        editor.cursor.col = 11;
+
+        handle_insert_mode(&mut editor, ctrl_key('d'));
+
+        assert_eq!(editor.buffer().content(), "  alpha\nbeta\n");
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 7));
     }
 
     #[test]
@@ -9712,7 +10175,10 @@ mod tests {
         assert_eq!(editor.finder.cursor, 1);
         assert_eq!(editor.finder.selected, 0);
         assert_eq!(
-            editor.finder.selected_item().map(|item| item.display.as_str()),
+            editor
+                .finder
+                .selected_item()
+                .map(|item| item.display.as_str()),
             Some("2: beta.rs")
         );
 
@@ -9758,6 +10224,30 @@ mod tests {
     }
 
     #[test]
+    fn finder_preview_ctrl_d_and_ctrl_u_scroll_preview_without_changing_query_or_selection() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 30);
+        editor.finder.open_harpoon(vec![PathBuf::from("alpha.rs")]);
+        editor.mode = Mode::Finder;
+        editor.finder.preview_enabled = true;
+        editor
+            .finder
+            .set_preview_content(PathBuf::from("alpha.rs"), numbered_lines(40));
+
+        handle_key(&mut editor, ctrl_key('d'));
+
+        assert_eq!(editor.finder.preview_scroll, 8);
+        assert_eq!(editor.finder.query, "");
+        assert_eq!(editor.finder.selected, 0);
+
+        handle_key(&mut editor, ctrl_key('u'));
+
+        assert_eq!(editor.finder.preview_scroll, 0);
+        assert_eq!(editor.finder.query, "");
+        assert_eq!(editor.finder.selected, 0);
+    }
+
+    #[test]
     fn finder_enter_opens_selected_buffer_item() {
         let tmp = unique_temp_dir("nevi_finder_buffer_select");
         std::fs::create_dir_all(&tmp).expect("create temp dir");
@@ -9772,7 +10262,10 @@ mod tests {
         assert_eq!(editor.current_buffer_index(), 1);
 
         editor.open_finder_buffers();
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
 
         assert_eq!(editor.mode, Mode::Normal);
         assert_eq!(editor.current_buffer_index(), 0);
@@ -9788,13 +10281,19 @@ mod tests {
         std::fs::write(&path, "fn changed() {}\n").expect("write file");
 
         let mut editor = Editor::default();
-        editor.finder.open_git_changes(vec![
-            crate::finder::FinderItem::new("M changed.rs".to_string(), path.clone())
-                .with_git_status(crate::git::GitFileStatus::Modified),
-        ]);
+        editor
+            .finder
+            .open_git_changes(vec![crate::finder::FinderItem::new(
+                "M changed.rs".to_string(),
+                path.clone(),
+            )
+            .with_git_status(crate::git::GitFileStatus::Modified)]);
         editor.mode = Mode::Finder;
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
 
         assert_eq!(editor.mode, Mode::Normal);
         assert_eq!(editor.buffer().path.as_ref(), Some(&path));
@@ -9809,18 +10308,173 @@ mod tests {
         let path = tmp.join("deleted.rs");
 
         let mut editor = Editor::default();
-        editor.finder.open_git_changes(vec![
-            crate::finder::FinderItem::new("D deleted.rs".to_string(), path)
-                .with_git_status(crate::git::GitFileStatus::Deleted),
-        ]);
+        editor
+            .finder
+            .open_git_changes(vec![crate::finder::FinderItem::new(
+                "D deleted.rs".to_string(),
+                path,
+            )
+            .with_git_status(crate::git::GitFileStatus::Deleted)]);
         editor.mode = Mode::Finder;
 
-        handle_key(&mut editor, KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
 
         assert_eq!(editor.mode, Mode::Normal);
         assert_eq!(editor.status_message.as_deref(), Some("File was deleted"));
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_gf_opens_file_under_cursor_relative_to_current_file() {
+        let tmp = unique_temp_dir("nevi_gf_file_under_cursor");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let current = tmp.join("current.txt");
+        let target = tmp.join("target.txt");
+        std::fs::write(&current, "open target.txt now\n").expect("write current");
+        std::fs::write(&target, "target file\n").expect("write target");
+
+        let mut editor = Editor::default();
+        editor.open_file(current.clone()).expect("open current");
+        editor.cursor.line = 0;
+        editor.cursor.col = 7;
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('f'));
+
+        assert_eq!(editor.buffer().path.as_ref(), Some(&target));
+        assert_eq!(editor.buffer().content(), "target file\n");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_gx_reports_missing_url_under_cursor() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("not a url\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 2;
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('x'));
+
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("No URL under cursor")
+        );
+    }
+
+    #[test]
+    fn normal_g_shift_d_sets_goto_declaration_lsp_action() {
+        let mut editor = Editor::default();
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, shift_key('D'));
+
+        assert_eq!(
+            format!("{:?}", editor.pending_lsp_action),
+            "Some(GotoDeclaration)"
+        );
+    }
+
+    #[test]
+    fn normal_g_shift_i_sets_goto_implementation_lsp_action() {
+        let mut editor = Editor::default();
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, shift_key('I'));
+
+        assert_eq!(
+            format!("{:?}", editor.pending_lsp_action),
+            "Some(GotoImplementation)"
+        );
+    }
+
+    #[test]
+    fn normal_apostrophe_apostrophe_jumps_to_previous_jump_line_first_non_blank() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  previous spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.previous_jump_position = Some((None, 1, 11));
+
+        handle_key(&mut editor, key('\''));
+        handle_key(&mut editor, key('\''));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
+    }
+
+    #[test]
+    fn normal_backtick_backtick_jumps_to_previous_jump_exact_position() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  previous spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.previous_jump_position = Some((None, 1, 11));
+
+        handle_key(&mut editor, key('`'));
+        handle_key(&mut editor, key('`'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 11));
+    }
+
+    #[test]
+    fn normal_apostrophe_dot_jumps_to_last_change_line_first_non_blank() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  changed spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.change_list.record(1, 10);
+
+        handle_key(&mut editor, key('\''));
+        handle_key(&mut editor, key('.'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
+    }
+
+    #[test]
+    fn normal_backtick_dot_jumps_to_last_change_exact_position() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  changed spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.change_list.record(1, 10);
+
+        handle_key(&mut editor, key('`'));
+        handle_key(&mut editor, key('.'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 10));
+    }
+
+    #[test]
+    fn normal_apostrophe_caret_jumps_to_last_insert_line_first_non_blank() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  insert spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.last_insert_position = Some((1, 10));
+
+        handle_key(&mut editor, key('\''));
+        handle_key(&mut editor, key('^'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
+    }
+
+    #[test]
+    fn normal_backtick_caret_jumps_to_last_insert_exact_position() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("current\n  insert spot\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+        editor.last_insert_position = Some((1, 10));
+
+        handle_key(&mut editor, key('`'));
+        handle_key(&mut editor, key('^'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 10));
     }
 
     #[test]
@@ -9836,11 +10490,17 @@ mod tests {
         editor.open_finder_harpoon();
         editor.finder.selected = 1;
         handle_key(&mut editor, shift_key('K'));
-        assert_eq!(editor.harpoon.files(), [two.clone(), one.clone(), three.clone()]);
+        assert_eq!(
+            editor.harpoon.files(),
+            [two.clone(), one.clone(), three.clone()]
+        );
         assert_eq!(editor.finder.selected, 0);
 
         handle_key(&mut editor, shift_key('J'));
-        assert_eq!(editor.harpoon.files(), [one.clone(), two.clone(), three.clone()]);
+        assert_eq!(
+            editor.harpoon.files(),
+            [one.clone(), two.clone(), three.clone()]
+        );
         assert_eq!(editor.finder.selected, 1);
 
         handle_key(&mut editor, key('d'));
@@ -9868,6 +10528,200 @@ mod tests {
         handle_key(&mut editor, key('x'));
 
         assert_eq!(editor.buffer().content(), "d\n");
+    }
+
+    #[test]
+    fn normal_plus_minus_move_to_first_non_blank_on_target_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("zero\n    one\n  two\nthree\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 2;
+
+        handle_key(&mut editor, key('+'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+
+        handle_key(&mut editor, key('+'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 2));
+
+        handle_key(&mut editor, key('-'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+
+        let mut counted = Editor::default();
+        counted.replace_buffer_content("zero\n    one\n  two\nthree\n");
+        counted.cursor.line = 0;
+        counted.cursor.col = 2;
+
+        handle_key(&mut counted, key('2'));
+        handle_key(&mut counted, key('+'));
+
+        assert_eq!((counted.cursor.line, counted.cursor.col), (2, 2));
+    }
+
+    #[test]
+    fn normal_gj_gk_move_by_wrapped_display_lines() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 12);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 5;
+        editor.settings.editor.line_numbers = false;
+        editor.replace_buffer_content("abcdefghij\nklmno\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 1;
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('j'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 6));
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('j'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 1));
+
+        handle_key(&mut editor, key('2'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('k'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+    }
+
+    #[test]
+    fn normal_g0_g_dollar_g_caret_target_current_wrapped_row() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 12);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 5;
+        editor.settings.editor.line_numbers = false;
+        editor.replace_buffer_content("  abcdefghij\n");
+        editor.cursor.line = 0;
+
+        editor.cursor.col = 6;
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('0'));
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+
+        editor.cursor.col = 6;
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('$'));
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 7));
+
+        editor.cursor.col = 6;
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('^'));
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+    }
+
+    #[test]
+    fn normal_equal_equal_auto_indents_current_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("fn main() {\nprintln!(\"hi\");\n}\n");
+        editor.cursor.line = 1;
+
+        handle_key(&mut editor, key('='));
+        handle_key(&mut editor, key('='));
+
+        assert_eq!(
+            editor.buffer().content(),
+            "fn main() {\n    println!(\"hi\");\n}\n"
+        );
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+    }
+
+    #[test]
+    fn normal_equal_motion_auto_indents_motion_line_range() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(
+            "fn main() {\nprintln!(\"hi\");\nif true {\nprintln!(\"nested\");\n}\n}\n",
+        );
+        editor.cursor.line = 1;
+
+        handle_key(&mut editor, key('='));
+        handle_key(&mut editor, key('j'));
+
+        assert_eq!(
+            editor.buffer().content(),
+            "fn main() {\n    println!(\"hi\");\n    if true {\nprintln!(\"nested\");\n}\n}\n"
+        );
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+    }
+
+    #[test]
+    fn normal_gn_selects_next_search_match() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha target beta\ntarget gamma\n");
+        editor.search.last_pattern = Some("target".to_string());
+        editor.cursor.line = 0;
+        editor.cursor.col = 0;
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('n'));
+
+        assert_eq!(editor.mode, Mode::Visual);
+        assert_eq!(editor.get_visual_range(), (0, 6, 0, 11));
+
+        handle_key(&mut editor, key('y'));
+
+        assert_eq!(
+            editor.registers.get(None),
+            Some(&RegisterContent::Chars("target".to_string()))
+        );
+    }
+
+    #[test]
+    fn normal_g_shift_n_selects_previous_search_match() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("target alpha\nmiddle\ngamma target\n");
+        editor.search.last_pattern = Some("target".to_string());
+        editor.cursor.line = 1;
+        editor.cursor.col = 0;
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, shift_key('N'));
+
+        assert_eq!(editor.mode, Mode::Visual);
+        assert_eq!(editor.get_visual_range(), (0, 0, 0, 5));
+
+        handle_key(&mut editor, key('y'));
+
+        assert_eq!(
+            editor.registers.get(None),
+            Some(&RegisterContent::Chars("target".to_string()))
+        );
+    }
+
+    #[test]
+    fn normal_paren_motions_move_between_sentence_starts() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("First sentence. Second sentence! Third sentence?\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 3;
+
+        handle_key(&mut editor, key(')'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 16));
+
+        handle_key(&mut editor, key(')'));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 33));
+
+        handle_key(&mut editor, key('('));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 16));
+
+        handle_key(&mut editor, key('('));
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+
+        let mut counted = Editor::default();
+        counted.replace_buffer_content("First sentence. Second sentence! Third sentence?\n");
+
+        handle_key(&mut counted, key('2'));
+        handle_key(&mut counted, key(')'));
+
+        assert_eq!((counted.cursor.line, counted.cursor.col), (0, 33));
     }
 
     #[test]
@@ -10017,14 +10871,20 @@ mod tests {
 
         handle_key(&mut editor, key('v'));
         assert_eq!(editor.mode, Mode::Visual);
-        assert_eq!((editor.visual.anchor_line, editor.visual.anchor_col), (0, 0));
+        assert_eq!(
+            (editor.visual.anchor_line, editor.visual.anchor_col),
+            (0, 0)
+        );
 
         handle_key(&mut editor, key('l'));
         assert_eq!(editor.get_visual_range(), (0, 0, 0, 1));
 
         handle_key(&mut editor, key('o'));
         assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
-        assert_eq!((editor.visual.anchor_line, editor.visual.anchor_col), (0, 1));
+        assert_eq!(
+            (editor.visual.anchor_line, editor.visual.anchor_col),
+            (0, 1)
+        );
         assert_eq!(editor.get_visual_range(), (0, 0, 0, 1));
 
         handle_key(&mut editor, esc_key());
@@ -10047,6 +10907,34 @@ mod tests {
         assert_eq!(editor.mode, Mode::VisualBlock);
         handle_key(&mut editor, ctrl_key('v'));
         assert_eq!(editor.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn visual_block_shift_o_moves_to_other_corner_on_cursor_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("abcd\nefgh\n");
+
+        handle_key(&mut editor, ctrl_key('v'));
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('l'));
+        handle_key(&mut editor, key('l'));
+        assert_eq!(editor.mode, Mode::VisualBlock);
+        assert_eq!(
+            (editor.visual.anchor_line, editor.visual.anchor_col),
+            (0, 0)
+        );
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
+        assert_eq!(editor.get_visual_range(), (0, 0, 1, 2));
+
+        handle_key(&mut editor, shift_key('O'));
+
+        assert_eq!(editor.mode, Mode::VisualBlock);
+        assert_eq!(
+            (editor.visual.anchor_line, editor.visual.anchor_col),
+            (0, 2)
+        );
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+        assert_eq!(editor.get_visual_range(), (0, 0, 1, 2));
     }
 
     #[test]
@@ -10195,6 +11083,170 @@ mod tests {
     }
 
     #[test]
+    fn normal_dip_deletes_inner_paragraph_without_blank_separator() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("one\n\ntwo\nthree\n\nfour\n");
+        editor.cursor.line = 2;
+        editor.cursor.col = 1;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "one\n\n\nfour\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+    }
+
+    #[test]
+    fn normal_dap_deletes_paragraph_and_following_blank_separator() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("one\n\ntwo\nthree\n\nfour\n");
+        editor.cursor.line = 2;
+        editor.cursor.col = 1;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "one\n\nfour\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+    }
+
+    #[test]
+    fn normal_dis_deletes_inner_sentence_without_separator() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("Alpha one. Beta two! Gamma three?\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 14;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('s'));
+
+        assert_eq!(editor.buffer().content(), "Alpha one.  Gamma three?\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 11));
+    }
+
+    #[test]
+    fn normal_das_deletes_sentence_and_following_separator() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("Alpha one. Beta two! Gamma three?\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 14;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('s'));
+
+        assert_eq!(editor.buffer().content(), "Alpha one. Gamma three?\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 11));
+    }
+
+    #[test]
+    fn visual_is_selects_and_yanks_inner_sentence() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("Alpha one. Beta two! Gamma three?\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 14;
+
+        handle_key(&mut editor, key('v'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('s'));
+        handle_key(&mut editor, key('y'));
+
+        assert_eq!(
+            editor.registers.get(None),
+            Some(&RegisterContent::Chars("Beta two!".to_string()))
+        );
+        assert_eq!(editor.mode, Mode::Normal);
+    }
+
+    #[test]
+    fn normal_dit_deletes_inner_tag_text_object_with_attributes() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(
+            "before <div class=\"x\">hello <span>world</span></div> after\n",
+        );
+        editor.cursor.line = 0;
+        editor.cursor.col = 24;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('t'));
+
+        assert_eq!(
+            editor.buffer().content(),
+            "before <div class=\"x\"></div> after\n"
+        );
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 22));
+    }
+
+    #[test]
+    fn normal_dat_deletes_around_tag_text_object_with_attributes() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(
+            "before <div class=\"x\">hello <span>world</span></div> after\n",
+        );
+        editor.cursor.line = 0;
+        editor.cursor.col = 24;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('t'));
+
+        assert_eq!(editor.buffer().content(), "before  after\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 7));
+    }
+
+    #[test]
+    fn normal_dit_prefers_nearest_nested_same_name_tag_text_object() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("<div>outer <div>inner</div> tail</div>\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 18;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('t'));
+
+        assert_eq!(
+            editor.buffer().content(),
+            "<div>outer <div></div> tail</div>\n"
+        );
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 16));
+    }
+
+    #[test]
+    fn visual_it_yanks_inner_tag_text_object() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(
+            "before <div class=\"x\">hello <span>world</span></div> after\n",
+        );
+        editor.cursor.line = 0;
+        editor.cursor.col = 24;
+
+        handle_key(&mut editor, key('v'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('t'));
+        handle_key(&mut editor, key('y'));
+
+        assert_eq!(
+            editor.registers.get(None),
+            Some(&RegisterContent::Chars(
+                "hello <span>world</span>".to_string()
+            ))
+        );
+        assert_eq!(editor.mode, Mode::Normal);
+    }
+
+    #[test]
     fn change_text_object_keeps_insert_point_at_deleted_word_start() {
         let mut editor = Editor::default();
         editor.replace_buffer_content("foo bar\n");
@@ -10255,6 +11307,294 @@ mod tests {
         handle_key(&mut editor, key('p'));
 
         assert_eq!(editor.buffer().content(), "axxxb\n");
+    }
+
+    #[test]
+    fn normal_quote_percent_pastes_current_filename() {
+        let tmp = unique_temp_dir("nevi_current_filename_register");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("current.txt");
+        std::fs::write(&path, "x\n").expect("write current file");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open current file");
+        editor.cursor.line = 0;
+        editor.cursor.col = 0;
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('%'));
+        handle_key(&mut editor, key('p'));
+
+        let expected = format!("x{}\n", path.to_string_lossy());
+        assert_eq!(editor.buffer().content(), expected);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_quote_colon_pastes_last_command() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n");
+        editor.command_line.history = vec!["write".to_string(), "buffers".to_string()];
+        editor.cursor.line = 0;
+        editor.cursor.col = 0;
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key(':'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "xbuffers\n");
+    }
+
+    #[test]
+    fn normal_quote_hash_pastes_alternate_filename() {
+        let tmp = unique_temp_dir("nevi_alternate_filename_register");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "x\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first.clone()).expect("open first");
+        editor.open_file(second).expect("open second");
+        editor.cursor.line = 0;
+        editor.cursor.col = 0;
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('#'));
+        handle_key(&mut editor, key('p'));
+
+        let expected = format!("x{}\n", first.to_string_lossy());
+        assert_eq!(editor.buffer().content(), expected);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_quote_dot_pastes_last_inserted_text() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n\n");
+
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('n'));
+        handle_key(&mut editor, key('e'));
+        handle_key(&mut editor, key('v'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, esc_key());
+
+        editor.cursor.line = 1;
+        editor.cursor.col = 0;
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('.'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "nevix\nnevi\n");
+    }
+
+    #[test]
+    fn insert_ctrl_a_inserts_previously_inserted_text() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n\n");
+
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, key('n'));
+        handle_key(&mut editor, key('e'));
+        handle_key(&mut editor, key('v'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, esc_key());
+
+        editor.cursor.line = 1;
+        editor.cursor.col = 0;
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, ctrl_key('a'));
+
+        assert_eq!(editor.buffer().content(), "nevix\nnevi\n");
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+    }
+
+    #[test]
+    fn insert_ctrl_r_inserts_named_register_text() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n");
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Chars("nevi".to_string()));
+
+        handle_key(&mut editor, shift_key('A'));
+        handle_key(&mut editor, ctrl_key('r'));
+        handle_key(&mut editor, key('a'));
+
+        assert_eq!(editor.buffer().content(), "xnevi\n");
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+    }
+
+    #[test]
+    fn insert_ctrl_o_runs_one_normal_command_then_returns_to_insert() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("abc\n");
+
+        handle_key(&mut editor, shift_key('A'));
+        handle_key(&mut editor, ctrl_key('o'));
+        handle_key(&mut editor, key('0'));
+
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+
+        handle_key(&mut editor, shift_key('X'));
+
+        assert_eq!(editor.buffer().content(), "Xabc\n");
+        assert_eq!(editor.mode, Mode::Insert);
+    }
+
+    #[test]
+    fn normal_gp_pastes_after_and_leaves_cursor_after_pasted_text() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("ab\n");
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Chars("xy".to_string()));
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "axyb\n");
+        assert_eq!(editor.cursor.col, 3);
+    }
+
+    #[test]
+    fn normal_g_shift_p_pastes_before_and_leaves_cursor_after_pasted_text() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("ab\n");
+        editor.cursor.col = 1;
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Chars("xy".to_string()));
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, shift_key('P'));
+
+        assert_eq!(editor.buffer().content(), "axyb\n");
+        assert_eq!(editor.cursor.col, 3);
+    }
+
+    #[test]
+    fn normal_gp_linewise_paste_leaves_cursor_after_inserted_block() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("aa\nbb\ncc\n");
+        editor.cursor.line = 1;
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Lines("xx\n".to_string()));
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "aa\nbb\nxx\ncc\n");
+        assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+    }
+
+    #[test]
+    fn normal_g_shift_p_linewise_paste_leaves_cursor_after_inserted_block() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("aa\nbb\ncc\n");
+        editor.cursor.line = 1;
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Lines("xx\n".to_string()));
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, shift_key('P'));
+
+        assert_eq!(editor.buffer().content(), "aa\nxx\nbb\ncc\n");
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+    }
+
+    #[test]
+    fn normal_leader_popup_items_follow_current_prefix() {
+        let mut editor = Editor::default();
+
+        handle_key(&mut editor, key(' '));
+
+        assert_eq!(editor.leader_sequence.as_deref(), Some(""));
+        let root_items = editor.leader_popup_items();
+        assert!(root_items
+            .iter()
+            .any(|item| item.key == "f" && item.has_children));
+        assert!(root_items
+            .iter()
+            .any(|item| item.key == "w" && item.description == "Save file"));
+
+        handle_key(&mut editor, key('f'));
+
+        assert_eq!(editor.leader_sequence.as_deref(), Some("f"));
+        let file_items = editor.leader_popup_items();
+        assert!(file_items
+            .iter()
+            .any(|item| item.key == "f" && item.sequence == "ff"));
+        assert!(file_items
+            .iter()
+            .any(|item| item.key == "k" && item.description == "Search keymaps"));
+    }
+
+    #[test]
+    fn normal_leader_popup_items_respect_config_toggle() {
+        let mut editor = Editor::default();
+        editor.settings.keymap.show_leader_popup = false;
+
+        handle_key(&mut editor, key(' '));
+
+        assert_eq!(editor.leader_sequence.as_deref(), Some(""));
+        assert!(editor.leader_popup_items().is_empty());
+    }
+
+    #[test]
+    fn leader_popup_items_are_hidden_while_finder_owns_ui() {
+        let mut editor = Editor::default();
+        editor.mode = Mode::Finder;
+        editor.leader_sequence = Some("f".to_string());
+
+        assert!(editor.leader_popup_items().is_empty());
+    }
+
+    #[test]
+    fn normal_leader_mapping_clears_popup_state_when_opening_finder() {
+        let mut editor = Editor::default();
+
+        handle_key(&mut editor, key(' '));
+        handle_key(&mut editor, key('f'));
+        handle_key(&mut editor, key('f'));
+
+        assert_eq!(editor.mode, Mode::Finder);
+        assert_eq!(editor.finder.mode, FinderMode::Files);
+        assert!(editor.leader_sequence.is_none());
+        assert!(editor.leader_popup_items().is_empty());
+    }
+
+    #[test]
+    fn executing_leader_action_clears_stale_popup_state() {
+        let mut editor = Editor::default();
+        editor.leader_sequence = Some("f".to_string());
+        editor.leader_sequence_start = Some(std::time::Instant::now());
+        editor.leader_pending_action = editor.keymap.get_leader_action("f").cloned();
+        let action = editor.keymap.get_leader_action("ff").cloned().unwrap();
+
+        execute_leader_action(&mut editor, &action);
+
+        assert_eq!(editor.mode, Mode::Finder);
+        assert_eq!(editor.finder.mode, FinderMode::Files);
+        assert!(editor.leader_sequence.is_none());
+        assert!(editor.leader_popup_items().is_empty());
     }
 
     #[test]

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -200,26 +200,30 @@ fn parse_hex_color(s: &str) -> Option<Color> {
 }
 
 /// Parse a style from TOML
-fn parse_style(style_toml: &Option<StyleToml>, palette: &HashMap<String, String>, default: StyleDef) -> StyleDef {
+fn parse_style(
+    style_toml: &Option<StyleToml>,
+    palette: &HashMap<String, String>,
+    default: StyleDef,
+) -> StyleDef {
     match style_toml {
-        Some(s) => {
-            StyleDef {
-                fg: s.fg.as_ref()
-                    .and_then(|v| resolve_color(v, palette))
-                    .unwrap_or(default.fg),
-                bg: s.bg.as_ref().and_then(|v| resolve_color(v, palette)),
-                bold: s.bold,
-                italic: s.italic,
-            }
-        }
+        Some(s) => StyleDef {
+            fg: s
+                .fg
+                .as_ref()
+                .and_then(|v| resolve_color(v, palette))
+                .unwrap_or(default.fg),
+            bg: s.bg.as_ref().and_then(|v| resolve_color(v, palette)),
+            bold: s.bold,
+            italic: s.italic,
+        },
         None => default,
     }
 }
 
 /// Load a theme from TOML content (returns Result for error reporting)
 pub fn try_load_theme_from_toml(name: &str, content: &str) -> Result<Theme, String> {
-    let toml: ThemeToml = toml::from_str(content)
-        .map_err(|e| format!("Theme '{}': {}", name, e))?;
+    let toml: ThemeToml =
+        toml::from_str(content).map_err(|e| format!("Theme '{}': {}", name, e))?;
     Ok(load_theme_from_toml_inner(name, &toml))
 }
 
@@ -263,149 +267,307 @@ fn load_theme_from_toml_inner(name: &str, toml: &ThemeToml) -> Theme {
 
     // Parse UI colors
     let ui = UiColors {
-        background: toml.ui.background.as_ref()
+        background: toml
+            .ui
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.background),
-        foreground: toml.ui.foreground.as_ref()
+        foreground: toml
+            .ui
+            .foreground
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.foreground),
-        cursor_line: toml.ui.cursor_line.as_ref()
+        cursor_line: toml
+            .ui
+            .cursor_line
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.cursor_line),
-        selection: toml.ui.selection.as_ref()
+        selection: toml
+            .ui
+            .selection
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.selection),
-        line_number: toml.ui.line_number.as_ref()
+        line_number: toml
+            .ui
+            .line_number
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.line_number),
-        line_number_active: toml.ui.line_number_active.as_ref()
+        line_number_active: toml
+            .ui
+            .line_number_active
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.line_number_active),
 
-        statusline_bg: toml.ui.statusline.background.as_ref()
+        statusline_bg: toml
+            .ui
+            .statusline
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_bg),
-        statusline_fg: toml.ui.statusline.foreground.as_ref()
+        statusline_fg: toml
+            .ui
+            .statusline
+            .foreground
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_fg),
-        statusline_mode_normal: toml.ui.statusline.mode_normal.as_ref()
+        statusline_mode_normal: toml
+            .ui
+            .statusline
+            .mode_normal
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_normal),
-        statusline_mode_insert: toml.ui.statusline.mode_insert.as_ref()
+        statusline_mode_insert: toml
+            .ui
+            .statusline
+            .mode_insert
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_insert),
-        statusline_mode_visual: toml.ui.statusline.mode_visual.as_ref()
+        statusline_mode_visual: toml
+            .ui
+            .statusline
+            .mode_visual
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_visual),
-        statusline_mode_command: toml.ui.statusline.mode_command.as_ref()
+        statusline_mode_command: toml
+            .ui
+            .statusline
+            .mode_command
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_command),
-        statusline_mode_replace: toml.ui.statusline.mode_replace.as_ref()
+        statusline_mode_replace: toml
+            .ui
+            .statusline
+            .mode_replace
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_replace),
 
-        popup_bg: toml.ui.popup.background.as_ref()
+        popup_bg: toml
+            .ui
+            .popup
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.popup_bg),
-        popup_border: toml.ui.popup.border.as_ref()
+        popup_border: toml
+            .ui
+            .popup
+            .border
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.popup_border),
-        popup_selection: toml.ui.popup.selection.as_ref()
+        popup_selection: toml
+            .ui
+            .popup
+            .selection
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.popup_selection),
 
-        completion_bg: toml.ui.completion.background.as_ref()
+        completion_bg: toml
+            .ui
+            .completion
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.completion_bg),
-        completion_border: toml.ui.completion.border.as_ref()
+        completion_border: toml
+            .ui
+            .completion
+            .border
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.completion_border),
-        completion_selected: toml.ui.completion.selected.as_ref()
+        completion_selected: toml
+            .ui
+            .completion
+            .selected
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.completion_selected),
-        completion_match: toml.ui.completion.match_.as_ref()
+        completion_match: toml
+            .ui
+            .completion
+            .match_
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.completion_match),
-        completion_detail: toml.ui.completion.detail.as_ref()
+        completion_detail: toml
+            .ui
+            .completion
+            .detail
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.completion_detail),
 
-        finder_bg: toml.ui.finder.background.as_ref()
+        finder_bg: toml
+            .ui
+            .finder
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.finder_bg),
-        finder_border: toml.ui.finder.border.as_ref()
+        finder_border: toml
+            .ui
+            .finder
+            .border
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.finder_border),
-        finder_selected: toml.ui.finder.selected.as_ref()
+        finder_selected: toml
+            .ui
+            .finder
+            .selected
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.finder_selected),
-        finder_match: toml.ui.finder.match_.as_ref()
+        finder_match: toml
+            .ui
+            .finder
+            .match_
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.finder_match),
-        finder_prompt: toml.ui.finder.prompt.as_ref()
+        finder_prompt: toml
+            .ui
+            .finder
+            .prompt
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.finder_prompt),
 
-        search_match_bg: toml.ui.search.match_bg.as_ref()
+        search_match_bg: toml
+            .ui
+            .search
+            .match_bg
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.search_match_bg),
-        search_match_fg: toml.ui.search.match_fg.as_ref()
+        search_match_fg: toml
+            .ui
+            .search
+            .match_fg
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.search_match_fg),
 
-        visual_bg: toml.ui.visual_bg.as_ref()
+        visual_bg: toml
+            .ui
+            .visual_bg
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.visual_bg),
 
-        explorer_bg: toml.ui.explorer.background.as_ref()
+        explorer_bg: toml
+            .ui
+            .explorer
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.explorer_bg),
-        explorer_border: toml.ui.explorer.border.as_ref()
+        explorer_border: toml
+            .ui
+            .explorer
+            .border
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.explorer_border),
-        explorer_selected: toml.ui.explorer.selected.as_ref()
+        explorer_selected: toml
+            .ui
+            .explorer
+            .selected
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.explorer_selected),
-        explorer_directory: toml.ui.explorer.directory.as_ref()
+        explorer_directory: toml
+            .ui
+            .explorer
+            .directory
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.explorer_directory),
 
-        harpoon_bg: toml.ui.harpoon.background.as_ref()
+        harpoon_bg: toml
+            .ui
+            .harpoon
+            .background
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.harpoon_bg),
-        harpoon_border: toml.ui.harpoon.border.as_ref()
+        harpoon_border: toml
+            .ui
+            .harpoon
+            .border
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.harpoon_border),
-        harpoon_selected: toml.ui.harpoon.selected.as_ref()
+        harpoon_selected: toml
+            .ui
+            .harpoon
+            .selected
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.harpoon_selected),
     };
 
     // Parse diagnostic colors
     let diagnostic = DiagnosticColors {
-        error: toml.diagnostic.error.as_ref()
+        error: toml
+            .diagnostic
+            .error
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.diagnostic.error),
-        warning: toml.diagnostic.warning.as_ref()
+        warning: toml
+            .diagnostic
+            .warning
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.diagnostic.warning),
-        info: toml.diagnostic.info.as_ref()
+        info: toml
+            .diagnostic
+            .info
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.diagnostic.info),
-        hint: toml.diagnostic.hint.as_ref()
+        hint: toml
+            .diagnostic
+            .hint
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.diagnostic.hint),
     };
 
     // Parse git colors
     let git = GitColors {
-        added: toml.git.added.as_ref()
+        added: toml
+            .git
+            .added
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.git.added),
-        modified: toml.git.modified.as_ref()
+        modified: toml
+            .git
+            .modified
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.git.modified),
-        deleted: toml.git.deleted.as_ref()
+        deleted: toml
+            .git
+            .deleted
+            .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.git.deleted),
     };
@@ -444,12 +606,10 @@ pub fn load_user_themes() -> (Vec<Theme>, Vec<String>) {
             if path.extension().map(|e| e == "toml").unwrap_or(false) {
                 if let Some(name) = path.file_stem().and_then(|s| s.to_str()) {
                     match std::fs::read_to_string(&path) {
-                        Ok(content) => {
-                            match try_load_theme_from_toml(name, &content) {
-                                Ok(theme) => themes.push(theme),
-                                Err(e) => errors.push(e),
-                            }
-                        }
+                        Ok(content) => match try_load_theme_from_toml(name, &content) {
+                            Ok(theme) => themes.push(theme),
+                            Err(e) => errors.push(e),
+                        },
                         Err(e) => {
                             errors.push(format!("Theme '{}': failed to read file: {}", name, e));
                         }

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -69,10 +69,10 @@ pub struct SyntaxColors {
     pub tag: StyleDef,
     pub embedded: StyleDef, // For embedded expressions like ${} in template strings
     // New groups for improved Rust highlighting
-    pub macro_: StyleDef,       // format!, println!
-    pub method: StyleDef,       // .clone(), .ok()
-    pub constructor: StyleDef,  // Some, None, Ok, Err
-    pub boolean: StyleDef,      // true, false
+    pub macro_: StyleDef,      // format!, println!
+    pub method: StyleDef,      // .clone(), .ok()
+    pub constructor: StyleDef, // Some, None, Ok, Err
+    pub boolean: StyleDef,     // true, false
 }
 
 /// UI element colors
@@ -160,17 +160,61 @@ impl Theme {
     /// Create the default One Dark theme
     pub fn onedark() -> Self {
         // One Dark palette
-        let red = Color::Rgb { r: 224, g: 108, b: 117 };
-        let green = Color::Rgb { r: 152, g: 195, b: 121 };
-        let yellow = Color::Rgb { r: 229, g: 192, b: 123 };
-        let blue = Color::Rgb { r: 97, g: 175, b: 239 };
-        let purple = Color::Rgb { r: 198, g: 120, b: 221 };
-        let cyan = Color::Rgb { r: 86, g: 182, b: 194 };
-        let orange = Color::Rgb { r: 209, g: 154, b: 102 };
-        let gray = Color::Rgb { r: 92, g: 99, b: 112 };
-        let fg = Color::Rgb { r: 171, g: 178, b: 191 };
-        let bg = Color::Rgb { r: 40, g: 44, b: 52 };
-        let bg_dark = Color::Rgb { r: 33, g: 37, b: 43 };
+        let red = Color::Rgb {
+            r: 224,
+            g: 108,
+            b: 117,
+        };
+        let green = Color::Rgb {
+            r: 152,
+            g: 195,
+            b: 121,
+        };
+        let yellow = Color::Rgb {
+            r: 229,
+            g: 192,
+            b: 123,
+        };
+        let blue = Color::Rgb {
+            r: 97,
+            g: 175,
+            b: 239,
+        };
+        let purple = Color::Rgb {
+            r: 198,
+            g: 120,
+            b: 221,
+        };
+        let cyan = Color::Rgb {
+            r: 86,
+            g: 182,
+            b: 194,
+        };
+        let orange = Color::Rgb {
+            r: 209,
+            g: 154,
+            b: 102,
+        };
+        let gray = Color::Rgb {
+            r: 92,
+            g: 99,
+            b: 112,
+        };
+        let fg = Color::Rgb {
+            r: 171,
+            g: 178,
+            b: 191,
+        };
+        let bg = Color::Rgb {
+            r: 40,
+            g: 44,
+            b: 52,
+        };
+        let bg_dark = Color::Rgb {
+            r: 33,
+            g: 37,
+            b: 43,
+        };
 
         Self {
             name: "onedark".to_string(),
@@ -200,8 +244,16 @@ impl Theme {
             ui: UiColors {
                 background: bg,
                 foreground: fg,
-                cursor_line: Color::Rgb { r: 44, g: 49, b: 60 },
-                selection: Color::Rgb { r: 62, g: 68, b: 81 },
+                cursor_line: Color::Rgb {
+                    r: 44,
+                    g: 49,
+                    b: 60,
+                },
+                selection: Color::Rgb {
+                    r: 62,
+                    g: 68,
+                    b: 81,
+                },
                 line_number: gray,
                 line_number_active: fg,
 
@@ -214,38 +266,106 @@ impl Theme {
                 statusline_mode_replace: red,
 
                 popup_bg: bg_dark,
-                popup_border: Color::Rgb { r: 55, g: 55, b: 65 },
-                popup_selection: Color::Rgb { r: 55, g: 77, b: 95 },
+                popup_border: Color::Rgb {
+                    r: 55,
+                    g: 55,
+                    b: 65,
+                },
+                popup_selection: Color::Rgb {
+                    r: 55,
+                    g: 77,
+                    b: 95,
+                },
 
-                completion_bg: Color::Rgb { r: 30, g: 30, b: 36 },
-                completion_border: Color::Rgb { r: 55, g: 55, b: 65 },
-                completion_selected: Color::Rgb { r: 55, g: 77, b: 95 },
+                completion_bg: Color::Rgb {
+                    r: 30,
+                    g: 30,
+                    b: 36,
+                },
+                completion_border: Color::Rgb {
+                    r: 55,
+                    g: 55,
+                    b: 65,
+                },
+                completion_selected: Color::Rgb {
+                    r: 55,
+                    g: 77,
+                    b: 95,
+                },
                 completion_match: yellow,
-                completion_detail: Color::Rgb { r: 100, g: 100, b: 115 },
+                completion_detail: Color::Rgb {
+                    r: 100,
+                    g: 100,
+                    b: 115,
+                },
 
-                finder_bg: Color::Rgb { r: 25, g: 25, b: 30 },
-                finder_border: Color::Rgb { r: 100, g: 100, b: 100 },
-                finder_selected: Color::Rgb { r: 60, g: 60, b: 100 },
+                finder_bg: Color::Rgb {
+                    r: 25,
+                    g: 25,
+                    b: 30,
+                },
+                finder_border: Color::Rgb {
+                    r: 100,
+                    g: 100,
+                    b: 100,
+                },
+                finder_selected: Color::Rgb {
+                    r: 60,
+                    g: 60,
+                    b: 100,
+                },
                 finder_match: yellow,
                 finder_prompt: blue,
 
-                search_match_bg: Color::Rgb { r: 180, g: 160, b: 60 },
+                search_match_bg: Color::Rgb {
+                    r: 180,
+                    g: 160,
+                    b: 60,
+                },
                 search_match_fg: Color::Rgb { r: 0, g: 0, b: 0 },
 
-                visual_bg: Color::Rgb { r: 62, g: 68, b: 81 },
+                visual_bg: Color::Rgb {
+                    r: 62,
+                    g: 68,
+                    b: 81,
+                },
 
                 explorer_bg: bg_dark,
-                explorer_border: Color::Rgb { r: 55, g: 55, b: 65 },
-                explorer_selected: Color::Rgb { r: 55, g: 77, b: 95 },
+                explorer_border: Color::Rgb {
+                    r: 55,
+                    g: 55,
+                    b: 65,
+                },
+                explorer_selected: Color::Rgb {
+                    r: 55,
+                    g: 77,
+                    b: 95,
+                },
                 explorer_directory: blue,
 
                 harpoon_bg: bg_dark,
-                harpoon_border: Color::Rgb { r: 55, g: 55, b: 65 },
-                harpoon_selected: Color::Rgb { r: 55, g: 77, b: 95 },
+                harpoon_border: Color::Rgb {
+                    r: 55,
+                    g: 55,
+                    b: 65,
+                },
+                harpoon_selected: Color::Rgb {
+                    r: 55,
+                    g: 77,
+                    b: 95,
+                },
             },
             diagnostic: DiagnosticColors {
-                error: Color::Rgb { r: 255, g: 100, b: 100 },
-                warning: Color::Rgb { r: 255, g: 200, b: 100 },
+                error: Color::Rgb {
+                    r: 255,
+                    g: 100,
+                    b: 100,
+                },
+                warning: Color::Rgb {
+                    r: 255,
+                    g: 200,
+                    b: 100,
+                },
                 info: blue,
                 hint: cyan,
             },
@@ -395,7 +515,9 @@ impl ThemeManager {
         }
 
         // Add user themes (sorted)
-        let mut user_themes: Vec<&str> = self.available.keys()
+        let mut user_themes: Vec<&str> = self
+            .available
+            .keys()
             .filter(|name| !bundled_names.contains(&name.as_str()))
             .map(|s| s.as_str())
             .collect();


### PR DESCRIPTION
## Summary
- Implement a broad batch of Vim/Neovim-compatible keybinds across motions, text objects, insert mode, LSP navigation, registers, windows, finder preview, and buffer deletion.
- Add a which-key-style leader popup with a configurable [keymap].show_leader_popup toggle.
- 
## Test Plan
- cargo fmt
- cargo test keybinds
- git diff --check
- cargo test

