### PR TITLE
feat: implement expression register keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -487,6 +487,7 @@ Registers are like named clipboards. Prefix operations with `"{register}`.
 | `"%` | Current filename |
 | `":` | Last command |
 | `"#` | Alternate filename |
+| `"=` | Expression register |
 
 > **Examples:**
 > - `"ayy` - Yank line into register `a`
@@ -494,6 +495,9 @@ Registers are like named clipboards. Prefix operations with `"{register}`.
 > - `"+y` - Yank to system clipboard
 > - `"+p` - Paste from system clipboard
 > - `"_dd` - Delete line without saving to any register
+> - `"=1+2*3<Enter>p` - Paste evaluated expression result
+
+> **Expression register:** supports arithmetic (`+`, `-`, `*`, `/`, parentheses) and quoted string literals.
 
 ---
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 283 keybinds implemented, 1 planned.**
+**Status: 284 keybinds implemented, 0 planned.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -17,8 +17,7 @@ keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
 
 ## Planned
 
-### Registers (read-only)
-- `"=` — expression register
+No planned keybinds are currently tracked.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Press `<Space>` by itself to show available leader continuations. Set `[keymap] 
 `Ctrl+w v` (vsplit), `Ctrl+w s` (hsplit), `Ctrl+w q` (close), `Ctrl+w h/j/k/l` or `Ctrl+h/j/k/l` (navigate), `Ctrl+w w/W` (next/previous), `Ctrl+w =` (equalize), `Ctrl+w r/R` (rotate), `Ctrl+w x` (exchange)
 
 ### And More
-Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-only registers (`"%`, `":`, `"#`, `".`), insert helpers (`Ctrl+t/Ctrl+d/Ctrl+a/Ctrl+r/Ctrl+o`), replace mode (`R`)
+Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-only/expression registers (`"%`, `":`, `"#`, `".`, `"=`), insert helpers (`Ctrl+t/Ctrl+d/Ctrl+a/Ctrl+r/Ctrl+o`), replace mode (`R`)
 
 > **Missing a keybind?** Check [KEYBINDINGS.md](KEYBINDINGS.md) for the full list of what's implemented. If you don't see the one you want, take a look at the [keybind roadmap](KEYBINDS_ROADMAP.md) to see if it's already planned — and if it's not, [open an issue](https://github.com/anthonyamaro15/nevi/issues) to request it (PRs welcome too).
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1006,6 +1006,7 @@ fn default_config_template() -> &'static str {
 # "%               - Current filename
 # ":               - Last command
 # "#               - Alternate filename
+# "=               - Expression register
 #
 # ----------------------------------------------------------------------------
 # LEADER MAPPINGS (default: Space)

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -44,6 +44,15 @@ pub enum Mode {
     RenamePrompt,
 }
 
+/// Where the expression-register result should be applied.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpressionRegisterTarget {
+    /// Normal mode: keep the result in the expression register for the next operation.
+    Normal,
+    /// Insert mode: insert the result immediately at the cursor.
+    Insert,
+}
+
 impl Mode {
     pub fn as_str(&self) -> &'static str {
         match self {
@@ -867,6 +876,12 @@ pub struct Editor {
     current_inserted_text: String,
     /// Insert mode is waiting for a register name after `<C-r>`.
     pub pending_insert_register: bool,
+    /// Expression register input is active after `"=` or `<C-r>=`.
+    pub pending_expression_register: Option<ExpressionRegisterTarget>,
+    /// Expression being typed for the expression register.
+    pub expression_register_input: String,
+    /// Last evaluated expression register value.
+    expression_register_value: Option<String>,
     /// Insert mode temporarily handed control to one normal-mode command after `<C-o>`.
     pub pending_insert_normal_once: bool,
     /// Previous jump position for `''` command (path, line, col)
@@ -1061,6 +1076,198 @@ impl ThemePicker {
     }
 }
 
+fn evaluate_expression_register(input: &str) -> Result<String, String> {
+    let expression = input.trim();
+    if expression.is_empty() {
+        return Err("empty expression".to_string());
+    }
+
+    if let Some(text) = parse_quoted_expression(expression)? {
+        return Ok(text);
+    }
+
+    let mut parser = ExpressionParser::new(expression);
+    let value = parser.parse_expression()?;
+    parser.skip_ws();
+    if !parser.is_done() {
+        return Err("unexpected trailing input".to_string());
+    }
+    Ok(format_expression_number(value))
+}
+
+fn parse_quoted_expression(input: &str) -> Result<Option<String>, String> {
+    let mut chars = input.chars();
+    let Some(quote @ ('\'' | '"')) = chars.next() else {
+        return Ok(None);
+    };
+
+    let mut output = String::new();
+    let mut escaped = false;
+    while let Some(ch) = chars.next() {
+        if escaped {
+            let resolved = match ch {
+                'n' => '\n',
+                't' => '\t',
+                'r' => '\r',
+                '\\' => '\\',
+                '\'' => '\'',
+                '"' => '"',
+                other => other,
+            };
+            output.push(resolved);
+            escaped = false;
+            continue;
+        }
+
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == quote {
+            if chars.as_str().trim().is_empty() {
+                return Ok(Some(output));
+            }
+            return Err("unexpected trailing input".to_string());
+        }
+        output.push(ch);
+    }
+
+    Err("unterminated string".to_string())
+}
+
+fn format_expression_number(value: f64) -> String {
+    if !value.is_finite() {
+        return value.to_string();
+    }
+    let normalized = if value.abs() < 1e-12 { 0.0 } else { value };
+    if normalized.fract().abs() < 1e-12 {
+        return format!("{}", normalized.trunc() as i64);
+    }
+
+    let mut text = format!("{:.12}", normalized);
+    while text.contains('.') && text.ends_with('0') {
+        text.pop();
+    }
+    if text.ends_with('.') {
+        text.pop();
+    }
+    text
+}
+
+struct ExpressionParser<'a> {
+    input: &'a str,
+    pos: usize,
+}
+
+impl<'a> ExpressionParser<'a> {
+    fn new(input: &'a str) -> Self {
+        Self { input, pos: 0 }
+    }
+
+    fn is_done(&self) -> bool {
+        self.pos >= self.input.len()
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(ch) = self.peek() {
+            if ch.is_whitespace() {
+                self.pos += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<char> {
+        self.input[self.pos..].chars().next()
+    }
+
+    fn consume(&mut self, expected: char) -> bool {
+        self.skip_ws();
+        if self.peek() == Some(expected) {
+            self.pos += expected.len_utf8();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn parse_expression(&mut self) -> Result<f64, String> {
+        let mut value = self.parse_term()?;
+        loop {
+            if self.consume('+') {
+                value += self.parse_term()?;
+            } else if self.consume('-') {
+                value -= self.parse_term()?;
+            } else {
+                return Ok(value);
+            }
+        }
+    }
+
+    fn parse_term(&mut self) -> Result<f64, String> {
+        let mut value = self.parse_factor()?;
+        loop {
+            if self.consume('*') {
+                value *= self.parse_factor()?;
+            } else if self.consume('/') {
+                let divisor = self.parse_factor()?;
+                if divisor.abs() < f64::EPSILON {
+                    return Err("division by zero".to_string());
+                }
+                value /= divisor;
+            } else {
+                return Ok(value);
+            }
+        }
+    }
+
+    fn parse_factor(&mut self) -> Result<f64, String> {
+        self.skip_ws();
+        if self.consume('+') {
+            return self.parse_factor();
+        }
+        if self.consume('-') {
+            return Ok(-self.parse_factor()?);
+        }
+        if self.consume('(') {
+            let value = self.parse_expression()?;
+            if !self.consume(')') {
+                return Err("expected ')'".to_string());
+            }
+            return Ok(value);
+        }
+        self.parse_number()
+    }
+
+    fn parse_number(&mut self) -> Result<f64, String> {
+        self.skip_ws();
+        let start = self.pos;
+        let mut seen_digit = false;
+        let mut seen_dot = false;
+
+        while let Some(ch) = self.peek() {
+            if ch.is_ascii_digit() {
+                seen_digit = true;
+                self.pos += ch.len_utf8();
+            } else if ch == '.' && !seen_dot {
+                seen_dot = true;
+                self.pos += ch.len_utf8();
+            } else {
+                break;
+            }
+        }
+
+        if !seen_digit {
+            return Err("expected number".to_string());
+        }
+
+        self.input[start..self.pos]
+            .parse::<f64>()
+            .map_err(|_| "invalid number".to_string())
+    }
+}
+
 impl Editor {
     pub fn new(settings: Settings) -> Self {
         let (keymap, keymap_errors) = KeymapLookup::from_settings(&settings.keymap);
@@ -1153,6 +1360,9 @@ impl Editor {
             last_inserted_text: None,
             current_inserted_text: String::new(),
             pending_insert_register: false,
+            pending_expression_register: None,
+            expression_register_input: String::new(),
+            expression_register_value: None,
             pending_insert_normal_once: false,
             previous_jump_position: None,
             languages_config: crate::config::load_languages_config(),
@@ -3150,6 +3360,12 @@ impl Editor {
                 .filter(|text| !text.is_empty())
                 .cloned()
                 .map(RegisterContent::Chars),
+            Some('=') => self
+                .expression_register_value
+                .as_ref()
+                .filter(|text| !text.is_empty())
+                .cloned()
+                .map(RegisterContent::Chars),
             _ => self.registers.get_content(register),
         }
     }
@@ -3466,6 +3682,62 @@ impl Editor {
         }
 
         self.insert_text_at_cursor(&text);
+        true
+    }
+
+    /// Begin collecting expression-register input.
+    pub fn start_expression_register(&mut self, target: ExpressionRegisterTarget) {
+        self.pending_expression_register = Some(target);
+        self.expression_register_input.clear();
+        self.set_status("=");
+    }
+
+    /// Append one typed character to the expression-register prompt.
+    pub fn push_expression_register_char(&mut self, ch: char) {
+        self.expression_register_input.push(ch);
+        self.set_status(format!("={}", self.expression_register_input));
+    }
+
+    /// Remove the last character from the expression-register prompt.
+    pub fn pop_expression_register_char(&mut self) {
+        self.expression_register_input.pop();
+        self.set_status(format!("={}", self.expression_register_input));
+    }
+
+    /// Cancel expression-register input and clear the pending target.
+    pub fn cancel_expression_register(&mut self) {
+        self.pending_expression_register = None;
+        self.expression_register_input.clear();
+        self.input_state.selected_register = None;
+        self.clear_status();
+    }
+
+    /// Evaluate the pending expression and route the result to normal/insert behavior.
+    pub fn submit_expression_register(&mut self) -> bool {
+        let Some(target) = self.pending_expression_register.take() else {
+            return false;
+        };
+        let expression = std::mem::take(&mut self.expression_register_input);
+        let result = match evaluate_expression_register(&expression) {
+            Ok(result) => result,
+            Err(err) => {
+                self.input_state.selected_register = None;
+                self.set_status(format!("Expression error: {}", err));
+                return false;
+            }
+        };
+
+        self.expression_register_value = Some(result.clone());
+        match target {
+            ExpressionRegisterTarget::Normal => {
+                self.input_state.selected_register = Some('=');
+                self.set_status(format!("={}", expression));
+            }
+            ExpressionRegisterTarget::Insert => {
+                self.insert_text_at_cursor(&result);
+                self.clear_status();
+            }
+        }
         true
     }
 

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -26,10 +26,9 @@
 # <Space> = Space   <BS> = Backspace
 #
 # ORGANIZATION:
-# Within each category, implemented keybinds come first, followed by
-# a "--- NOT IMPLEMENTED YET ---" separator, then planned keybinds.
+# Within each category, implemented keybinds are grouped by behavior.
 #
-# Last Updated: 2026-06-18
+# Last Updated: 2026-06-22
 # ============================================================================
 
 # ============================================================================
@@ -938,10 +937,8 @@ status = "implemented"
 vim_default = false
 
 # ----------------------------------------------------------------------------
-# G commands - Miscellaneous (NOT IMPLEMENTED YET)
+# G commands - Miscellaneous
 # ----------------------------------------------------------------------------
-
-# --- NOT IMPLEMENTED YET ---
 
 [[normal.g_commands]]
 key = "gf"
@@ -1924,13 +1921,11 @@ desc = "Alternate file name (read-only)"
 status = "implemented"
 vim_default = true
 
-# --- NOT IMPLEMENTED YET ---
-
 [[registers]]
 key = "\"="
 action = "expression_register"
 desc = "Expression register"
-status = "planned"
+status = "implemented"
 vim_default = true
 
 # ============================================================================

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -439,7 +439,7 @@ impl InputState {
         if self.pending_register_select {
             self.pending_register_select = false;
             if let KeyCode::Char(c) = key.code {
-                // Valid register names: a-z, A-Z, 0-9, ", -, +, *, _, /, %, :, #, .
+                // Valid register names: a-z, A-Z, 0-9, ", -, +, *, _, /, %, :, #, ., =
                 if c.is_ascii_alphabetic()
                     || c.is_ascii_digit()
                     || c == '"'
@@ -452,6 +452,7 @@ impl InputState {
                     || c == ':'
                     || c == '#'
                     || c == '.'
+                    || c == '='
                 {
                     self.selected_register = Some(c);
                     return KeyAction::Pending;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -57,7 +57,9 @@ fn finder_preview_match_ranges(line: &str, query: &str) -> Vec<(usize, usize)> {
 
 use crate::commands::{parse_command, Command, CommandPopupMode, CommandResult};
 use crate::config::{CommandModeAction, LeaderAction};
-use crate::editor::{Editor, LspAction, Mode, Pane, PaneDirection, SplitLayout};
+use crate::editor::{
+    Editor, ExpressionRegisterTarget, LspAction, Mode, Pane, PaneDirection, SplitLayout,
+};
 use crate::input::{
     InsertPosition, KeyAction, Operator, TextObject, TextObjectModifier, TextObjectType,
 };
@@ -6248,6 +6250,25 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
+    if editor.pending_expression_register.is_some() {
+        match (key.modifiers, key.code) {
+            (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {
+                editor.cancel_expression_register();
+            }
+            (KeyModifiers::NONE, KeyCode::Enter) => {
+                editor.submit_expression_register();
+            }
+            (KeyModifiers::NONE, KeyCode::Backspace) => {
+                editor.pop_expression_register_char();
+            }
+            (_, KeyCode::Char(ch)) if !ch.is_control() => {
+                editor.push_expression_register_char(ch);
+            }
+            _ => {}
+        }
+        return;
+    }
+
     // Handle references picker if active
     if editor.references_picker.is_some() {
         handle_references_picker_key(editor, key);
@@ -6434,6 +6455,10 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
     match action {
         KeyAction::Pending => {
             // Key was consumed, waiting for more input
+            if editor.input_state.selected_register == Some('=') {
+                editor.input_state.selected_register = None;
+                editor.start_expression_register(ExpressionRegisterTarget::Normal);
+            }
         }
 
         KeyAction::Motion(motion, count) => {
@@ -7110,7 +7135,11 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
         match (key.modifiers, key.code) {
             (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {}
             (_, KeyCode::Char(register)) => {
-                editor.insert_register_text(register);
+                if register == '=' {
+                    editor.start_expression_register(ExpressionRegisterTarget::Insert);
+                } else {
+                    editor.insert_register_text(register);
+                }
             }
             _ => {}
         }
@@ -11393,6 +11422,27 @@ mod tests {
     }
 
     #[test]
+    fn normal_expression_register_evaluates_expression_before_paste() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n");
+
+        handle_key(&mut editor, key('"'));
+        handle_key(&mut editor, key('='));
+        handle_key(&mut editor, key('1'));
+        handle_key(&mut editor, key('+'));
+        handle_key(&mut editor, key('2'));
+        handle_key(&mut editor, key('*'));
+        handle_key(&mut editor, key('3'));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+        handle_key(&mut editor, key('p'));
+
+        assert_eq!(editor.buffer().content(), "x7\n");
+    }
+
+    #[test]
     fn insert_ctrl_a_inserts_previously_inserted_text() {
         let mut editor = Editor::default();
         editor.replace_buffer_content("x\n\n");
@@ -11429,6 +11479,28 @@ mod tests {
         assert_eq!(editor.buffer().content(), "xnevi\n");
         assert_eq!(editor.mode, Mode::Insert);
         assert_eq!((editor.cursor.line, editor.cursor.col), (0, 5));
+    }
+
+    #[test]
+    fn insert_ctrl_r_equals_evaluates_expression_at_cursor() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("x\n");
+
+        handle_key(&mut editor, shift_key('A'));
+        handle_key(&mut editor, ctrl_key('r'));
+        handle_key(&mut editor, key('='));
+        handle_key(&mut editor, key('1'));
+        handle_key(&mut editor, key('0'));
+        handle_key(&mut editor, key('/'));
+        handle_key(&mut editor, key('4'));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(editor.buffer().content(), "x2.5\n");
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 4));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Implement the Vim expression register (`"=`) for normal paste flows and insert-mode `<C-r>=` insertion.
- Support arithmetic expressions with `+`, `-`, `*`, `/`, parentheses, unary signs, plus quoted string literals.
- Update `KEYBINDINGS.md`, `KEYBINDS_ROADMAP.md`, `README.md`, generated config comments, and `:Keymaps` metadata.


