### PR TITLE
feat: add performance profiling summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,20 @@ Contributions are welcome! Please feel free to submit issues and pull requests.
 - [Report a bug](https://github.com/anthonyamaro15/nevi/issues)
 - [Request a feature](https://github.com/anthonyamaro15/nevi/issues)
 
+### Performance Profiling
+
+Profiling is opt-in and disabled by default. To capture hot-path timings while
+using Nevi locally:
+
+```bash
+NEVI_PROFILE=1 cargo run --release -- path/to/file
+```
+
+Nevi writes raw timing events and a summary to `/tmp/nevi_profile.log`. The
+summary includes count, retained sample count, total, average, p50, p95, and max
+microseconds for metrics such as key handling, syntax updates, full renders, and
+terminal-only renders.
+
 ## License
 
 MIT License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod indent;
 pub mod input;
 pub mod lsp;
 pub mod markdown_preview;
+pub mod perf;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ use nevi::copilot::{
 };
 use nevi::editor::{CopilotAction, CopilotGhostText, LspAction};
 use nevi::lsp;
+use nevi::perf::PerfStats;
 use nevi::terminal::{execute_leader_action, handle_key, EditorEvent};
 
 use nevi::{
@@ -139,6 +140,11 @@ fn main() -> anyhow::Result<()> {
     } else {
         None
     };
+    let mut profile_stats = if profile_enabled {
+        Some(PerfStats::default())
+    } else {
+        None
+    };
 
     // Helper macro for profiling
     macro_rules! profile {
@@ -149,6 +155,19 @@ fn main() -> anyhow::Result<()> {
                 }
             }
         };
+    }
+    macro_rules! profile_metric {
+        ($stats:expr, $file:expr, $name:literal, $duration:expr) => {{
+            let elapsed = $duration;
+            if profile_enabled {
+                if let Some(ref mut stats) = $stats {
+                    stats.record($name, elapsed);
+                }
+                if let Some(Some(ref mut f)) = $file {
+                    let _ = writeln!(f, "{}: {:?}", $name, elapsed);
+                }
+            }
+        }};
     }
 
     // Load configuration
@@ -349,7 +368,7 @@ fn main() -> anyhow::Result<()> {
         // Track loop cycle time
         let cycle_time = loop_start.elapsed();
         if cycle_time.as_millis() > 100 {
-            profile!(profile_file, "SLOW_CYCLE: {:?}", cycle_time);
+            profile_metric!(profile_stats, profile_file, "slow_cycle", cycle_time);
         }
         loop_start = Instant::now();
 
@@ -512,6 +531,7 @@ fn main() -> anyhow::Result<()> {
                         key_went_to_terminal =
                             terminal_visible_before_key && editor.floating_terminal.is_visible();
                         let elapsed = t_handle_key.elapsed();
+                        profile_metric!(profile_stats, profile_file, "handle_key", elapsed);
                         // Only log slow handle_key operations (>1ms) with details
                         if elapsed.as_micros() > 1000 {
                             profile!(
@@ -521,8 +541,6 @@ fn main() -> anyhow::Result<()> {
                                 mode_before,
                                 key.code
                             );
-                        } else {
-                            profile!(profile_file, "handle_key: {:?}", elapsed);
                         }
                     }
                     last_input_at = Some(Instant::now());
@@ -989,7 +1007,12 @@ fn main() -> anyhow::Result<()> {
             let t_syntax = Instant::now();
             let syntax_updated = editor.maybe_update_syntax_debounced(debounce);
             if syntax_updated {
-                profile!(profile_file, "syntax_update: {:?}", t_syntax.elapsed());
+                profile_metric!(
+                    profile_stats,
+                    profile_file,
+                    "syntax_update",
+                    t_syntax.elapsed()
+                );
                 needs_redraw = true;
             }
         }
@@ -1744,7 +1767,7 @@ fn main() -> anyhow::Result<()> {
                 }
                 let t_render = Instant::now();
                 terminal.render(&editor)?;
-                profile!(profile_file, "render: {:?}", t_render.elapsed());
+                profile_metric!(profile_stats, profile_file, "render", t_render.elapsed());
                 needs_redraw = false;
                 terminal_redraw_pending = false;
                 last_render = now;
@@ -1756,11 +1779,24 @@ fn main() -> anyhow::Result<()> {
                 editor.sync_floating_terminal_size();
                 let t_render = Instant::now();
                 terminal.render_terminal_only(&editor)?;
-                profile!(profile_file, "terminal_render: {:?}", t_render.elapsed());
+                profile_metric!(
+                    profile_stats,
+                    profile_file,
+                    "terminal_render",
+                    t_render.elapsed()
+                );
                 terminal_redraw_pending = false;
                 last_render = now;
                 redraw_from_input = false;
             }
+        }
+    }
+
+    if profile_enabled {
+        if let (Some(stats), Some(Some(ref mut file))) =
+            (profile_stats.as_ref(), profile_file.as_mut())
+        {
+            let _ = stats.write_summary(file);
         }
     }
 

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,0 +1,135 @@
+use std::collections::BTreeMap;
+use std::io::{self, Write};
+use std::time::Duration;
+
+const MAX_SAMPLES_PER_METRIC: usize = 10_000;
+
+#[derive(Debug, Default)]
+pub struct PerfStats {
+    metrics: BTreeMap<String, MetricStats>,
+}
+
+#[derive(Debug, Default)]
+struct MetricStats {
+    count: u64,
+    total_us: u128,
+    max_us: u128,
+    samples_us: Vec<u128>,
+}
+
+impl PerfStats {
+    pub fn record(&mut self, name: impl Into<String>, duration: Duration) {
+        let elapsed_us = duration.as_micros();
+        let metric = self.metrics.entry(name.into()).or_default();
+        metric.count += 1;
+        metric.total_us += elapsed_us;
+        metric.max_us = metric.max_us.max(elapsed_us);
+        if metric.samples_us.len() < MAX_SAMPLES_PER_METRIC {
+            metric.samples_us.push(elapsed_us);
+        }
+    }
+
+    pub fn summary_lines(&self) -> Vec<String> {
+        self.metrics
+            .iter()
+            .map(|(name, metric)| {
+                let avg_us = metric.total_us / u128::from(metric.count);
+                let mut samples = metric.samples_us.clone();
+                samples.sort_unstable();
+                let p50_us = percentile(&samples, 50);
+                let p95_us = percentile(&samples, 95);
+
+                format!(
+                    "{name} count={} samples={} total_us={} avg_us={} p50_us={} p95_us={} max_us={}",
+                    metric.count,
+                    metric.samples_us.len(),
+                    metric.total_us,
+                    avg_us,
+                    p50_us,
+                    p95_us,
+                    metric.max_us
+                )
+            })
+            .collect()
+    }
+
+    pub fn write_summary(&self, mut writer: impl Write) -> io::Result<()> {
+        if self.metrics.is_empty() {
+            return Ok(());
+        }
+
+        writeln!(writer, "# profile summary")?;
+        for line in self.summary_lines() {
+            writeln!(writer, "{line}")?;
+        }
+        Ok(())
+    }
+}
+
+fn percentile(sorted_samples: &[u128], percentile: u32) -> u128 {
+    if sorted_samples.is_empty() {
+        return 0;
+    }
+
+    let percentile = percentile.min(100) as usize;
+    let rank = (percentile * sorted_samples.len()).div_ceil(100);
+    let index = rank.saturating_sub(1).min(sorted_samples.len() - 1);
+    sorted_samples[index]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PerfStats;
+    use std::time::Duration;
+
+    #[test]
+    fn profile_summary_reports_sorted_metrics_and_percentiles() {
+        let mut stats = PerfStats::default();
+        stats.record("render", Duration::from_micros(3000));
+        stats.record("render", Duration::from_micros(1000));
+        stats.record("render", Duration::from_micros(2000));
+        stats.record("handle_key", Duration::from_micros(500));
+
+        assert_eq!(
+            stats.summary_lines(),
+            vec![
+                "handle_key count=1 samples=1 total_us=500 avg_us=500 p50_us=500 p95_us=500 max_us=500",
+                "render count=3 samples=3 total_us=6000 avg_us=2000 p50_us=2000 p95_us=3000 max_us=3000",
+            ]
+        );
+    }
+
+    #[test]
+    fn profile_summary_writer_includes_header_and_empty_stats_write_nothing() {
+        let empty = PerfStats::default();
+        let mut output = Vec::new();
+        empty.write_summary(&mut output).unwrap();
+        assert!(output.is_empty());
+
+        let mut stats = PerfStats::default();
+        stats.record("syntax_update", Duration::from_micros(42));
+
+        stats.write_summary(&mut output).unwrap();
+
+        assert_eq!(
+            String::from_utf8(output).unwrap(),
+            "# profile summary\nsyntax_update count=1 samples=1 total_us=42 avg_us=42 p50_us=42 p95_us=42 max_us=42\n"
+        );
+    }
+
+    #[test]
+    fn profile_summary_caps_retained_samples_without_losing_counts() {
+        let mut stats = PerfStats::default();
+
+        for _ in 0..10_005 {
+            stats.record("render", Duration::from_micros(1));
+        }
+
+        assert_eq!(
+            stats.summary_lines(),
+            vec![
+                "render count=10005 samples=10000 total_us=10005 avg_us=1 p50_us=1 p95_us=1 max_us=1",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- adds a small opt-in performance stats recorder for NEVI_PROFILE sessions
- records summary stats for hot-path metrics like key handling, syntax updates, renders, terminal renders, and slow loop cycles
- documents how to run local profiling and where to find /tmp/nevi_profile.log

## Performance Guardrails
- profiling remains disabled by default
- no new runtime dependencies
- retained timing samples are capped per metric while total counts/totals continue tracking

