### PR TITLE
feat: add checkhealth report

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -828,6 +828,7 @@ Type `:` to enter command mode. Implemented commands include:
 | `:Themes` | Open theme picker |
 | `:Theme {name}` / `:theme {name}` / `:colorscheme {name}` | Set theme |
 | `:LazyGit` / `:lg` | Open lazygit |
+| `:checkhealth` / `:CheckHealth` / `:Health` | Open editor health report with config, profiling, and LSP summary |
 | `:!{command}` | Run external shell command |
 | `:Terminal` / `:term` | Toggle floating terminal |
 | `:TerminalNew [name]` / `:termnew [name]` | Create floating terminal session |

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ nevi file1.rs file2.rs
 - `:w` - Save
 - `:q` - Quit
 - `:wq` - Save and quit
+- `:checkhealth` / `:Health` - Open editor health report
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
@@ -277,6 +278,10 @@ Nevi writes raw timing events and a summary to `/tmp/nevi_profile.log`. The
 summary includes count, retained sample count, total, average, p50, p95, and max
 microseconds for metrics such as key handling, syntax updates, full renders, and
 terminal-only renders.
+
+Run `:checkhealth` (or `:Health`) inside Nevi to see config paths, LSP settings,
+profiling status, and any profile summary from `/tmp/nevi_profile.log`. Profile
+summaries are written when a profiled Nevi session exits.
 
 ## License
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -138,6 +138,8 @@ pub enum Command {
     Themes,
     /// :Keymaps - Open searchable keybinding cheatsheet
     Keymaps,
+    /// :checkhealth - Open the editor health report
+    CheckHealth,
     /// :marks - Show all marks
     Marks,
     /// :delmarks {marks} - Delete specified marks
@@ -587,6 +589,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "checkhealth",
+        aliases: &["CheckHealth", "Health", "health"],
+        description: "Open editor health report",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "marks",
         aliases: &[],
         description: "Show all marks",
@@ -975,6 +983,7 @@ pub fn parse_command(input: &str) -> Command {
         }
         "Themes" | "themes" => Command::Themes,
         "Keymaps" | "keymaps" | "keys" => Command::Keymaps,
+        "checkhealth" | "CheckHealth" | "Health" | "health" => Command::CheckHealth,
 
         // Marks commands
         "marks" => Command::Marks,
@@ -1551,6 +1560,25 @@ mod tests {
         assert!(matches!(parse_command("Keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keys"), Command::Keymaps));
+    }
+
+    #[test]
+    fn checkhealth_command_is_parseable_and_suggested() {
+        assert!(matches!(parse_command("checkhealth"), Command::CheckHealth));
+        assert!(matches!(parse_command("CheckHealth"), Command::CheckHealth));
+        assert!(matches!(parse_command("Health"), Command::CheckHealth));
+
+        let suggestions = command_suggestions("health", 8);
+        assert!(
+            suggestions.iter().any(|item| item.command == "checkhealth"),
+            "expected checkhealth to match health query"
+        );
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":checkhealth"),
+            "expected :checkhealth in command cheatsheet rows"
+        );
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1547,6 +1547,16 @@ impl Editor {
         Ok(())
     }
 
+    /// Open a snapshot health report in the read-only preview overlay.
+    pub fn open_health_report(&mut self) {
+        let report = crate::health::collect_health_report(&self.settings);
+        let rendered = crate::markdown_preview::render_markdown(&report);
+        let width = crate::markdown_preview::preview_content_width(self.term_width);
+        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::with_title(
+            rendered, width, "Health",
+        ));
+    }
+
     /// Close the floating Markdown preview.
     pub fn close_markdown_preview(&mut self) {
         self.markdown_preview = None;

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,0 +1,447 @@
+use std::path::PathBuf;
+
+pub const PROFILE_LOG_PATH: &str = "/tmp/nevi_profile.log";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProfileMetricSummary {
+    pub name: String,
+    pub count: u64,
+    pub samples: u64,
+    pub total_us: u128,
+    pub avg_us: u128,
+    pub p50_us: u128,
+    pub p95_us: u128,
+    pub max_us: u128,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileCheckStatus {
+    Missing,
+    Ok,
+    Error(String),
+    Unavailable,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProfileLogStatus {
+    Missing,
+    NoSummary,
+    Summary(Vec<ProfileMetricSummary>),
+    Error(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HealthReportInput {
+    pub config_path: Option<PathBuf>,
+    pub config_status: FileCheckStatus,
+    pub languages_path: Option<PathBuf>,
+    pub languages_status: FileCheckStatus,
+    pub profile_enabled: bool,
+    pub profile_log_path: PathBuf,
+    pub profile_log_status: ProfileLogStatus,
+    pub lsp_enabled: bool,
+    pub lsp_servers: Vec<LspServerHealth>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LspServerHealth {
+    pub language: &'static str,
+    pub enabled: bool,
+    pub command: String,
+}
+
+pub fn parse_profile_summary(contents: &str) -> Vec<ProfileMetricSummary> {
+    let mut in_summary = false;
+    let mut metrics = Vec::new();
+
+    for raw_line in contents.lines() {
+        let line = raw_line.trim();
+        if line == "# profile summary" {
+            in_summary = true;
+            continue;
+        }
+
+        if !in_summary || line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+
+        if let Some(metric) = parse_profile_metric_line(line) {
+            metrics.push(metric);
+        }
+    }
+
+    metrics
+}
+
+fn parse_profile_metric_line(line: &str) -> Option<ProfileMetricSummary> {
+    let mut parts = line.split_whitespace();
+    let name = parts.next()?.to_string();
+
+    let mut count = None;
+    let mut samples = None;
+    let mut total_us = None;
+    let mut avg_us = None;
+    let mut p50_us = None;
+    let mut p95_us = None;
+    let mut max_us = None;
+
+    for part in parts {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+
+        match key {
+            "count" => count = value.parse::<u64>().ok(),
+            "samples" => samples = value.parse::<u64>().ok(),
+            "total_us" => total_us = value.parse::<u128>().ok(),
+            "avg_us" => avg_us = value.parse::<u128>().ok(),
+            "p50_us" => p50_us = value.parse::<u128>().ok(),
+            "p95_us" => p95_us = value.parse::<u128>().ok(),
+            "max_us" => max_us = value.parse::<u128>().ok(),
+            _ => {}
+        }
+    }
+
+    Some(ProfileMetricSummary {
+        name,
+        count: count?,
+        samples: samples?,
+        total_us: total_us?,
+        avg_us: avg_us?,
+        p50_us: p50_us?,
+        p95_us: p95_us?,
+        max_us: max_us?,
+    })
+}
+
+pub fn build_health_report(input: &HealthReportInput) -> String {
+    let mut report = String::new();
+    report.push_str("# Nevi Health\n\n");
+
+    report.push_str("## Configuration\n");
+    report.push_str(&format!(
+        "- Configuration file: {} ({})\n",
+        file_status_label(&input.config_status),
+        path_label(input.config_path.as_ref())
+    ));
+    report.push_str(&format!(
+        "- Languages file: {} ({})\n\n",
+        file_status_label(&input.languages_status),
+        path_label(input.languages_path.as_ref())
+    ));
+
+    report.push_str("## Performance\n");
+    report.push_str(&format!(
+        "- Profiling: {} for this session (`NEVI_PROFILE=1`)\n",
+        if input.profile_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    ));
+    report.push_str(&format!(
+        "- Profile log: {}\n",
+        input.profile_log_path.display()
+    ));
+    match &input.profile_log_status {
+        ProfileLogStatus::Missing => {
+            report.push_str(
+                "- Profile summary: missing. Restart with `NEVI_PROFILE=1`, reproduce the issue, quit Nevi so the summary is written, then run `:checkhealth` again.\n",
+            );
+        }
+        ProfileLogStatus::NoSummary => {
+            report.push_str(
+                "- Profile summary: log exists, but no summary is present yet. The summary is written when Nevi exits.\n",
+            );
+        }
+        ProfileLogStatus::Summary(metrics) => {
+            if input.profile_enabled {
+                report.push_str("- Profile summary: found\n");
+            } else {
+                report.push_str("- Profile summary: found from saved log\n");
+            }
+            for metric in metrics {
+                report.push_str(&format!(
+                    "- {}: count={} avg={}us p95={}us max={}us\n",
+                    metric.name, metric.count, metric.avg_us, metric.p95_us, metric.max_us
+                ));
+            }
+        }
+        ProfileLogStatus::Error(error) => {
+            report.push_str(&format!("- Profile summary: error ({error})\n"));
+        }
+    }
+    report.push('\n');
+
+    report.push_str("## LSP\n");
+    report.push_str(&format!(
+        "- LSP: {}\n",
+        if input.lsp_enabled {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    ));
+    if input.lsp_servers.is_empty() {
+        report.push_str("- Configured servers: none\n");
+    } else {
+        report.push_str("- Configured servers:\n");
+        for server in &input.lsp_servers {
+            report.push_str(&format!(
+                "  - {}: {} ({})\n",
+                server.language,
+                if server.enabled {
+                    "enabled"
+                } else {
+                    "disabled"
+                },
+                if server.command.is_empty() {
+                    "<unset>"
+                } else {
+                    server.command.as_str()
+                }
+            ));
+        }
+    }
+    report.push_str("- External tool checks: skipped in v1 to keep `:checkhealth` cheap.\n");
+
+    report
+}
+
+pub fn collect_health_report(settings: &crate::config::Settings) -> String {
+    let config_path = crate::config::config_path();
+    let languages_path = crate::config::languages::languages_config_path();
+    let profile_log_path = PathBuf::from(PROFILE_LOG_PATH);
+
+    build_health_report(&HealthReportInput {
+        config_status: inspect_toml_file::<crate::config::Settings>(config_path.as_ref()),
+        languages_status: inspect_toml_file::<crate::config::LanguagesConfig>(
+            languages_path.as_ref(),
+        ),
+        config_path,
+        languages_path,
+        profile_enabled: profile_enabled_from_env(),
+        profile_log_status: inspect_profile_log(&profile_log_path),
+        profile_log_path,
+        lsp_enabled: settings.lsp.enabled,
+        lsp_servers: lsp_server_health(settings),
+    })
+}
+
+pub fn profile_enabled_from_env() -> bool {
+    profile_enabled_from_value(std::env::var("NEVI_PROFILE").ok().as_deref())
+}
+
+pub fn profile_enabled_from_value(value: Option<&str>) -> bool {
+    let Some(value) = value.map(str::trim) else {
+        return false;
+    };
+
+    value == "1"
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
+}
+
+fn inspect_toml_file<T>(path: Option<&PathBuf>) -> FileCheckStatus
+where
+    T: serde::de::DeserializeOwned,
+{
+    let Some(path) = path else {
+        return FileCheckStatus::Unavailable;
+    };
+
+    if !path.exists() {
+        return FileCheckStatus::Missing;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(contents) => match toml::from_str::<T>(&contents) {
+            Ok(_) => FileCheckStatus::Ok,
+            Err(error) => FileCheckStatus::Error(error.to_string()),
+        },
+        Err(error) => FileCheckStatus::Error(error.to_string()),
+    }
+}
+
+fn inspect_profile_log(path: &PathBuf) -> ProfileLogStatus {
+    if !path.exists() {
+        return ProfileLogStatus::Missing;
+    }
+
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let metrics = parse_profile_summary(&contents);
+            if metrics.is_empty() {
+                ProfileLogStatus::NoSummary
+            } else {
+                ProfileLogStatus::Summary(metrics)
+            }
+        }
+        Err(error) => ProfileLogStatus::Error(error.to_string()),
+    }
+}
+
+fn lsp_server_health(settings: &crate::config::Settings) -> Vec<LspServerHealth> {
+    let servers = &settings.lsp.servers;
+    vec![
+        server_health("rust", &servers.rust),
+        server_health("typescript", &servers.typescript),
+        server_health("javascript", &servers.javascript),
+        server_health("css", &servers.css),
+        server_health("json", &servers.json),
+        server_health("toml", &servers.toml),
+        server_health("markdown", &servers.markdown),
+        server_health("html", &servers.html),
+        server_health("python", &servers.python),
+    ]
+}
+
+fn server_health(
+    language: &'static str,
+    config: &crate::config::LspServerConfig,
+) -> LspServerHealth {
+    LspServerHealth {
+        language,
+        enabled: config.enabled,
+        command: config.effective_command().to_string(),
+    }
+}
+
+fn file_status_label(status: &FileCheckStatus) -> String {
+    match status {
+        FileCheckStatus::Missing => "missing".to_string(),
+        FileCheckStatus::Ok => "ok".to_string(),
+        FileCheckStatus::Error(error) => format!("error: {error}"),
+        FileCheckStatus::Unavailable => "unavailable".to_string(),
+    }
+}
+
+fn path_label(path: Option<&PathBuf>) -> String {
+    path.map(|path| path.display().to_string())
+        .unwrap_or_else(|| "path unavailable".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_profile_summary_after_header() {
+        let metrics = parse_profile_summary(
+            "render: 1ms\n\
+             # profile summary\n\
+             handle_key count=97 samples=97 total_us=93125 avg_us=960 p50_us=11 p95_us=4759 max_us=33710\n\
+             render count=300 samples=300 total_us=479017 avg_us=1596 p50_us=877 p95_us=3396 max_us=54689\n",
+        );
+
+        assert_eq!(
+            metrics,
+            vec![
+                ProfileMetricSummary {
+                    name: "handle_key".to_string(),
+                    count: 97,
+                    samples: 97,
+                    total_us: 93_125,
+                    avg_us: 960,
+                    p50_us: 11,
+                    p95_us: 4_759,
+                    max_us: 33_710,
+                },
+                ProfileMetricSummary {
+                    name: "render".to_string(),
+                    count: 300,
+                    samples: 300,
+                    total_us: 479_017,
+                    avg_us: 1_596,
+                    p50_us: 877,
+                    p95_us: 3_396,
+                    max_us: 54_689,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn health_report_guides_when_profile_summary_is_missing() {
+        let report = build_health_report(&HealthReportInput {
+            config_path: Some(PathBuf::from("/home/me/.config/nevi/config.toml")),
+            config_status: FileCheckStatus::Ok,
+            languages_path: Some(PathBuf::from("/home/me/.config/nevi/languages.toml")),
+            languages_status: FileCheckStatus::Missing,
+            profile_enabled: false,
+            profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
+            profile_log_status: ProfileLogStatus::Missing,
+            lsp_enabled: true,
+            lsp_servers: vec![LspServerHealth {
+                language: "rust",
+                enabled: true,
+                command: "rust-analyzer".to_string(),
+            }],
+        });
+
+        assert!(report.contains("# Nevi Health"));
+        assert!(report.contains("/home/me/.config/nevi/config.toml"));
+        assert!(report.contains("Configuration file: ok"));
+        assert!(report.contains("Languages file: missing"));
+        assert!(report.contains("Profiling: disabled"));
+        assert!(report.contains("/tmp/nevi_profile.log"));
+        assert!(report.contains("NEVI_PROFILE=1"));
+        assert!(report.contains("rust: enabled (rust-analyzer)"));
+    }
+
+    #[test]
+    fn health_report_lists_profile_summary_metrics() {
+        let report = build_health_report(&HealthReportInput {
+            config_path: None,
+            config_status: FileCheckStatus::Unavailable,
+            languages_path: None,
+            languages_status: FileCheckStatus::Unavailable,
+            profile_enabled: true,
+            profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
+            profile_log_status: ProfileLogStatus::Summary(vec![ProfileMetricSummary {
+                name: "render".to_string(),
+                count: 300,
+                samples: 300,
+                total_us: 479_017,
+                avg_us: 1_596,
+                p50_us: 877,
+                p95_us: 3_396,
+                max_us: 54_689,
+            }]),
+            lsp_enabled: false,
+            lsp_servers: Vec::new(),
+        });
+
+        assert!(report.contains("Profiling: enabled"));
+        assert!(report.contains("render: count=300 avg=1596us p95=3396us max=54689us"));
+        assert!(report.contains("LSP: disabled"));
+    }
+
+    #[test]
+    fn health_report_marks_saved_profile_summary_when_current_session_is_not_profiled() {
+        let report = build_health_report(&HealthReportInput {
+            config_path: None,
+            config_status: FileCheckStatus::Unavailable,
+            languages_path: None,
+            languages_status: FileCheckStatus::Unavailable,
+            profile_enabled: false,
+            profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
+            profile_log_status: ProfileLogStatus::Summary(vec![ProfileMetricSummary {
+                name: "render".to_string(),
+                count: 1,
+                samples: 1,
+                total_us: 42,
+                avg_us: 42,
+                p50_us: 42,
+                p95_us: 42,
+                max_us: 42,
+            }]),
+            lsp_enabled: true,
+            lsp_servers: Vec::new(),
+        });
+
+        assert!(report.contains("Profiling: disabled for this session"));
+        assert!(report.contains("Profile summary: found from saved log"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod formatter;
 pub mod frecency;
 pub mod git;
 pub mod harpoon;
+pub mod health;
 pub mod indent;
 pub mod input;
 pub mod lsp;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,18 +24,11 @@ use nevi::{
 };
 
 fn profile_enabled_from_env() -> bool {
-    profile_enabled_from_value(env::var("NEVI_PROFILE").ok().as_deref())
+    nevi::health::profile_enabled_from_env()
 }
 
 fn profile_enabled_from_value(value: Option<&str>) -> bool {
-    let Some(value) = value.map(str::trim) else {
-        return false;
-    };
-
-    value == "1"
-        || value.eq_ignore_ascii_case("true")
-        || value.eq_ignore_ascii_case("yes")
-        || value.eq_ignore_ascii_case("on")
+    nevi::health::profile_enabled_from_value(value)
 }
 
 fn editor_redraw_interval(
@@ -136,7 +129,7 @@ fn main() -> anyhow::Result<()> {
     // Profiling is opt-in with NEVI_PROFILE=1/true/yes/on.
     let profile_enabled = profile_enabled_from_env();
     let mut profile_file = if profile_enabled {
-        Some(std::fs::File::create("/tmp/nevi_profile.log").ok())
+        Some(std::fs::File::create(nevi::health::PROFILE_LOG_PATH).ok())
     } else {
         None
     };

--- a/src/markdown_preview.rs
+++ b/src/markdown_preview.rs
@@ -64,6 +64,7 @@ pub struct MarkdownPreview {
 
 #[derive(Debug, Clone)]
 pub struct MarkdownPreviewState {
+    pub title: String,
     pub lines: Vec<PreviewLine>,
     display_lines: Vec<PreviewLine>,
     pub scroll: usize,
@@ -72,8 +73,13 @@ pub struct MarkdownPreviewState {
 
 impl MarkdownPreviewState {
     pub fn new(preview: MarkdownPreview, width: usize) -> Self {
+        Self::with_title(preview, width, "Markdown Preview")
+    }
+
+    pub fn with_title(preview: MarkdownPreview, width: usize, title: impl Into<String>) -> Self {
         let display_lines = wrap_preview_lines(&preview.lines, width);
         Self {
+            title: title.into(),
             lines: preview.lines,
             display_lines,
             scroll: 0,
@@ -554,6 +560,16 @@ mod tests {
 
         assert_eq!(preview.max_scroll(1), 1);
         assert_eq!(preview.max_scroll(2), 0);
+    }
+
+    #[test]
+    fn preview_state_supports_custom_titles() {
+        let default_preview = MarkdownPreviewState::new(render_markdown("alpha"), 20);
+        assert_eq!(default_preview.title, "Markdown Preview");
+
+        let health_preview =
+            MarkdownPreviewState::with_title(render_markdown("# Nevi Health"), 20, "Health");
+        assert_eq!(health_preview.title, "Health");
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4033,11 +4033,11 @@ impl Terminal {
             cursor::MoveTo(rect.x, rect.y)
         )?;
         print!("╭");
-        let title = " Markdown Preview ";
+        let title = format!(" {} ", preview.title);
         let title_start = (rect.width as usize).saturating_sub(title.len()) / 2;
         for i in 1..rect.width.saturating_sub(1) {
             if i as usize == title_start {
-                print!("{title}");
+                print!("{}", title);
             } else if i as usize > title_start && (i as usize) < title_start + title.len() {
                 continue;
             } else {
@@ -9448,6 +9448,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_keymaps_picker();
             CommandResult::Ok
         }
+        Command::CheckHealth => {
+            editor.open_health_report();
+            CommandResult::Ok
+        }
 
         Command::Marks => {
             editor.open_finder_marks();
@@ -9794,6 +9798,26 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn checkhealth_command_opens_health_report_preview() {
+        let mut editor = Editor::default();
+
+        execute_command(&mut editor, Command::CheckHealth);
+
+        let preview = editor.markdown_preview.as_ref().expect("health preview");
+        assert_eq!(preview.title, "Health");
+        let text = preview
+            .lines
+            .iter()
+            .map(|line| line.plain_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("Nevi Health"));
+        assert!(text.contains("Configuration"));
+        assert!(text.contains("Performance"));
+        assert!(text.contains("LSP"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add :checkhealth/:CheckHealth/:Health command that opens a health report overlay
- Report config file status, profiling state/profile summary, and configured LSP servers
- Reuse the preview overlay with custom titles and document the new command

