### PR TITLE
feat: improve terminal session workflow

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -67,7 +67,7 @@ For example, the terminal picker is mapped to `<Space>tt` by default and can be 
 
 ```toml
 [[keymap.leader_mappings]]
-key = "t"
+key = "tt"
 action = ":Terminals"
 desc = "Terminal picker"
 ```
@@ -77,6 +77,7 @@ desc = "Terminal picker"
 When specifying keys, use these formats:
 - Regular keys: `"a"`, `"H"`, `";"`, `"0"`
 - Control: `"<C-s>"` (Ctrl+s)
+- Combined modifiers: `"<C-S-t>"` (Ctrl+Shift+t), `"<C-Tab>"`
 - Special keys: `"<CR>"` (Enter), `"<Esc>"`, `"<Tab>"`, `"<Space>"`, `"<BS>"` (Backspace)
 
 > **Tip:** The config file at `~/.config/nevi/config.toml` is auto-generated on first run and contains a full reference with all options commented out.
@@ -618,12 +619,22 @@ the popup, or press `Esc` to cancel.
 | `<leader>fb` | Find buffers |
 | `<leader>ft` | Theme picker |
 | `<leader>tt` | Terminal picker |
+| `<leader>tn` | New terminal session |
+| `<leader>tj` | Next terminal session |
+| `<leader>tk` | Previous terminal session |
+| `<leader>tr` | Rename active terminal session |
+| `<leader>tx` | Kill active terminal session |
+| `<leader>t1` - `<leader>t4` | Jump to terminal session 1-4 |
 
 ### Floating Terminal
 
 | Key / Mouse | Action |
 |-------------|--------|
 | `Ctrl+\` | Toggle the active floating terminal |
+| `Ctrl+Shift+T` | New terminal session |
+| `Ctrl+Tab` | Next terminal session |
+| `Ctrl+Shift+Tab` | Previous terminal session |
+| `Ctrl+Shift+W` | Close current terminal session |
 | Mouse wheel | Scroll terminal scrollback when the shell app is not using mouse reporting |
 | Drag with mouse | Select visible terminal text |
 | `y` | Copy the current terminal selection |
@@ -632,7 +643,7 @@ the popup, or press `Esc` to cancel.
 | `Esc` / `Ctrl+[` | Clear the current terminal selection |
 | Terminal paste (`Cmd+V`, `Ctrl+Shift+V`, or terminal menu) | Paste into the shell; bracketed paste is used when the shell requests it |
 
-> **Note:** Some terminal apps reserve `Cmd+C` for their own native Copy command, so Nevi may never receive that key. Use `y` or `Ctrl+Shift+C` when copying from a floating terminal selection.
+> **Note:** Some terminal apps reserve `Cmd+C` for their own native Copy command, so Nevi may never receive that key. Use `y` or `Ctrl+Shift+C` when copying from a floating terminal selection. Terminal-focused session shortcuts can be remapped under `[terminal.shortcuts]`; set a shortcut to `"none"` to disable it.
 
 > **Tip:** In the file finder or grep, press `Ctrl+t` to toggle a preview panel showing file contents.
 
@@ -837,6 +848,7 @@ Type `:` to enter command mode. Implemented commands include:
 | `:TerminalList` / `:termls` | List floating terminal sessions |
 | `:Terminals` / `:termmenu` | Open floating terminal session picker (`Enter` selects, `d` kills, `n` creates, `r` renames) |
 | `:TerminalSelect {n}` / `:termsel {n}` | Select floating terminal session |
+| `:TerminalRename` / `:termrename` | Prefill a rename command for the active terminal session |
 | `:TerminalRename [n] {name}` / `:termrename [n] {name}` | Rename active terminal or terminal session `n` |
 | `:TerminalKill` / `:termkill` | Kill floating terminal |
 | `:CopilotAuth` / `:Copilot` | Sign in to Copilot |

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ nevi file1.rs file2.rs
 - `<Space>gc` - Git changes picker
 - `<Space>e` - File explorer
 - `<Space>tt` - Terminal picker
+- `<Space>tn` / `<Space>tj` / `<Space>tk` - New / next / previous terminal session
+- `<Space>tr` - Rename active terminal session
 - `<Space>fk` - Search keymaps (keybinding cheatsheet)
 
 ## Configuration

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -122,6 +122,8 @@ pub enum Command {
     TerminalSelect(usize),
     /// :TerminalRename [index] {name} - Rename a floating terminal session
     TerminalRename(Option<usize>, String),
+    /// :TerminalRename - Prompt to rename the active floating terminal session
+    TerminalRenamePrompt,
     /// :TerminalKill - Kill the floating terminal process
     TerminalKill,
     /// :CopilotAuth - Initiate Copilot sign-in
@@ -1003,7 +1005,7 @@ pub fn parse_command(input: &str) -> Command {
 
 fn parse_terminal_rename_args(args: Option<&str>) -> Command {
     let Some(args) = args.map(str::trim).filter(|value| !value.is_empty()) else {
-        return Command::Unknown("termrename: missing name".to_string());
+        return Command::TerminalRenamePrompt;
     };
 
     let mut parts = args.splitn(2, char::is_whitespace);
@@ -1682,6 +1684,10 @@ mod tests {
         assert!(matches!(
             parse_command("termrename server"),
             Command::TerminalRename(None, name) if name == "server"
+        ));
+        assert!(matches!(
+            parse_command("termrename"),
+            Command::TerminalRenamePrompt
         ));
         assert!(matches!(
             parse_command("termrename 2 test runner"),

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -412,62 +412,66 @@ pub fn parse_key_notation(s: &str) -> Option<KeyEvent> {
 
 /// Parse special notation (content inside < >)
 fn parse_special_notation(inner: &str) -> Option<KeyEvent> {
-    let inner_lower = inner.to_lowercase();
+    let parts = inner.split('-').collect::<Vec<_>>();
+    let (modifier_parts, key_part) = parts.split_at(parts.len().saturating_sub(1));
+    let key_part = key_part.first().copied()?;
+    let mut modifiers = KeyModifiers::NONE;
 
-    // Control key: <C-x>
-    if inner_lower.starts_with("c-") && inner.len() == 3 {
-        let c = inner.chars().nth(2)?;
-        return Some(KeyEvent::new(
-            KeyCode::Char(c.to_ascii_lowercase()),
-            KeyModifiers::CONTROL,
-        ));
+    for modifier in modifier_parts {
+        match modifier.to_lowercase().as_str() {
+            "c" | "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+            "a" | "alt" | "m" | "meta" => modifiers |= KeyModifiers::ALT,
+            "s" | "shift" => modifiers |= KeyModifiers::SHIFT,
+            _ => return None,
+        }
     }
 
-    // Alt/Meta key: <A-x> or <M-x>
-    if (inner_lower.starts_with("a-") || inner_lower.starts_with("m-")) && inner.len() == 3 {
-        let c = inner.chars().nth(2)?;
-        return Some(KeyEvent::new(
-            KeyCode::Char(c.to_ascii_lowercase()),
-            KeyModifiers::ALT,
-        ));
+    let code = parse_special_key_code(key_part, modifiers.contains(KeyModifiers::SHIFT))?;
+    if matches!(code, KeyCode::BackTab) {
+        modifiers |= KeyModifiers::SHIFT;
     }
 
-    // Shift key: <S-x>
-    if inner_lower.starts_with("s-") && inner.len() == 3 {
-        let c = inner.chars().nth(2)?;
-        return Some(KeyEvent::new(
-            KeyCode::Char(c.to_ascii_uppercase()),
-            KeyModifiers::SHIFT,
-        ));
-    }
+    Some(KeyEvent::new(code, modifiers))
+}
 
-    // Function keys: <F1> through <F12>
-    if inner_lower.starts_with('f') {
-        if let Ok(n) = inner[1..].parse::<u8>() {
+fn parse_special_key_code(key: &str, shifted: bool) -> Option<KeyCode> {
+    let key_lower = key.to_lowercase();
+
+    if key_lower.starts_with('f') {
+        if let Ok(n) = key[1..].parse::<u8>() {
             if (1..=12).contains(&n) {
-                return Some(KeyEvent::new(KeyCode::F(n), KeyModifiers::NONE));
+                return Some(KeyCode::F(n));
             }
         }
     }
 
-    // Special named keys
-    match inner_lower.as_str() {
-        "cr" | "enter" | "return" => Some(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-        "esc" | "escape" => Some(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
-        "tab" => Some(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
-        "backtab" => Some(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT)),
-        "bs" | "backspace" => Some(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
-        "del" | "delete" => Some(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE)),
-        "space" => Some(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE)),
-        "up" => Some(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
-        "down" => Some(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
-        "left" => Some(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)),
-        "right" => Some(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
-        "home" => Some(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
-        "end" => Some(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
-        "pageup" => Some(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
-        "pagedown" => Some(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
-        "insert" => Some(KeyEvent::new(KeyCode::Insert, KeyModifiers::NONE)),
+    match key_lower.as_str() {
+        "cr" | "enter" | "return" => Some(KeyCode::Enter),
+        "esc" | "escape" => Some(KeyCode::Esc),
+        "tab" if shifted => Some(KeyCode::BackTab),
+        "tab" => Some(KeyCode::Tab),
+        "backtab" => Some(KeyCode::BackTab),
+        "bs" | "backspace" => Some(KeyCode::Backspace),
+        "del" | "delete" => Some(KeyCode::Delete),
+        "space" => Some(KeyCode::Char(' ')),
+        "up" => Some(KeyCode::Up),
+        "down" => Some(KeyCode::Down),
+        "left" => Some(KeyCode::Left),
+        "right" => Some(KeyCode::Right),
+        "home" => Some(KeyCode::Home),
+        "end" => Some(KeyCode::End),
+        "pageup" => Some(KeyCode::PageUp),
+        "pagedown" => Some(KeyCode::PageDown),
+        "insert" => Some(KeyCode::Insert),
+        _ if key.chars().count() == 1 => {
+            let ch = key.chars().next()?;
+            let ch = if shifted {
+                ch.to_ascii_uppercase()
+            } else {
+                ch.to_ascii_lowercase()
+            };
+            Some(KeyCode::Char(ch))
+        }
         _ => None,
     }
 }
@@ -506,6 +510,21 @@ mod tests {
         let key = parse_key_notation("<C-r>").unwrap();
         assert_eq!(key.code, KeyCode::Char('r'));
         assert_eq!(key.modifiers, KeyModifiers::CONTROL);
+    }
+
+    #[test]
+    fn test_parse_combined_modifiers_for_terminal_shortcuts() {
+        let key = parse_key_notation("<C-S-t>").unwrap();
+        assert_eq!(key.code, KeyCode::Char('T'));
+        assert_eq!(key.modifiers, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+
+        let key = parse_key_notation("<C-Tab>").unwrap();
+        assert_eq!(key.code, KeyCode::Tab);
+        assert_eq!(key.modifiers, KeyModifiers::CONTROL);
+
+        let key = parse_key_notation("<C-S-Tab>").unwrap();
+        assert_eq!(key.code, KeyCode::BackTab);
+        assert_eq!(key.modifiers, KeyModifiers::CONTROL | KeyModifiers::SHIFT);
     }
 
     #[test]
@@ -625,6 +644,15 @@ mod tests {
             ("fb", "FindBuffers"),
             ("ft", "Themes"),
             ("tt", "Terminals"),
+            ("tn", "TerminalNew"),
+            ("tj", "TerminalNext"),
+            ("tk", "TerminalPrev"),
+            ("tr", "TerminalRename"),
+            ("tx", "TerminalKill"),
+            ("t1", "TerminalSelect 1"),
+            ("t2", "TerminalSelect 2"),
+            ("t3", "TerminalSelect 3"),
+            ("t4", "TerminalSelect 4"),
             ("d", "FindDiagnostics"),
             ("D", "DiagnosticFloat"),
             ("gg", "LazyGit"),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -134,6 +134,8 @@ pub struct TerminalSettings {
     pub popup_width_ratio: f32,
     /// Floating terminal height as a ratio of the editor height (default: 0.9)
     pub popup_height_ratio: f32,
+    /// Floating terminal shortcut settings.
+    pub shortcuts: TerminalShortcutSettings,
 }
 
 impl Default for TerminalSettings {
@@ -141,6 +143,34 @@ impl Default for TerminalSettings {
         Self {
             popup_width_ratio: 0.9,
             popup_height_ratio: 0.9,
+            shortcuts: TerminalShortcutSettings::default(),
+        }
+    }
+}
+
+/// Floating terminal focused shortcut settings.
+///
+/// Set any shortcut to "none" to disable it.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct TerminalShortcutSettings {
+    /// Create a new terminal session while the floating terminal is focused.
+    pub new_session: String,
+    /// Switch to the next terminal session while the floating terminal is focused.
+    pub next_session: String,
+    /// Switch to the previous terminal session while the floating terminal is focused.
+    pub previous_session: String,
+    /// Close the current terminal session while the floating terminal is focused.
+    pub close_session: String,
+}
+
+impl Default for TerminalShortcutSettings {
+    fn default() -> Self {
+        Self {
+            new_session: "<C-S-t>".to_string(),
+            next_session: "<C-Tab>".to_string(),
+            previous_session: "<C-S-Tab>".to_string(),
+            close_session: "<C-S-w>".to_string(),
         }
     }
 }
@@ -345,6 +375,51 @@ impl Default for KeymapSettings {
                     key: "tt".to_string(),
                     action: ":Terminals".to_string(),
                     desc: Some("Open terminal picker".to_string()),
+                },
+                LeaderMapping {
+                    key: "tn".to_string(),
+                    action: ":TerminalNew".to_string(),
+                    desc: Some("New terminal session".to_string()),
+                },
+                LeaderMapping {
+                    key: "tj".to_string(),
+                    action: ":TerminalNext".to_string(),
+                    desc: Some("Next terminal session".to_string()),
+                },
+                LeaderMapping {
+                    key: "tk".to_string(),
+                    action: ":TerminalPrev".to_string(),
+                    desc: Some("Previous terminal session".to_string()),
+                },
+                LeaderMapping {
+                    key: "tr".to_string(),
+                    action: ":TerminalRename".to_string(),
+                    desc: Some("Rename terminal session".to_string()),
+                },
+                LeaderMapping {
+                    key: "tx".to_string(),
+                    action: ":TerminalKill".to_string(),
+                    desc: Some("Kill terminal session".to_string()),
+                },
+                LeaderMapping {
+                    key: "t1".to_string(),
+                    action: ":TerminalSelect 1".to_string(),
+                    desc: Some("Terminal session 1".to_string()),
+                },
+                LeaderMapping {
+                    key: "t2".to_string(),
+                    action: ":TerminalSelect 2".to_string(),
+                    desc: Some("Terminal session 2".to_string()),
+                },
+                LeaderMapping {
+                    key: "t3".to_string(),
+                    action: ":TerminalSelect 3".to_string(),
+                    desc: Some("Terminal session 3".to_string()),
+                },
+                LeaderMapping {
+                    key: "t4".to_string(),
+                    action: ":TerminalSelect 4".to_string(),
+                    desc: Some("Terminal session 4".to_string()),
                 },
                 // Keymap cheatsheet
                 LeaderMapping {
@@ -726,6 +801,12 @@ fn default_config_template() -> &'static str {
 # [terminal]
 # popup_width_ratio = 0.9     # Width as a fraction of the screen (0.2 to 1.0)
 # popup_height_ratio = 0.9    # Height as a fraction of the screen (0.2 to 1.0)
+#
+# [terminal.shortcuts]
+# new_session = "<C-S-t>"       # Set to "none" to disable
+# next_session = "<C-Tab>"
+# previous_session = "<C-S-Tab>"
+# close_session = "<C-S-w>"
 
 # ============================================================================
 # FINDER (Fuzzy file picker, grep)
@@ -1020,6 +1101,12 @@ fn default_config_template() -> &'static str {
 # <leader>fb       - Find buffers
 # <leader>ft       - Theme picker
 # <leader>tt       - Terminal picker
+# <leader>tn       - New terminal session
+# <leader>tj       - Next terminal session
+# <leader>tk       - Previous terminal session
+# <leader>tr       - Rename terminal session
+# <leader>tx       - Kill terminal session
+# <leader>t1..t4   - Jump to terminal session 1..4
 # <leader>fk       - Search keymaps
 #
 # Floating terminal:
@@ -1365,6 +1452,30 @@ mod tests {
         .expect("parse settings");
 
         assert!(!settings.keymap.show_leader_popup);
+    }
+
+    #[test]
+    fn terminal_shortcuts_have_defaults_and_are_partially_configurable() {
+        let settings = Settings::default();
+
+        assert_eq!(settings.terminal.shortcuts.new_session, "<C-S-t>");
+        assert_eq!(settings.terminal.shortcuts.next_session, "<C-Tab>");
+        assert_eq!(settings.terminal.shortcuts.previous_session, "<C-S-Tab>");
+        assert_eq!(settings.terminal.shortcuts.close_session, "<C-S-w>");
+
+        let settings: Settings = toml::from_str(
+            r#"
+            [terminal.shortcuts]
+            next_session = "<F6>"
+            close_session = "none"
+            "#,
+        )
+        .expect("parse settings");
+
+        assert_eq!(settings.terminal.shortcuts.new_session, "<C-S-t>");
+        assert_eq!(settings.terminal.shortcuts.next_session, "<F6>");
+        assert_eq!(settings.terminal.shortcuts.previous_session, "<C-S-Tab>");
+        assert_eq!(settings.terminal.shortcuts.close_session, "none");
     }
 }
 

--- a/src/floating_terminal.rs
+++ b/src/floating_terminal.rs
@@ -1673,27 +1673,52 @@ enum TerminalSessionControlAction {
     Close,
 }
 
-fn terminal_session_control_action(key: KeyEvent) -> Option<TerminalSessionControlAction> {
-    let has_ctrl = key.modifiers.contains(CrosstermKeyModifiers::CONTROL);
-    let has_shift = key.modifiers.contains(CrosstermKeyModifiers::SHIFT);
-    let has_alt = key.modifiers.contains(CrosstermKeyModifiers::ALT);
+fn configured_terminal_session_control_action(
+    key: KeyEvent,
+    settings: &crate::config::TerminalSettings,
+) -> Option<TerminalSessionControlAction> {
+    let shortcuts = &settings.shortcuts;
 
-    if has_alt || !has_ctrl {
-        return None;
+    if terminal_shortcut_matches(key, &shortcuts.new_session) {
+        Some(TerminalSessionControlAction::New)
+    } else if terminal_shortcut_matches(key, &shortcuts.next_session) {
+        Some(TerminalSessionControlAction::Next)
+    } else if terminal_shortcut_matches(key, &shortcuts.previous_session) {
+        Some(TerminalSessionControlAction::Previous)
+    } else if terminal_shortcut_matches(key, &shortcuts.close_session) {
+        Some(TerminalSessionControlAction::Close)
+    } else {
+        None
+    }
+}
+
+fn terminal_shortcut_matches(key: KeyEvent, shortcut: &str) -> bool {
+    let shortcut = shortcut.trim();
+    if shortcut.is_empty() || shortcut.eq_ignore_ascii_case("none") {
+        return false;
     }
 
-    match key.code {
-        KeyCode::Char('t' | 'T') if has_shift || matches!(key.code, KeyCode::Char('T')) => {
-            Some(TerminalSessionControlAction::New)
+    crate::config::keymap::parse_key_notation(shortcut).is_some_and(|configured| {
+        normalize_terminal_shortcut_key(configured) == normalize_terminal_shortcut_key(key)
+    })
+}
+
+fn normalize_terminal_shortcut_key(key: KeyEvent) -> KeyEvent {
+    let mut modifiers = key.modifiers;
+    let code = match key.code {
+        KeyCode::Char(ch)
+            if modifiers.contains(CrosstermKeyModifiers::SHIFT) && ch.is_ascii_lowercase() =>
+        {
+            KeyCode::Char(ch.to_ascii_uppercase())
         }
-        KeyCode::Char('w' | 'W') if has_shift || matches!(key.code, KeyCode::Char('W')) => {
-            Some(TerminalSessionControlAction::Close)
+        KeyCode::Char(ch) if ch.is_ascii_uppercase() => {
+            modifiers |= CrosstermKeyModifiers::SHIFT;
+            KeyCode::Char(ch)
         }
-        KeyCode::Tab if has_shift => Some(TerminalSessionControlAction::Previous),
-        KeyCode::BackTab => Some(TerminalSessionControlAction::Previous),
-        KeyCode::Tab => Some(TerminalSessionControlAction::Next),
-        _ => None,
-    }
+        other => other,
+    };
+
+    KeyEvent::new(code, modifiers)
 }
 
 impl FloatingTerminal {
@@ -1905,12 +1930,16 @@ impl FloatingTerminal {
         active.handle_search_key(key)
     }
 
-    pub fn handle_session_control_key(&mut self, key: crossterm::event::KeyEvent) -> bool {
+    pub fn handle_session_control_key(
+        &mut self,
+        key: crossterm::event::KeyEvent,
+        settings: &crate::config::TerminalSettings,
+    ) -> bool {
         if !self.is_visible() {
             return false;
         }
 
-        let Some(action) = terminal_session_control_action(key) else {
+        let Some(action) = configured_terminal_session_control_action(key, settings) else {
             return false;
         };
 
@@ -2795,35 +2824,46 @@ mod tests {
     fn terminal_session_control_shortcuts_manage_sessions() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+        let settings = crate::config::TerminalSettings::default();
         let mut terminal = FloatingTerminal::new();
         terminal.push_session(Some("server".to_string()));
         terminal.push_session(Some("logs".to_string()));
         terminal.active = Some(0);
         terminal.sessions[0].visible = true;
 
-        assert!(
-            terminal.handle_session_control_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL))
-        );
+        assert!(terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL),
+            &settings,
+        ));
         assert_eq!(terminal.session_infos()[1].active, true);
 
-        assert!(terminal.handle_session_control_key(KeyEvent::new(
-            KeyCode::BackTab,
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT
-        )));
+        assert!(terminal.handle_session_control_key(
+            KeyEvent::new(
+                KeyCode::BackTab,
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            ),
+            &settings
+        ));
         assert_eq!(terminal.session_infos()[0].active, true);
 
-        assert!(terminal.handle_session_control_key(KeyEvent::new(
-            KeyCode::Char('t'),
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT
-        )));
+        assert!(terminal.handle_session_control_key(
+            KeyEvent::new(
+                KeyCode::Char('t'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            ),
+            &settings
+        ));
         assert_eq!(terminal.session_infos().len(), 3);
         assert_eq!(terminal.session_infos()[2].name, "term-3");
         assert!(terminal.session_infos()[2].active);
 
-        assert!(terminal.handle_session_control_key(KeyEvent::new(
-            KeyCode::Char('w'),
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT
-        )));
+        assert!(terminal.handle_session_control_key(
+            KeyEvent::new(
+                KeyCode::Char('w'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            ),
+            &settings
+        ));
         assert_eq!(terminal.session_infos().len(), 2);
         assert!(terminal.session_infos()[1].active);
         assert_eq!(terminal.session_infos()[1].state, "visible");
@@ -2833,18 +2873,50 @@ mod tests {
     fn terminal_session_control_ignores_regular_terminal_input() {
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
+        let settings = crate::config::TerminalSettings::default();
         let mut terminal = FloatingTerminal::new();
         terminal.push_session(Some("server".to_string()));
         terminal.active = Some(0);
         terminal.sessions[0].visible = true;
 
-        assert!(!terminal
-            .handle_session_control_key(KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL)));
-        assert!(!terminal
-            .handle_session_control_key(KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL)));
-        assert!(
-            !terminal.handle_session_control_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE))
-        );
+        assert!(!terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            &settings,
+        ));
+        assert!(!terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+            &settings,
+        ));
+        assert!(!terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE),
+            &settings,
+        ));
+    }
+
+    #[test]
+    fn terminal_session_control_shortcuts_follow_configured_keys() {
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+        let mut settings = crate::config::TerminalSettings::default();
+        settings.shortcuts.next_session = "<F6>".to_string();
+
+        let mut terminal = FloatingTerminal::new();
+        terminal.push_session(Some("server".to_string()));
+        terminal.push_session(Some("logs".to_string()));
+        terminal.active = Some(0);
+        terminal.sessions[0].visible = true;
+
+        assert!(!terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::Tab, KeyModifiers::CONTROL),
+            &settings,
+        ));
+        assert_eq!(terminal.session_infos()[0].active, true);
+
+        assert!(terminal.handle_session_control_key(
+            KeyEvent::new(KeyCode::F(6), KeyModifiers::NONE),
+            &settings,
+        ));
+        assert_eq!(terminal.session_infos()[1].active, true);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6235,7 +6235,10 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
 
     // If floating terminal is visible, handle its keys
     if editor.floating_terminal.is_visible() {
-        if editor.floating_terminal.handle_session_control_key(key) {
+        if editor
+            .floating_terminal
+            .handle_session_control_key(key, &editor.settings.terminal)
+        {
             return;
         }
 
@@ -9409,6 +9412,22 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
                 Err(e) => CommandResult::Error(format!("Terminal rename failed: {}", e)),
             }
         }
+        Command::TerminalRenamePrompt => {
+            if let Some(session) = editor
+                .floating_terminal
+                .session_infos()
+                .into_iter()
+                .find(|session| session.active)
+            {
+                editor.enter_command_mode_with_input(format!(
+                    "termrename {} {}",
+                    session.position, session.name
+                ));
+                CommandResult::Ok
+            } else {
+                CommandResult::Error("Terminal rename failed: No terminal session".to_string())
+            }
+        }
         Command::TerminalKill => {
             editor.floating_terminal.close();
             CommandResult::Message("Terminal killed".to_string())
@@ -11691,6 +11710,21 @@ mod tests {
         assert_eq!(editor.finder.mode, FinderMode::Files);
         assert!(editor.leader_sequence.is_none());
         assert!(editor.leader_popup_items().is_empty());
+    }
+
+    #[test]
+    fn leader_terminal_rename_prefills_active_session_command() {
+        let mut editor = Editor::default();
+        editor
+            .floating_terminal
+            .create_session(Some("server".to_string()))
+            .unwrap();
+
+        let action = editor.keymap.get_leader_action("tr").cloned().unwrap();
+        execute_leader_action(&mut editor, &action);
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "termrename 1 server");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add default leader mappings for terminal session workflows: new, next, previous, rename, kill, and direct session jumps.
- Make floating-terminal session shortcuts configurable under [terminal.shortcuts], including support for disabling with "none".
- Add combined key notation parsing for shortcuts like <C-S-t> and document the new workflow/config options.
