### PR TITLE
feat: add command-line Ctrl-b keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -762,6 +762,19 @@ See [Leader Key Mappings](#leader-key-mappings) for adding files and jumping to 
 
 Type `:` to enter command mode. Implemented commands include:
 
+### Command-Line Editing
+
+While typing an Ex command after `:`.
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+b` | Move to beginning of command line |
+| `Ctrl+e` | Move to end of command line |
+| `Ctrl+r` | Toggle command history window |
+| `Tab` | Accept selected command completion |
+| `Shift+Tab` | Accept previous completion |
+| `Ctrl+n` / `Ctrl+p` | Select next / previous popup item |
+
 ### File Operations
 
 | Command | Action |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 284 keybinds implemented, 83 planned Vim/Neovim parity defaults.**
+**Status: 286 keybinds implemented, 81 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,8 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+b` | Move to beginning of the command line |
-| `Ctrl+e` | Move to end of the command line |
 | `Ctrl+w` | Delete the word before the cursor |
 | `Ctrl+u` | Delete from cursor back to the start of the command line |
 | `Ctrl+r {reg}` | Insert register contents into the command line |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1140,6 +1140,8 @@ fn default_config_template() -> &'static str {
 # ----------------------------------------------------------------------------
 # COMMAND MODE (while typing `:`)
 # ----------------------------------------------------------------------------
+# Ctrl+b           - Move to beginning of command line
+# Ctrl+e           - Move to end of command line
 # Ctrl+r           - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -109,6 +109,7 @@ fn mode_tag(mode: &str) -> &str {
         "insert" => "i",
         "leader" => "leader",
         "commands" => "cmd",
+        "cmdline" => "cmdline",
         "finder" => "finder",
         "terminal" => "term",
         "text_objects" => "text-obj",
@@ -152,16 +153,16 @@ pub fn keymap_finder_items(keymap: &KeymapSettings) -> Vec<FinderItem> {
     entries.iter().map(entry_to_item).collect()
 }
 
-/// True if the user has remapped `key` in the given mode (normal/visual/insert),
-/// so the built-in default row should be replaced by the user's remap.
+/// True if the user has remapped `key` in the given mode, so the built-in
+/// default row should be replaced by the user's remap.
 fn is_remapped(keymap: &KeymapSettings, mode: &str, key: &str) -> bool {
-    let remaps = match mode {
-        "normal" => &keymap.normal,
-        "visual" => &keymap.visual,
-        "insert" => &keymap.insert,
-        _ => return false,
-    };
-    remaps.iter().any(|entry| entry.from == key)
+    match mode {
+        "normal" => keymap.normal.iter().any(|entry| entry.from == key),
+        "visual" => keymap.visual.iter().any(|entry| entry.from == key),
+        "insert" => keymap.insert.iter().any(|entry| entry.from == key),
+        "cmdline" => keymap.command_mappings.iter().any(|entry| entry.key == key),
+        _ => false,
+    }
 }
 
 /// Rows for the user's own normal/visual/insert remaps, from the live config.
@@ -368,6 +369,27 @@ vim_default = true
                 .iter()
                 .any(|item| item.display.contains("<C-r>") && item.display.contains("history")),
             "command-line UX mappings (e.g. <C-r> history) should appear"
+        );
+    }
+
+    #[test]
+    fn picker_includes_builtin_command_line_editing_keys() {
+        let items = keymap_finder_items(&KeymapSettings::default());
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("cmdline")
+                    && item.display.contains("<C-b>")
+                    && item.display.contains("beginning")
+            }),
+            "command-line Ctrl+b should appear in :Keymaps"
+        );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("cmdline")
+                    && item.display.contains("<C-e>")
+                    && item.display.contains("end")
+            }),
+            "command-line Ctrl+e should appear in :Keymaps"
         );
     }
 

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1929,6 +1929,24 @@ status = "implemented"
 vim_default = true
 
 # ============================================================================
+# COMMAND-LINE EDITING (while typing `:`)
+# ============================================================================
+
+[[cmdline.editing]]
+key = "<C-b>"
+action = "command_line_begin"
+desc = "Move to beginning of command line"
+status = "implemented"
+vim_default = true
+
+[[cmdline.editing]]
+key = "<C-e>"
+action = "command_line_end"
+desc = "Move to end of command line"
+status = "implemented"
+vim_default = true
+
+# ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7660,7 +7660,9 @@ fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
         (KeyModifiers::NONE, KeyCode::Right) => {
             editor.command_line.move_right();
         }
-        (KeyModifiers::CONTROL, KeyCode::Char('a')) | (KeyModifiers::NONE, KeyCode::Home) => {
+        (KeyModifiers::CONTROL, KeyCode::Char('a'))
+        | (KeyModifiers::CONTROL, KeyCode::Char('b'))
+        | (KeyModifiers::NONE, KeyCode::Home) => {
             editor.command_line.move_to_start();
         }
         (KeyModifiers::CONTROL, KeyCode::Char('e')) | (KeyModifiers::NONE, KeyCode::End) => {
@@ -9618,6 +9620,31 @@ mod tests {
 
     fn numbered_lines(count: usize) -> Vec<String> {
         (1..=count).map(|line| format!("line {}", line)).collect()
+    }
+
+    #[test]
+    fn command_ctrl_b_moves_to_beginning_of_command_line() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write buffer");
+
+        handle_key(&mut editor, ctrl_key('b'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write buffer");
+        assert_eq!(editor.command_line.cursor, 0);
+    }
+
+    #[test]
+    fn command_ctrl_e_moves_to_end_of_command_line() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write buffer");
+        editor.command_line.cursor = 2;
+
+        handle_key(&mut editor, ctrl_key('e'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write buffer");
+        assert_eq!(editor.command_line.cursor, "write buffer".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim default Ctrl+b in command-line mode to move to the beginning of the command line.
- Add command-line Ctrl+b/Ctrl+e regression coverage and :Keymaps discoverability.
- Update keybinding docs, generated config comments, and roadmap counts.

