### PR TITLE
feat: add command-line Ctrl-w keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -770,6 +770,7 @@ While typing an Ex command after `:`.
 |-----|--------|
 | `Ctrl+b` | Move to beginning of command line |
 | `Ctrl+e` | Move to end of command line |
+| `Ctrl+w` | Delete word before cursor |
 | `Ctrl+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 286 keybinds implemented, 81 planned Vim/Neovim parity defaults.**
+**Status: 287 keybinds implemented, 80 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+w` | Delete the word before the cursor |
 | `Ctrl+u` | Delete from cursor back to the start of the command line |
 | `Ctrl+r {reg}` | Insert register contents into the command line |
 | `Ctrl+d` | List command-line completions |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1197,6 +1197,48 @@ impl CommandLine {
         }
     }
 
+    /// Delete the word before the cursor, matching Vim command-line Ctrl+w.
+    pub fn delete_word_before(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let chars: Vec<char> = self.input.chars().collect();
+        let start_cursor = self.cursor.min(chars.len());
+        let mut cursor = start_cursor;
+
+        while cursor > 0 && chars[cursor - 1].is_whitespace() {
+            cursor -= 1;
+        }
+
+        if cursor > 0 {
+            let delete_word_chars = chars[cursor - 1].is_alphanumeric() || chars[cursor - 1] == '_';
+            if delete_word_chars {
+                while cursor > 0
+                    && (chars[cursor - 1].is_alphanumeric() || chars[cursor - 1] == '_')
+                {
+                    cursor -= 1;
+                }
+            } else {
+                while cursor > 0 {
+                    let ch = chars[cursor - 1];
+                    if ch.is_whitespace() || ch.is_alphanumeric() || ch == '_' {
+                        break;
+                    }
+                    cursor -= 1;
+                }
+            }
+        }
+
+        if cursor < start_cursor {
+            let start_byte = self.char_to_byte_index(cursor);
+            let end_byte = self.char_to_byte_index(start_cursor);
+            self.input.replace_range(start_byte..end_byte, "");
+            self.cursor = cursor;
+            self.on_input_edited();
+        }
+    }
+
     /// Move cursor left
     pub fn move_left(&mut self) {
         if self.cursor > 0 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1142,6 +1142,7 @@ fn default_config_template() -> &'static str {
 # ----------------------------------------------------------------------------
 # Ctrl+b           - Move to beginning of command line
 # Ctrl+e           - Move to end of command line
+# Ctrl+w           - Delete word before cursor
 # Ctrl+r           - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -391,6 +391,14 @@ vim_default = true
             }),
             "command-line Ctrl+e should appear in :Keymaps"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("cmdline")
+                    && item.display.contains("<C-w>")
+                    && item.display.contains("Delete word")
+            }),
+            "command-line Ctrl+w should appear in :Keymaps"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1946,6 +1946,13 @@ desc = "Move to end of command line"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-w>"
+action = "command_line_delete_word_before"
+desc = "Delete word before cursor"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7653,6 +7653,11 @@ fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
             editor.command_line.delete_char_at();
         }
 
+        // Delete word before cursor
+        (KeyModifiers::CONTROL, KeyCode::Char('w')) => {
+            editor.command_line.delete_word_before();
+        }
+
         // Cursor movement
         (KeyModifiers::NONE, KeyCode::Left) => {
             editor.command_line.move_left();
@@ -9645,6 +9650,30 @@ mod tests {
         assert_eq!(editor.mode, Mode::Command);
         assert_eq!(editor.command_line.input, "write buffer");
         assert_eq!(editor.command_line.cursor, "write buffer".chars().count());
+    }
+
+    #[test]
+    fn command_ctrl_w_deletes_word_before_command_line_cursor() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write foo bar");
+
+        handle_key(&mut editor, ctrl_key('w'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write foo ");
+        assert_eq!(editor.command_line.cursor, "write foo ".chars().count());
+    }
+
+    #[test]
+    fn command_ctrl_w_skips_trailing_spaces_before_deleting_word() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write foo   ");
+
+        handle_key(&mut editor, ctrl_key('w'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write ");
+        assert_eq!(editor.command_line.cursor, "write ".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim default Ctrl+w in command-line mode to delete the word before the cursor.
- Add command-line Ctrl+w regression coverage and :Keymaps discoverability.
- Update keybinding docs, generated config comments, and roadmap counts.

## Test Plan
- [x] cargo test
- [x] cargo fmt --check
- [x] git diff --check origin/master...HEAD
- [x] Manual test: :write foo bar, Ctrl+w leaves :write foo
- [x] Manual test: :write foo   , Ctrl+w leaves :write