### PR TITLE
feat: add command-line Ctrl-u keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -771,6 +771,7 @@ While typing an Ex command after `:`.
 | `Ctrl+b` | Move to beginning of command line |
 | `Ctrl+e` | Move to end of command line |
 | `Ctrl+w` | Delete word before cursor |
+| `Ctrl+u` | Delete from cursor to beginning of command line |
 | `Ctrl+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 287 keybinds implemented, 80 planned Vim/Neovim parity defaults.**
+**Status: 288 keybinds implemented, 79 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+u` | Delete from cursor back to the start of the command line |
 | `Ctrl+r {reg}` | Insert register contents into the command line |
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete the longest common prefix |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1239,6 +1239,18 @@ impl CommandLine {
         }
     }
 
+    /// Delete from the cursor back to the start of the command line.
+    pub fn delete_to_start(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let end_byte = self.char_to_byte_index(self.cursor);
+        self.input.replace_range(0..end_byte, "");
+        self.cursor = 0;
+        self.on_input_edited();
+    }
+
     /// Move cursor left
     pub fn move_left(&mut self) {
         if self.cursor > 0 {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1143,6 +1143,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+b           - Move to beginning of command line
 # Ctrl+e           - Move to end of command line
 # Ctrl+w           - Delete word before cursor
+# Ctrl+u           - Delete from cursor to beginning of command line
 # Ctrl+r           - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -399,6 +399,14 @@ vim_default = true
             }),
             "command-line Ctrl+w should appear in :Keymaps"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("cmdline")
+                    && item.display.contains("<C-u>")
+                    && item.display.contains("beginning")
+            }),
+            "command-line Ctrl+u should appear in :Keymaps"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1953,6 +1953,13 @@ desc = "Delete word before cursor"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-u>"
+action = "command_line_delete_to_start"
+desc = "Delete from cursor to beginning of command line"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7690,9 +7690,9 @@ fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
             }
         }
 
-        // Clear line
+        // Delete from cursor to start
         (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
-            editor.command_line.begin_prompt();
+            editor.command_line.delete_to_start();
         }
 
         // Regular character - accept any modifier for printable chars
@@ -9674,6 +9674,19 @@ mod tests {
         assert_eq!(editor.mode, Mode::Command);
         assert_eq!(editor.command_line.input, "write ");
         assert_eq!(editor.command_line.cursor, "write ".chars().count());
+    }
+
+    #[test]
+    fn command_ctrl_u_deletes_from_command_line_cursor_to_start() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write foo bar");
+        editor.command_line.cursor = "write foo ".chars().count();
+
+        handle_key(&mut editor, ctrl_key('u'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "bar");
+        assert_eq!(editor.command_line.cursor, 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim-compatible Ctrl+u in command-line mode to delete from cursor to beginning.
- Add regression coverage for preserving text after the command-line cursor.
- Update keybinding docs, generated config comments, :Keymaps, and roadmap counts.

## Test Plan
- [x] cargo test
- [x] cargo fmt --check
- [x] git diff --check
- [x] Manual test: :write foo bar with cursor before bar, Ctrl+u leaves :bar