### PR TITLE
feat: add command-line Ctrl-r register keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -772,7 +772,8 @@ While typing an Ex command after `:`.
 | `Ctrl+e` | Move to end of command line |
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+u` | Delete from cursor to beginning of command line |
-| `Ctrl+r` | Toggle command history window |
+| `Ctrl+r {reg}` | Insert register contents |
+| `Alt+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |
 | `Ctrl+n` / `Ctrl+p` | Select next / previous popup item |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 288 keybinds implemented, 79 planned Vim/Neovim parity defaults.**
+**Status: 289 keybinds implemented, 78 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+r {reg}` | Insert register contents into the command line |
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete the longest common prefix |
 | `Ctrl+a` | Insert all matching completions |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1120,6 +1120,8 @@ pub struct CommandLine {
     pub history_popup_items: Vec<String>,
     /// Selected item in history popup
     pub history_popup_index: usize,
+    /// Waiting for a register name after command-line Ctrl+r
+    pub pending_register: bool,
 }
 
 impl CommandLine {
@@ -1154,6 +1156,7 @@ impl CommandLine {
         self.suggestion_index = 0;
         self.history_popup_items.clear();
         self.history_popup_index = 0;
+        self.pending_register = false;
     }
 
     /// Convert char index to byte index
@@ -1175,6 +1178,18 @@ impl CommandLine {
         let byte_idx = self.char_to_byte_index(self.cursor);
         self.input.insert(byte_idx, ch);
         self.cursor += 1;
+        self.on_input_edited();
+    }
+
+    /// Insert text at the command-line cursor.
+    pub fn insert_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+
+        let byte_idx = self.char_to_byte_index(self.cursor);
+        self.input.insert_str(byte_idx, text);
+        self.cursor += text.chars().count();
         self.on_input_edited();
     }
 

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -40,6 +40,8 @@ struct LeaderMetadata {
 pub enum CommandModeAction {
     /// Toggle history popup window
     HistoryToggle,
+    /// Insert the next typed register into the command line
+    InsertRegister,
     /// Accept current completion/history selection
     Complete,
     /// Move selection backward and accept completion
@@ -368,6 +370,7 @@ fn parse_action(action: &str) -> LeaderAction {
 fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
     match action.trim().to_lowercase().as_str() {
         "history_toggle" => Some(CommandModeAction::HistoryToggle),
+        "insert_register" => Some(CommandModeAction::InsertRegister),
         "complete" => Some(CommandModeAction::Complete),
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -238,6 +238,11 @@ impl Default for KeymapSettings {
             command_mappings: vec![
                 CommandModeMapping {
                     key: "<C-r>".to_string(),
+                    action: "insert_register".to_string(),
+                    desc: Some("Insert register contents".to_string()),
+                },
+                CommandModeMapping {
+                    key: "<A-r>".to_string(),
                     action: "history_toggle".to_string(),
                     desc: Some("Toggle command history window".to_string()),
                 },
@@ -456,9 +461,9 @@ pub struct LeaderMapping {
 /// A command-mode mapping for command-line UX actions
 #[derive(Debug, Clone, Deserialize)]
 pub struct CommandModeMapping {
-    /// Key notation (e.g., "<C-r>", "<Tab>", "<BackTab>")
+    /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (history_toggle, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, history_toggle, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1144,7 +1149,8 @@ fn default_config_template() -> &'static str {
 # Ctrl+e           - Move to end of command line
 # Ctrl+w           - Delete word before cursor
 # Ctrl+u           - Delete from cursor to beginning of command line
-# Ctrl+r           - Toggle command history window
+# Ctrl+r {reg}     - Insert register contents
+# Alt+r            - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion
 # Ctrl+n / Ctrl+p  - Next / previous popup item

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3695,6 +3695,22 @@ impl Editor {
         true
     }
 
+    /// Insert text from a register at the command-line cursor.
+    pub fn insert_register_text_into_command_line(&mut self, register: char) -> bool {
+        let Some(content) = self.register_content_for_paste(Some(register)) else {
+            return false;
+        };
+        let text = match content {
+            RegisterContent::Chars(text) | RegisterContent::Lines(text) => text,
+        };
+        if text.is_empty() {
+            return false;
+        }
+
+        self.command_line.insert_text(&text);
+        true
+    }
+
     /// Begin collecting expression-register input.
     pub fn start_expression_register(&mut self, target: ExpressionRegisterTarget) {
         self.pending_expression_register = Some(target);

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -240,7 +240,7 @@ fn leader_entries(leader_mappings: &[LeaderMapping]) -> Vec<KeybindEntry> {
 }
 
 /// Rows for the command-line UX mappings (keys active while typing a `:`
-/// command, e.g. `<C-r>` for history), from the live config.
+/// command, e.g. `<A-r>` for history), from the live config.
 fn command_mode_entries(keymap: &KeymapSettings) -> Vec<KeybindEntry> {
     keymap
         .command_mappings
@@ -367,8 +367,14 @@ vim_default = true
         assert!(
             items
                 .iter()
-                .any(|item| item.display.contains("<C-r>") && item.display.contains("history")),
-            "command-line UX mappings (e.g. <C-r> history) should appear"
+                .any(|item| item.display.contains("<C-r>") && item.display.contains("register")),
+            "command-line UX mappings (e.g. <C-r> register insertion) should appear"
+        );
+        assert!(
+            items
+                .iter()
+                .any(|item| item.display.contains("<A-r>") && item.display.contains("history")),
+            "command-line UX mappings (e.g. <A-r> history) should appear"
         );
     }
 

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1960,6 +1960,13 @@ desc = "Delete from cursor to beginning of command line"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-r>{reg}"
+action = "command_line_insert_register"
+desc = "Insert register contents"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2696,8 +2696,8 @@ impl Terminal {
         }
 
         let header_text = match command_line.popup_mode {
-            CommandPopupMode::Completion => "[COMMANDS] Tab:accept  Shift+Tab:prev  Ctrl+r:history",
-            CommandPopupMode::History => "[HISTORY] Enter/Tab:use  Ctrl+n/p:move  Ctrl+r:close",
+            CommandPopupMode::Completion => "[COMMANDS] Tab:accept  Shift+Tab:prev  Alt+r:history",
+            CommandPopupMode::History => "[HISTORY] Enter/Tab:use  Ctrl+n/p:move  Alt+r:close",
             CommandPopupMode::None => "",
         };
 
@@ -7586,6 +7586,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::HistoryToggle => {
             editor.command_line.toggle_history_popup();
         }
+        CommandModeAction::InsertRegister => {
+            editor.command_line.pending_register = true;
+        }
         CommandModeAction::Complete => {
             if editor.command_line.popup_mode == CommandPopupMode::History {
                 editor.command_line.accept_history_popup_selection();
@@ -7611,6 +7614,18 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
 }
 
 fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
+    if editor.command_line.pending_register {
+        editor.command_line.pending_register = false;
+        match (key.modifiers, key.code) {
+            (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {}
+            (_, KeyCode::Char(register)) => {
+                editor.insert_register_text_into_command_line(register);
+            }
+            _ => {}
+        }
+        return;
+    }
+
     if let Some(action) = editor.keymap.get_command_action(key) {
         execute_command_mode_action(editor, action);
         return;
@@ -9596,7 +9611,7 @@ mod tests {
         execute_leader_action, finder_preview_match_ranges, handle_insert_mode, handle_key,
         replace_completion_text, Terminal,
     };
-    use crate::commands::Command;
+    use crate::commands::{Command, CommandPopupMode};
     use crate::config::{KeymapEntry, Settings};
     use crate::editor::{Editor, Mode, RegisterContent};
     use crate::finder::FinderMode;
@@ -9617,6 +9632,10 @@ mod tests {
 
     fn ctrl_key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    fn alt_key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)
     }
 
     fn esc_key() -> KeyEvent {
@@ -9687,6 +9706,39 @@ mod tests {
         assert_eq!(editor.mode, Mode::Command);
         assert_eq!(editor.command_line.input, "bar");
         assert_eq!(editor.command_line.cursor, 0);
+    }
+
+    #[test]
+    fn command_ctrl_r_inserts_named_register_text_at_command_cursor() {
+        let mut editor = Editor::default();
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Chars("nevi.txt".to_string()));
+        editor.enter_command_mode_with_input("write bar");
+        editor.command_line.cursor = "write ".chars().count();
+
+        handle_key(&mut editor, ctrl_key('r'));
+        handle_key(&mut editor, key('a'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write nevi.txtbar");
+        assert_eq!(editor.command_line.cursor, "write nevi.txt".chars().count());
+    }
+
+    #[test]
+    fn command_alt_r_toggles_command_history_popup() {
+        let mut editor = Editor::default();
+        editor.command_line.history = vec!["write".to_string()];
+        editor.enter_command_mode();
+
+        handle_key(&mut editor, alt_key('r'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.popup_mode, CommandPopupMode::History);
+
+        handle_key(&mut editor, alt_key('r'));
+
+        assert_ne!(editor.command_line.popup_mode, CommandPopupMode::History);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim-compatible Ctrl+r {reg} in command-line mode to insert register contents at the command cursor.
- Move command-history toggle to Alt+r by default while keeping command-mode actions configurable.
- Update :Keymaps data/tests, keybinding docs, generated config comments, and roadmap counts.

## Test Plan
- [x] cargo test
- [x] cargo fmt --check
- [x] git diff --check
- [x] Manual test: in : mode, Ctrl+r then % inserts the current file path
- [x] Manual test: Alt+r opens/closes command history