### PR TITLE
feat: add command-line Ctrl-d completions keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -773,6 +773,7 @@ While typing an Ex command after `:`.
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+u` | Delete from cursor to beginning of command line |
 | `Ctrl+r {reg}` | Insert register contents |
+| `Ctrl+d` | List command-line completions |
 | `Alt+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 289 keybinds implemented, 78 planned Vim/Neovim parity defaults.**
+**Status: 290 keybinds implemented, 77 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete the longest common prefix |
 | `Ctrl+a` | Insert all matching completions |
 | `Ctrl+f` | Open the command-line window |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1353,6 +1353,21 @@ impl CommandLine {
         self.refresh_history_popup();
     }
 
+    /// Show available command-line completions without accepting one.
+    pub fn list_completions(&mut self) -> bool {
+        self.refresh_command_suggestions();
+        self.history_popup_items.clear();
+        self.history_popup_index = 0;
+
+        if self.suggestions.is_empty() {
+            self.popup_mode = CommandPopupMode::None;
+            false
+        } else {
+            self.popup_mode = CommandPopupMode::Completion;
+            true
+        }
+    }
+
     /// Move selection down in current popup.
     pub fn popup_next(&mut self) {
         match self.popup_mode {

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -42,6 +42,8 @@ pub enum CommandModeAction {
     HistoryToggle,
     /// Insert the next typed register into the command line
     InsertRegister,
+    /// Show available command-line completions
+    ListCompletions,
     /// Accept current completion/history selection
     Complete,
     /// Move selection backward and accept completion
@@ -371,6 +373,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
     match action.trim().to_lowercase().as_str() {
         "history_toggle" => Some(CommandModeAction::HistoryToggle),
         "insert_register" => Some(CommandModeAction::InsertRegister),
+        "list_completions" => Some(CommandModeAction::ListCompletions),
         "complete" => Some(CommandModeAction::Complete),
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -247,6 +247,11 @@ impl Default for KeymapSettings {
                     desc: Some("Toggle command history window".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-d>".to_string(),
+                    action: "list_completions".to_string(),
+                    desc: Some("List command-line completions".to_string()),
+                },
+                CommandModeMapping {
                     key: "<Tab>".to_string(),
                     action: "complete".to_string(),
                     desc: Some("Accept selected command completion".to_string()),
@@ -463,7 +468,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, history_toggle, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, history_toggle, list_completions, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1150,6 +1155,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+w           - Delete word before cursor
 # Ctrl+u           - Delete from cursor to beginning of command line
 # Ctrl+r {reg}     - Insert register contents
+# Ctrl+d           - List command-line completions
 # Alt+r            - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -376,6 +376,12 @@ vim_default = true
                 .any(|item| item.display.contains("<A-r>") && item.display.contains("history")),
             "command-line UX mappings (e.g. <A-r> history) should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("<C-d>") && item.display.contains("completions")
+            }),
+            "command-line UX mappings (e.g. <C-d> completions) should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1967,6 +1967,13 @@ desc = "Insert register contents"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-d>"
+action = "command_line_list_completions"
+desc = "List command-line completions"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7589,6 +7589,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::InsertRegister => {
             editor.command_line.pending_register = true;
         }
+        CommandModeAction::ListCompletions => {
+            editor.command_line.list_completions();
+        }
         CommandModeAction::Complete => {
             if editor.command_line.popup_mode == CommandPopupMode::History {
                 editor.command_line.accept_history_popup_selection();
@@ -9723,6 +9726,25 @@ mod tests {
         assert_eq!(editor.mode, Mode::Command);
         assert_eq!(editor.command_line.input, "write nevi.txtbar");
         assert_eq!(editor.command_line.cursor, "write nevi.txt".chars().count());
+    }
+
+    #[test]
+    fn command_ctrl_d_lists_command_line_completions_without_accepting() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("w");
+        editor.command_line.popup_mode = CommandPopupMode::None;
+
+        handle_key(&mut editor, ctrl_key('d'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "w");
+        assert_eq!(editor.command_line.cursor, 1);
+        assert_eq!(editor.command_line.popup_mode, CommandPopupMode::Completion);
+        assert!(editor
+            .command_line
+            .suggestions
+            .iter()
+            .any(|item| item.command == "w"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the default command-line Ctrl+d mapping for listing command completions
- wire the action through configurable command-mode mappings
- document the keybind in :Keymaps, KEYBINDINGS.md, and KEYBINDS_ROADMAP.md

## Testing
- cargo test
- cargo fmt --check
- git diff --check