### PR TITLE
feat: add command-line Ctrl-L common prefix completion

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -774,6 +774,7 @@ While typing an Ex command after `:`.
 | `Ctrl+u` | Delete from cursor to beginning of command line |
 | `Ctrl+r {reg}` | Insert register contents |
 | `Ctrl+d` | List command-line completions |
+| `Ctrl+l` | Complete longest common command prefix |
 | `Alt+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 290 keybinds implemented, 77 planned Vim/Neovim parity defaults.**
+**Status: 291 keybinds implemented, 76 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+l` | Complete the longest common prefix |
 | `Ctrl+a` | Insert all matching completions |
 | `Ctrl+f` | Open the command-line window |
 | `Ctrl+n` | Select the next command-line history/completion entry with Vim-compatible semantics |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -775,6 +775,36 @@ fn split_input_segments(input: &str) -> (&str, &str, &str) {
     (&input[..start], &input[start..end], &input[end..])
 }
 
+fn common_prefix_preserving_left_case(left: &str, right: &str) -> String {
+    let mut end_byte = 0;
+
+    for ((left_idx, left_ch), right_ch) in left.char_indices().zip(right.chars()) {
+        if left_ch.eq_ignore_ascii_case(&right_ch) {
+            end_byte = left_idx + left_ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    left[..end_byte].to_string()
+}
+
+fn longest_common_command_prefix(suggestions: &[CommandSuggestion]) -> String {
+    let Some(first) = suggestions.first() else {
+        return String::new();
+    };
+
+    let mut prefix = first.command.to_string();
+    for suggestion in suggestions.iter().skip(1) {
+        prefix = common_prefix_preserving_left_case(&prefix, suggestion.command);
+        if prefix.is_empty() {
+            break;
+        }
+    }
+
+    prefix
+}
+
 fn command_history_path() -> PathBuf {
     dirs::config_dir()
         .unwrap_or_else(|| PathBuf::from("."))
@@ -1366,6 +1396,42 @@ impl CommandLine {
             self.popup_mode = CommandPopupMode::Completion;
             true
         }
+    }
+
+    /// Complete to the longest common command prefix across current matches.
+    pub fn complete_longest_common_prefix(&mut self) -> bool {
+        self.refresh_command_suggestions();
+        self.history_popup_items.clear();
+        self.history_popup_index = 0;
+
+        if self.suggestions.is_empty() {
+            self.popup_mode = CommandPopupMode::None;
+            return false;
+        }
+
+        self.popup_mode = CommandPopupMode::Completion;
+        let (prefix, token, suffix) = split_input_segments(&self.input);
+        if token.is_empty() {
+            return false;
+        }
+
+        let matches = command_suggestions_for_token(token, COMMAND_SPECS.len());
+        let common_prefix = longest_common_command_prefix(&matches);
+        if common_prefix.is_empty() || common_prefix == token {
+            return false;
+        }
+
+        let prefix = prefix.to_string();
+        let suffix = suffix.to_string();
+        self.input = format!("{prefix}{common_prefix}{suffix}");
+        self.cursor = prefix.chars().count() + common_prefix.chars().count();
+        self.refresh_command_suggestions();
+        if self.suggestions.is_empty() {
+            self.popup_mode = CommandPopupMode::None;
+        } else {
+            self.popup_mode = CommandPopupMode::Completion;
+        }
+        true
     }
 
     /// Move selection down in current popup.

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -44,6 +44,8 @@ pub enum CommandModeAction {
     InsertRegister,
     /// Show available command-line completions
     ListCompletions,
+    /// Complete the longest common command-line completion prefix
+    CompleteLongestCommonPrefix,
     /// Accept current completion/history selection
     Complete,
     /// Move selection backward and accept completion
@@ -374,6 +376,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
         "history_toggle" => Some(CommandModeAction::HistoryToggle),
         "insert_register" => Some(CommandModeAction::InsertRegister),
         "list_completions" => Some(CommandModeAction::ListCompletions),
+        "complete_longest_common_prefix" => Some(CommandModeAction::CompleteLongestCommonPrefix),
         "complete" => Some(CommandModeAction::Complete),
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -252,6 +252,11 @@ impl Default for KeymapSettings {
                     desc: Some("List command-line completions".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-l>".to_string(),
+                    action: "complete_longest_common_prefix".to_string(),
+                    desc: Some("Complete longest common command prefix".to_string()),
+                },
+                CommandModeMapping {
                     key: "<Tab>".to_string(),
                     action: "complete".to_string(),
                     desc: Some("Accept selected command completion".to_string()),
@@ -468,7 +473,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, history_toggle, list_completions, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1156,6 +1161,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+u           - Delete from cursor to beginning of command line
 # Ctrl+r {reg}     - Insert register contents
 # Ctrl+d           - List command-line completions
+# Ctrl+l           - Complete longest common command prefix
 # Alt+r            - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -382,6 +382,12 @@ vim_default = true
             }),
             "command-line UX mappings (e.g. <C-d> completions) should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("<C-l>") && item.display.contains("common command prefix")
+            }),
+            "command-line UX mappings (e.g. <C-l> common prefix completion) should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1974,6 +1974,13 @@ desc = "List command-line completions"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-l>"
+action = "command_line_complete_longest_common_prefix"
+desc = "Complete longest common command prefix"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7630,6 +7630,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::ListCompletions => {
             editor.command_line.list_completions();
         }
+        CommandModeAction::CompleteLongestCommonPrefix => {
+            editor.command_line.complete_longest_common_prefix();
+        }
         CommandModeAction::Complete => {
             if editor.command_line.popup_mode == CommandPopupMode::History {
                 editor.command_line.accept_history_popup_selection();
@@ -9783,6 +9786,19 @@ mod tests {
             .suggestions
             .iter()
             .any(|item| item.command == "w"));
+    }
+
+    #[test]
+    fn command_ctrl_l_completes_longest_common_command_prefix() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("Term");
+
+        handle_key(&mut editor, ctrl_key('l'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "Terminal");
+        assert_eq!(editor.command_line.cursor, "Terminal".chars().count());
+        assert_eq!(editor.command_line.popup_mode, CommandPopupMode::Completion);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add command-mode Ctrl+l action for longest common command prefix completion
- include the default mapping in generated config and :Keymaps
- update keybinding docs and roadmap counts

## Tests
- cargo test