### PR TITLE
feat: add command-line Ctrl-A insert completions

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -775,6 +775,7 @@ While typing an Ex command after `:`.
 | `Ctrl+r {reg}` | Insert register contents |
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete longest common command prefix |
+| `Ctrl+a` | Insert all matching command completions |
 | `Alt+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 291 keybinds implemented, 76 planned Vim/Neovim parity defaults.**
+**Status: 292 keybinds implemented, 75 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+a` | Insert all matching completions |
 | `Ctrl+f` | Open the command-line window |
 | `Ctrl+n` | Select the next command-line history/completion entry with Vim-compatible semantics |
 | `Ctrl+p` | Select the previous command-line history/completion entry with Vim-compatible semantics |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1434,6 +1434,33 @@ impl CommandLine {
         true
     }
 
+    /// Insert every matching command completion into the command line.
+    pub fn insert_all_matching_completions(&mut self) -> bool {
+        self.history_popup_items.clear();
+        self.history_popup_index = 0;
+
+        let (prefix, token, suffix) = split_input_segments(&self.input);
+        let matches = command_suggestions_for_token(token, COMMAND_SPECS.len());
+        if matches.is_empty() {
+            self.suggestions.clear();
+            self.popup_mode = CommandPopupMode::None;
+            return false;
+        }
+
+        let inserted = matches
+            .iter()
+            .map(|suggestion| suggestion.command)
+            .collect::<Vec<_>>()
+            .join(" ");
+        let prefix = prefix.to_string();
+        let suffix = suffix.to_string();
+        self.input = format!("{prefix}{inserted}{suffix}");
+        self.cursor = prefix.chars().count() + inserted.chars().count();
+        self.suggestions.clear();
+        self.popup_mode = CommandPopupMode::None;
+        true
+    }
+
     /// Move selection down in current popup.
     pub fn popup_next(&mut self) {
         match self.popup_mode {

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -46,6 +46,8 @@ pub enum CommandModeAction {
     ListCompletions,
     /// Complete the longest common command-line completion prefix
     CompleteLongestCommonPrefix,
+    /// Insert all matching command-line completions
+    InsertAllCompletions,
     /// Accept current completion/history selection
     Complete,
     /// Move selection backward and accept completion
@@ -377,6 +379,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
         "insert_register" => Some(CommandModeAction::InsertRegister),
         "list_completions" => Some(CommandModeAction::ListCompletions),
         "complete_longest_common_prefix" => Some(CommandModeAction::CompleteLongestCommonPrefix),
+        "insert_all_completions" => Some(CommandModeAction::InsertAllCompletions),
         "complete" => Some(CommandModeAction::Complete),
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -257,6 +257,11 @@ impl Default for KeymapSettings {
                     desc: Some("Complete longest common command prefix".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-a>".to_string(),
+                    action: "insert_all_completions".to_string(),
+                    desc: Some("Insert all matching command completions".to_string()),
+                },
+                CommandModeMapping {
                     key: "<Tab>".to_string(),
                     action: "complete".to_string(),
                     desc: Some("Accept selected command completion".to_string()),
@@ -473,7 +478,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1162,6 +1167,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+r {reg}     - Insert register contents
 # Ctrl+d           - List command-line completions
 # Ctrl+l           - Complete longest common command prefix
+# Ctrl+a           - Insert all matching command completions
 # Alt+r            - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -388,6 +388,12 @@ vim_default = true
             }),
             "command-line UX mappings (e.g. <C-l> common prefix completion) should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("<C-a>") && item.display.contains("all matching")
+            }),
+            "command-line UX mappings (e.g. <C-a> all completions) should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1981,6 +1981,13 @@ desc = "Complete longest common command prefix"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-a>"
+action = "command_line_insert_all_completions"
+desc = "Insert all matching command completions"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7633,6 +7633,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::CompleteLongestCommonPrefix => {
             editor.command_line.complete_longest_common_prefix();
         }
+        CommandModeAction::InsertAllCompletions => {
+            editor.command_line.insert_all_matching_completions();
+        }
         CommandModeAction::Complete => {
             if editor.command_line.popup_mode == CommandPopupMode::History {
                 editor.command_line.accept_history_popup_selection();
@@ -9799,6 +9802,20 @@ mod tests {
         assert_eq!(editor.command_line.input, "Terminal");
         assert_eq!(editor.command_line.cursor, "Terminal".chars().count());
         assert_eq!(editor.command_line.popup_mode, CommandPopupMode::Completion);
+    }
+
+    #[test]
+    fn command_ctrl_a_inserts_all_matching_command_completions() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("Term");
+
+        handle_key(&mut editor, ctrl_key('a'));
+
+        let expected = "Terminal TerminalList TerminalNew TerminalSelect TerminalKill TerminalNext TerminalPrev Terminals TerminalRename";
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, expected);
+        assert_eq!(editor.command_line.cursor, expected.chars().count());
+        assert_eq!(editor.command_line.popup_mode, CommandPopupMode::None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add command-mode Ctrl+a action for inserting all matching command completions
- include the default mapping in generated config and :Keymaps
- update keybinding docs and roadmap counts

## Tests
- cargo test
- cargo fmt --check
- git diff --check