### PR TITLE
feat: add command-line Ctrl-F window keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -776,6 +776,7 @@ While typing an Ex command after `:`.
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete longest common command prefix |
 | `Ctrl+a` | Insert all matching command completions |
+| `Ctrl+f` | Open command-line window |
 | `Alt+r` | Toggle command history window |
 | `Tab` | Accept selected command completion |
 | `Shift+Tab` | Accept previous completion |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 292 keybinds implemented, 75 planned Vim/Neovim parity defaults.**
+**Status: 293 keybinds implemented, 74 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+f` | Open the command-line window |
 | `Ctrl+n` | Select the next command-line history/completion entry with Vim-compatible semantics |
 | `Ctrl+p` | Select the previous command-line history/completion entry with Vim-compatible semantics |
 | `Ctrl+v` | Insert the next character literally |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1383,6 +1383,12 @@ impl CommandLine {
         self.refresh_history_popup();
     }
 
+    /// Open the command-line history window.
+    pub fn open_command_line_window(&mut self) {
+        self.popup_mode = CommandPopupMode::History;
+        self.refresh_history_popup();
+    }
+
     /// Show available command-line completions without accepting one.
     pub fn list_completions(&mut self) -> bool {
         self.refresh_command_suggestions();

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -48,6 +48,8 @@ pub enum CommandModeAction {
     CompleteLongestCommonPrefix,
     /// Insert all matching command-line completions
     InsertAllCompletions,
+    /// Open the command-line window
+    OpenCommandLineWindow,
     /// Accept current completion/history selection
     Complete,
     /// Move selection backward and accept completion
@@ -380,6 +382,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
         "list_completions" => Some(CommandModeAction::ListCompletions),
         "complete_longest_common_prefix" => Some(CommandModeAction::CompleteLongestCommonPrefix),
         "insert_all_completions" => Some(CommandModeAction::InsertAllCompletions),
+        "open_command_line_window" => Some(CommandModeAction::OpenCommandLineWindow),
         "complete" => Some(CommandModeAction::Complete),
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -262,6 +262,11 @@ impl Default for KeymapSettings {
                     desc: Some("Insert all matching command completions".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-f>".to_string(),
+                    action: "open_command_line_window".to_string(),
+                    desc: Some("Open command-line window".to_string()),
+                },
+                CommandModeMapping {
                     key: "<Tab>".to_string(),
                     action: "complete".to_string(),
                     desc: Some("Accept selected command completion".to_string()),
@@ -478,7 +483,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, open_command_line_window, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1168,6 +1173,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+d           - List command-line completions
 # Ctrl+l           - Complete longest common command prefix
 # Ctrl+a           - Insert all matching command completions
+# Ctrl+f           - Open command-line window
 # Alt+r            - Toggle command history window
 # Tab              - Accept selected command completion
 # Shift+Tab        - Accept previous completion

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -394,6 +394,12 @@ vim_default = true
             }),
             "command-line UX mappings (e.g. <C-a> all completions) should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("<C-f>") && item.display.contains("command-line window")
+            }),
+            "command-line UX mappings (e.g. <C-f> command-line window) should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1988,6 +1988,13 @@ desc = "Insert all matching command completions"
 status = "implemented"
 vim_default = true
 
+[[cmdline.editing]]
+key = "<C-f>"
+action = "command_line_window"
+desc = "Open command-line window"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7636,6 +7636,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::InsertAllCompletions => {
             editor.command_line.insert_all_matching_completions();
         }
+        CommandModeAction::OpenCommandLineWindow => {
+            editor.command_line.open_command_line_window();
+        }
         CommandModeAction::Complete => {
             if editor.command_line.popup_mode == CommandPopupMode::History {
                 editor.command_line.accept_history_popup_selection();
@@ -9816,6 +9819,26 @@ mod tests {
         assert_eq!(editor.command_line.input, expected);
         assert_eq!(editor.command_line.cursor, expected.chars().count());
         assert_eq!(editor.command_line.popup_mode, CommandPopupMode::None);
+    }
+
+    #[test]
+    fn command_ctrl_f_opens_command_line_window_without_changing_input() {
+        let mut editor = Editor::default();
+        editor.command_line.history = vec!["write".to_string(), "quit".to_string()];
+        editor.enter_command_mode_with_input("w");
+        editor.command_line.popup_mode = CommandPopupMode::None;
+
+        handle_key(&mut editor, ctrl_key('f'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "w");
+        assert_eq!(editor.command_line.cursor, 1);
+        assert_eq!(editor.command_line.popup_mode, CommandPopupMode::History);
+        assert!(editor
+            .command_line
+            .history_popup_items
+            .iter()
+            .any(|item| item == "write"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add the Vim/Neovim command-line Ctrl-F default mapping to open the command-line window/history UI
- make the action configurable through command-mode mappings and visible in :Keymaps
- update keybind docs and roadmap counts

## Tests
- cargo test
- cargo fmt --check
- git diff --check