### PR TITLE
feat: add explorer movement parity keybinds

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -726,6 +726,10 @@ When the file explorer sidebar is focused:
 | `Esc` / `Ctrl+[` / `q` | Close explorer |
 | `j` / `Down` | Move down |
 | `k` / `Up` | Move up |
+| `gg` | Move to top |
+| `G` | Move to bottom |
+| `Ctrl+d` / `Ctrl+u` | Move half page down/up |
+| `Ctrl+f` / `Ctrl+b` | Move page down/up |
 | `Enter` | Toggle directory or open file |
 | `l` / `Right` | Expand directory or open file |
 | `h` / `Left` | Collapse directory |

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -146,6 +146,8 @@ pub struct FileExplorer {
     pub search_matches: Vec<usize>,
     /// Current match index in search_matches
     pub current_match: usize,
+    /// Whether explorer is waiting for the second `g` in `gg`.
+    pending_goto_top: bool,
     /// Git status by file and ancestor directory path
     git_statuses: HashMap<PathBuf, GitFileStatus>,
 }
@@ -169,6 +171,7 @@ impl Default for FileExplorer {
             search_cursor: 0,
             search_matches: Vec::new(),
             current_match: 0,
+            pending_goto_top: false,
             git_statuses: HashMap::new(),
         }
     }
@@ -221,6 +224,44 @@ impl FileExplorer {
         if !self.flat_view.is_empty() && self.selected < self.flat_view.len() - 1 {
             self.selected += 1;
         }
+    }
+
+    /// Move selection to the first visible explorer row.
+    pub fn move_to_top(&mut self) {
+        self.selected = 0;
+    }
+
+    /// Move selection to the last visible explorer row.
+    pub fn move_to_bottom(&mut self) {
+        if !self.flat_view.is_empty() {
+            self.selected = self.flat_view.len() - 1;
+        }
+    }
+
+    /// Move selection down by a page-like amount, clamping at the bottom.
+    pub fn move_page_down(&mut self, amount: usize) {
+        if self.flat_view.is_empty() {
+            return;
+        }
+        let max_idx = self.flat_view.len() - 1;
+        self.selected = self.selected.saturating_add(amount).min(max_idx);
+    }
+
+    /// Move selection up by a page-like amount, clamping at the top.
+    pub fn move_page_up(&mut self, amount: usize) {
+        self.selected = self.selected.saturating_sub(amount);
+    }
+
+    /// Start waiting for the second `g` in `gg`.
+    pub fn start_goto_top_sequence(&mut self) {
+        self.pending_goto_top = true;
+    }
+
+    /// Returns true if explorer was waiting for the second `g`, then clears it.
+    pub fn take_goto_top_sequence(&mut self) -> bool {
+        let pending = self.pending_goto_top;
+        self.pending_goto_top = false;
+        pending
     }
 
     /// Get the currently selected path
@@ -1391,6 +1432,51 @@ mod tests {
             .iter()
             .position(|node| node.path == path)
             .expect("path should be visible in explorer");
+    }
+
+    fn explorer_with_flat_rows(count: usize) -> FileExplorer {
+        let root = PathBuf::from("/tmp/nevi-explorer-motion-test");
+        let mut explorer = FileExplorer::new();
+        explorer.flat_view = (0..count)
+            .map(|idx| super::FlatNode {
+                path: root.join(format!("file_{idx}.txt")),
+                name: format!("file_{idx}.txt"),
+                is_dir: false,
+                depth: 1,
+                is_expanded: false,
+            })
+            .collect();
+        explorer
+    }
+
+    #[test]
+    fn explorer_regular_buffer_style_top_and_bottom_motions() {
+        let mut explorer = explorer_with_flat_rows(5);
+        explorer.selected = 2;
+
+        explorer.move_to_top();
+        assert_eq!(explorer.selected, 0);
+
+        explorer.move_to_bottom();
+        assert_eq!(explorer.selected, 4);
+    }
+
+    #[test]
+    fn explorer_page_motions_clamp_to_visible_rows() {
+        let mut explorer = explorer_with_flat_rows(10);
+        explorer.selected = 4;
+
+        explorer.move_page_down(3);
+        assert_eq!(explorer.selected, 7);
+
+        explorer.move_page_down(10);
+        assert_eq!(explorer.selected, 9);
+
+        explorer.move_page_up(4);
+        assert_eq!(explorer.selected, 5);
+
+        explorer.move_page_up(10);
+        assert_eq!(explorer.selected, 0);
     }
 
     #[test]

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -110,6 +110,7 @@ fn mode_tag(mode: &str) -> &str {
         "leader" => "leader",
         "commands" => "cmd",
         "cmdline" => "cmdline",
+        "explorer" => "expl",
         "finder" => "finder",
         "terminal" => "term",
         "text_objects" => "text-obj",
@@ -399,6 +400,35 @@ vim_default = true
                 item.display.contains("<C-f>") && item.display.contains("command-line window")
             }),
             "command-line UX mappings (e.g. <C-f> command-line window) should appear"
+        );
+    }
+
+    #[test]
+    fn picker_sources_explorer_mode_mappings() {
+        let items = keymap_finder_items(&KeymapSettings::default());
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains("gg")
+                    && item.display.contains("top")
+            }),
+            "explorer mappings (e.g. gg top) should appear"
+        );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains("<C-d>")
+                    && item.display.contains("half page")
+            }),
+            "explorer mappings (e.g. Ctrl+d half page) should appear"
+        );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains("p")
+                    && item.display.contains("Paste")
+            }),
+            "existing explorer mappings (e.g. paste) should appear"
         );
     }
 

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1519,6 +1519,172 @@ desc = "Go to harpoon slot 4"
 status = "implemented"
 
 # ============================================================================
+# EXPLORER MODE (File Explorer Sidebar)
+# ============================================================================
+
+[[explorer.navigation]]
+key = "j"
+action = "move_down"
+desc = "Move down"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "k"
+action = "move_up"
+desc = "Move up"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "gg"
+action = "move_to_top"
+desc = "Move to top"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "G"
+action = "move_to_bottom"
+desc = "Move to bottom"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "<C-d>"
+action = "half_page_down"
+desc = "Move half page down"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "<C-u>"
+action = "half_page_up"
+desc = "Move half page up"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "<C-f>"
+action = "page_down"
+desc = "Move page down"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "<C-b>"
+action = "page_up"
+desc = "Move page up"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "Enter"
+action = "toggle_or_open"
+desc = "Toggle directory or open file"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "l"
+action = "expand_or_open"
+desc = "Expand directory or open file"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "h"
+action = "collapse_or_parent"
+desc = "Collapse directory or go to parent"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "Tab"
+action = "toggle_expand"
+desc = "Toggle expand/collapse"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "W"
+action = "collapse_all"
+desc = "Collapse all directories"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "R"
+action = "refresh"
+desc = "Refresh explorer and git status"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "-"
+action = "go_to_parent"
+desc = "Go to parent directory"
+status = "implemented"
+
+[[explorer.navigation]]
+key = "<C-l>"
+action = "focus_editor"
+desc = "Focus editor and keep explorer open"
+status = "implemented"
+
+[[explorer.files]]
+key = "a"
+action = "create"
+desc = "Create file or directory"
+status = "implemented"
+
+[[explorer.files]]
+key = "r"
+action = "rename"
+desc = "Rename selected item"
+status = "implemented"
+
+[[explorer.files]]
+key = "d"
+action = "delete"
+desc = "Delete selected item"
+status = "implemented"
+
+[[explorer.files]]
+key = "c"
+action = "copy"
+desc = "Copy selected item"
+status = "implemented"
+
+[[explorer.files]]
+key = "x"
+action = "cut"
+desc = "Cut selected item"
+status = "implemented"
+
+[[explorer.files]]
+key = "p"
+action = "paste"
+desc = "Paste copied/cut item"
+status = "implemented"
+
+[[explorer.search]]
+key = "/"
+action = "search"
+desc = "Search explorer"
+status = "implemented"
+
+[[explorer.search]]
+key = "n"
+action = "next_match"
+desc = "Next search match"
+status = "implemented"
+
+[[explorer.search]]
+key = "N"
+action = "previous_match"
+desc = "Previous search match"
+status = "implemented"
+
+[[explorer.mode]]
+key = "Esc"
+action = "close"
+desc = "Close explorer"
+status = "implemented"
+
+[[explorer.mode]]
+key = "q"
+action = "close"
+desc = "Close explorer"
+status = "implemented"
+
+# ============================================================================
 # TERMINAL MODE (ALL IMPLEMENTED)
 # ============================================================================
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8440,6 +8440,14 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
     ));
 }
 
+fn explorer_visible_rows(editor: &Editor) -> usize {
+    editor.text_rows().saturating_sub(1).max(1)
+}
+
+fn explorer_half_page_rows(editor: &Editor) -> usize {
+    (explorer_visible_rows(editor) / 2).max(1)
+}
+
 fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
     // Handle search input mode
     if editor.explorer.is_searching {
@@ -8523,6 +8531,16 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
+    if editor.explorer.take_goto_top_sequence() {
+        if matches!(
+            (key.modifiers, key.code),
+            (KeyModifiers::NONE, KeyCode::Char('g'))
+        ) {
+            editor.explorer.move_to_top();
+            return;
+        }
+    }
+
     // Handle leader key sequences (same as normal mode)
     if let Some(ref mut sequence) = editor.leader_sequence {
         if key.code == KeyCode::Esc {
@@ -8581,6 +8599,38 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
         // Move up
         (KeyModifiers::NONE, KeyCode::Char('k')) | (KeyModifiers::NONE, KeyCode::Up) => {
             editor.explorer.move_up();
+        }
+
+        // gg - move to top
+        (KeyModifiers::NONE, KeyCode::Char('g')) => {
+            editor.explorer.start_goto_top_sequence();
+        }
+
+        // G - move to bottom
+        (KeyModifiers::SHIFT, KeyCode::Char('G')) | (KeyModifiers::NONE, KeyCode::Char('G')) => {
+            editor.explorer.move_to_bottom();
+        }
+
+        // Ctrl+d / Ctrl+u - half-page movement
+        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
+            editor
+                .explorer
+                .move_page_down(explorer_half_page_rows(editor));
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            editor
+                .explorer
+                .move_page_up(explorer_half_page_rows(editor));
+        }
+
+        // Ctrl+f / Ctrl+b - page movement
+        (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
+            editor
+                .explorer
+                .move_page_down(explorer_visible_rows(editor));
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
+            editor.explorer.move_page_up(explorer_visible_rows(editor));
         }
 
         // Enter - toggle directory or open file
@@ -9664,6 +9714,7 @@ mod tests {
     use crate::commands::{Command, CommandPopupMode};
     use crate::config::{KeymapEntry, Settings};
     use crate::editor::{Editor, Mode, RegisterContent};
+    use crate::explorer::FlatNode;
     use crate::finder::FinderMode;
     use crate::input::Motion;
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
@@ -9910,6 +9961,44 @@ mod tests {
     }
 
     #[test]
+    fn explorer_g_and_gg_follow_regular_buffer_top_bottom_motions() {
+        let mut editor = editor_with_explorer_rows(5);
+        editor.explorer.selected = 2;
+
+        handle_key(&mut editor, shift_key('G'));
+        assert_eq!(editor.mode, Mode::Explorer);
+        assert_eq!(editor.explorer.selected, 4);
+
+        handle_key(&mut editor, key('g'));
+        assert_eq!(
+            editor.explorer.selected, 4,
+            "single g should wait for a second g"
+        );
+
+        handle_key(&mut editor, key('g'));
+        assert_eq!(editor.explorer.selected, 0);
+    }
+
+    #[test]
+    fn explorer_ctrl_page_motions_follow_regular_buffer_scrolling() {
+        let mut editor = editor_with_explorer_rows(30);
+        editor.set_size(100, 12);
+        editor.explorer.selected = 10;
+
+        handle_key(&mut editor, ctrl_key('d'));
+        assert_eq!(editor.explorer.selected, 14);
+
+        handle_key(&mut editor, ctrl_key('u'));
+        assert_eq!(editor.explorer.selected, 10);
+
+        handle_key(&mut editor, ctrl_key('f'));
+        assert_eq!(editor.explorer.selected, 19);
+
+        handle_key(&mut editor, ctrl_key('b'));
+        assert_eq!(editor.explorer.selected, 10);
+    }
+
+    #[test]
     fn wrap_segments_measure_tabs_by_display_width() {
         let segments = super::calculate_wrap_segments("ab\tcd", 5, true, 4);
 
@@ -9958,6 +10047,22 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    fn editor_with_explorer_rows(count: usize) -> Editor {
+        let mut editor = Editor::default();
+        editor.mode = Mode::Explorer;
+        editor.explorer.visible = true;
+        editor.explorer.flat_view = (0..count)
+            .map(|idx| FlatNode {
+                path: PathBuf::from(format!("/tmp/nevi-explorer-motion/file_{idx}.txt")),
+                name: format!("file_{idx}.txt"),
+                is_dir: false,
+                depth: 1,
+                is_expanded: false,
+            })
+            .collect();
+        editor
     }
 
     fn completion_item(label: &str) -> CompletionItem {


### PR DESCRIPTION
## Summary
- Add Vim-style explorer movement mappings for gg, G, Ctrl+d/u, and Ctrl+f/b.
- Teach explorer selection to jump top/bottom and move by half/full pages.
- Add explorer mappings to :Keymaps and document them in KEYBINDINGS.md.

## Test Plan
- cargo fmt --check
- git diff --check
- cargo test --quiet
- Manual test confirmed: explorer gg/G/Ctrl+d/Ctrl+u/Ctrl+f/Ctrl+b worked as expected.