### PR TITLE
feat: add explorer keymaps help shortcut

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -736,6 +736,7 @@ When the file explorer sidebar is focused:
 | `Tab` | Toggle expand/collapse |
 | `W` | Collapse all directories |
 | `R` | Refresh explorer and git status |
+| `?` | Show explorer keymaps |
 | `-` | Go to parent directory |
 | `Ctrl+l` | Focus editor and keep explorer open |
 | `a` | Create file or directory |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -8829,8 +8829,13 @@ impl Editor {
 
     /// Open the fuzzy finder in keymaps cheatsheet mode (read-only).
     pub fn open_keymaps_picker(&mut self) {
+        self.open_keymaps_picker_with_query("");
+    }
+
+    /// Open the fuzzy finder in keymaps mode with a pre-filled filter query.
+    pub fn open_keymaps_picker_with_query(&mut self, query: &str) {
         let items = crate::finder::keymap_finder_items(&self.settings.keymap);
-        self.finder.open_keymaps(items);
+        self.finder.open_keymaps_with_query(items, query);
         self.mode = Mode::Finder;
     }
 

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -430,6 +430,14 @@ vim_default = true
             }),
             "existing explorer mappings (e.g. paste) should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains("?")
+                    && item.display.contains("keymaps")
+            }),
+            "explorer help mapping should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1606,6 +1606,12 @@ action = "refresh"
 desc = "Refresh explorer and git status"
 status = "implemented"
 
+[[explorer.help]]
+key = "?"
+action = "show_explorer_keymaps"
+desc = "Show explorer keymaps"
+status = "implemented"
+
 [[explorer.navigation]]
 key = "-"
 action = "go_to_parent"

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -431,18 +431,23 @@ impl FuzzyFinder {
 
     /// Open the finder in keymaps (cheatsheet) mode — read-only, no preview pane.
     pub fn open_keymaps(&mut self, items: Vec<FinderItem>) {
+        self.open_keymaps_with_query(items, "");
+    }
+
+    /// Open the finder in keymaps mode with a pre-filled query.
+    pub fn open_keymaps_with_query(&mut self, items: Vec<FinderItem>, query: &str) {
         self.mode = FinderMode::Keymaps;
         self.input_mode = FinderInputMode::Insert;
-        self.query.clear();
-        self.cursor = 0;
+        self.query = query.to_string();
+        self.cursor = query.chars().count();
         self.selected = 0;
         self.scroll_offset = 0;
         self.clear_preview_cache();
         self.cancel_grep_search();
 
         self.items = items;
-        self.filtered = (0..self.items.len()).collect();
         self.populated = true;
+        self.update_filter();
     }
 
     /// Open the finder in git changes mode
@@ -1191,6 +1196,40 @@ mod tests {
             !finder.mode_supports_preview(),
             "keymaps mode has no preview pane"
         );
+    }
+
+    #[test]
+    fn open_keymaps_with_query_prefilters_items() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_keymaps_with_query(
+            vec![
+                FinderItem::new(
+                    "n       h                  Move cursor left".to_string(),
+                    PathBuf::new(),
+                ),
+                FinderItem::new(
+                    "expl    gg                 Move to top".to_string(),
+                    PathBuf::new(),
+                ),
+                FinderItem::new(
+                    "expl    <C-d>              Move half page down".to_string(),
+                    PathBuf::new(),
+                ),
+            ],
+            "expl",
+        );
+
+        assert_eq!(finder.mode, FinderMode::Keymaps);
+        assert_eq!(finder.query, "expl");
+        assert_eq!(finder.cursor, 4);
+        assert_eq!(finder.filtered.len(), 2);
+        assert!(finder.filtered.iter().all(|idx| {
+            finder
+                .items
+                .get(*idx)
+                .map(|item| item.display.starts_with("expl"))
+                .unwrap_or(false)
+        }));
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8688,6 +8688,11 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
             editor.refresh_explorer_git_statuses();
         }
 
+        // Help / discoverability
+        (KeyModifiers::SHIFT, KeyCode::Char('?')) | (KeyModifiers::NONE, KeyCode::Char('?')) => {
+            editor.open_keymaps_picker_with_query("expl");
+        }
+
         // Go to parent directory
         (KeyModifiers::NONE, KeyCode::Char('-')) => {
             editor.explorer.go_to_parent();
@@ -9996,6 +10001,28 @@ mod tests {
 
         handle_key(&mut editor, ctrl_key('b'));
         assert_eq!(editor.explorer.selected, 10);
+    }
+
+    #[test]
+    fn explorer_question_opens_keymaps_filtered_to_explorer() {
+        let mut editor = editor_with_explorer_rows(5);
+
+        handle_key(&mut editor, key('?'));
+
+        assert_eq!(editor.mode, Mode::Finder);
+        assert_eq!(editor.finder.mode, FinderMode::Keymaps);
+        assert_eq!(editor.finder.query, "expl");
+        assert!(
+            editor.finder.filtered.iter().any(|idx| {
+                editor
+                    .finder
+                    .items
+                    .get(*idx)
+                    .map(|item| item.display.contains("gg") && item.display.contains("top"))
+                    .unwrap_or(false)
+            }),
+            "filtered keymaps should include explorer mappings"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add ? in Explorer mode to open :Keymaps pre-filtered to explorer mappings.
- Add a keymaps picker API that accepts an initial query.
- Document the explorer help shortcut and include it in :Keymaps.

## Test Plan
- cargo fmt --check
- git diff --check
- cargo test --quiet
- Manual test confirmed: pressing ? in Explorer opens :Keymaps with expl prefilled.