### PR TITLE
feat: add search prompt Ctrl-b and Ctrl-e

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -336,6 +336,15 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 
 > **Tip:** Search supports regex. Use `\c` at the start for case-insensitive search (e.g., `/\cfoo`).
 
+### Search Prompt Editing
+
+While typing a `/` or `?` search prompt.
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+b` | Move to beginning of search input |
+| `Ctrl+e` | Move to end of search input |
+
 ---
 
 ## Marks

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 293 keybinds implemented, 74 planned Vim/Neovim parity defaults.**
+**Status: 295 keybinds implemented, 72 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -43,8 +43,6 @@ These apply while editing `/` and `?` search prompts.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+b` | Move to beginning of the search input |
-| `Ctrl+e` | Move to end of the search input |
 | `Ctrl+w` | Delete the word before the cursor |
 | `Ctrl+u` | Delete from cursor back to the start of the search input |
 | `Ctrl+r {reg}` | Insert register contents into the search prompt |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1179,6 +1179,10 @@ fn default_config_template() -> &'static str {
 # Shift+Tab        - Accept previous completion
 # Ctrl+n / Ctrl+p  - Next / previous popup item
 #
+# Search prompt mode (while typing `/` or `?`):
+# Ctrl+b           - Move to beginning of search input
+# Ctrl+e           - Move to end of search input
+#
 # ============================================================================
 # CUSTOM KEYBIND EXAMPLES
 # ============================================================================

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -319,6 +319,16 @@ impl SearchState {
         }
     }
 
+    /// Move cursor to beginning of search input
+    pub fn move_to_start(&mut self) {
+        self.cursor = 0;
+    }
+
+    /// Move cursor to end of search input
+    pub fn move_to_end(&mut self) {
+        self.cursor = self.input.chars().count();
+    }
+
     /// Convert character index to byte index
     fn char_to_byte_index(&self, char_idx: usize) -> usize {
         self.input

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -486,6 +486,27 @@ vim_default = true
     }
 
     #[test]
+    fn picker_includes_builtin_search_prompt_editing_keys() {
+        let items = keymap_finder_items(&KeymapSettings::default());
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("search")
+                    && item.display.contains("<C-b>")
+                    && item.display.contains("beginning")
+            }),
+            "search prompt Ctrl+b should appear in :Keymaps"
+        );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("search")
+                    && item.display.contains("<C-e>")
+                    && item.display.contains("end")
+            }),
+            "search prompt Ctrl+e should appear in :Keymaps"
+        );
+    }
+
+    #[test]
     fn picker_includes_leader_popup_trigger() {
         let items = keymap_finder_items(&KeymapSettings::default());
         assert!(

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -2180,6 +2180,24 @@ status = "implemented"
 vim_default = true
 
 # ============================================================================
+# SEARCH PROMPT EDITING (while typing `/` or `?`)
+# ============================================================================
+
+[[search.editing]]
+key = "<C-b>"
+action = "search_prompt_begin"
+desc = "Move to beginning of search input"
+status = "implemented"
+vim_default = true
+
+[[search.editing]]
+key = "<C-e>"
+action = "search_prompt_end"
+desc = "Move to end of search input"
+status = "implemented"
+vim_default = true
+
+# ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7801,6 +7801,12 @@ fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
         (KeyModifiers::NONE, KeyCode::Right) => {
             editor.search.move_right();
         }
+        (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
+            editor.search.move_to_start();
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('e')) => {
+            editor.search.move_to_end();
+        }
 
         // Regular character - accept any modifier for printable chars
         (_, KeyCode::Char(c)) if !c.is_control() => {
@@ -9801,6 +9807,34 @@ mod tests {
         assert_eq!(editor.mode, Mode::Command);
         assert_eq!(editor.command_line.input, "write buffer");
         assert_eq!(editor.command_line.cursor, "write buffer".chars().count());
+    }
+
+    #[test]
+    fn search_ctrl_b_moves_to_beginning_of_search_prompt() {
+        let mut editor = Editor::default();
+        editor.enter_search_forward();
+        editor.search.input = "needle".to_string();
+        editor.search.cursor = 4;
+
+        handle_key(&mut editor, ctrl_key('b'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "needle");
+        assert_eq!(editor.search.cursor, 0);
+    }
+
+    #[test]
+    fn search_ctrl_e_moves_to_end_of_search_prompt() {
+        let mut editor = Editor::default();
+        editor.enter_search_backward();
+        editor.search.input = "naive".to_string();
+        editor.search.cursor = 2;
+
+        handle_key(&mut editor, ctrl_key('e'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "naive");
+        assert_eq!(editor.search.cursor, "naive".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim-compatible Ctrl+b and Ctrl+e cursor movement while editing / and ? search prompts.
- Document the new search prompt defaults in KEYBINDINGS, generated config comments, and :Keymaps.
- Move the completed search prompt defaults out of KEYBINDS_ROADMAP and add regression coverage.

