### PR TITLE
feat: add search prompt history navigation

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -344,6 +344,8 @@ While typing a `/` or `?` search prompt.
 |-----|--------|
 | `Ctrl+b` | Move to beginning of search input |
 | `Ctrl+e` | Move to end of search input |
+| `Up` | Navigate to previous search history entry |
+| `Down` | Navigate to next search history entry |
 
 ---
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 295 keybinds implemented, 72 planned Vim/Neovim parity defaults.**
+**Status: 297 keybinds implemented, 70 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -46,8 +46,6 @@ These apply while editing `/` and `?` search prompts.
 | `Ctrl+w` | Delete the word before the cursor |
 | `Ctrl+u` | Delete from cursor back to the start of the search input |
 | `Ctrl+r {reg}` | Insert register contents into the search prompt |
-| `Up` | Navigate to the previous search history entry |
-| `Down` | Navigate to the next search history entry |
 
 ### Window Management Extras
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1182,6 +1182,7 @@ fn default_config_template() -> &'static str {
 # Search prompt mode (while typing `/` or `?`):
 # Ctrl+b           - Move to beginning of search input
 # Ctrl+e           - Move to end of search input
+# Up/Down          - Navigate search history
 #
 # ============================================================================
 # CUSTOM KEYBIND EXAMPLES

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -258,6 +258,8 @@ pub enum SearchDirection {
     Backward,
 }
 
+const MAX_SEARCH_HISTORY_ENTRIES: usize = 100;
+
 /// Search state
 #[derive(Debug, Clone, Default)]
 pub struct SearchState {
@@ -271,6 +273,12 @@ pub struct SearchState {
     pub last_pattern: Option<String>,
     /// Last search direction
     pub last_direction: SearchDirection,
+    /// Previously executed non-empty search patterns.
+    pub history: Vec<String>,
+    /// Current index while navigating search history.
+    pub history_index: Option<usize>,
+    /// In-progress search input saved before history navigation begins.
+    pub saved_input: Option<String>,
 }
 
 impl SearchState {
@@ -278,6 +286,8 @@ impl SearchState {
     pub fn clear(&mut self) {
         self.input.clear();
         self.cursor = 0;
+        self.history_index = None;
+        self.saved_input = None;
     }
 
     /// Start a new search
@@ -285,6 +295,8 @@ impl SearchState {
         self.input.clear();
         self.cursor = 0;
         self.direction = direction;
+        self.history_index = None;
+        self.saved_input = None;
     }
 
     /// Insert a character at cursor (cursor is character index, not byte index)
@@ -293,6 +305,7 @@ impl SearchState {
         let byte_idx = self.char_to_byte_index(self.cursor);
         self.input.insert(byte_idx, ch);
         self.cursor += 1;
+        self.on_input_edited();
     }
 
     /// Delete character before cursor
@@ -302,6 +315,7 @@ impl SearchState {
             // Convert character index to byte index for String::remove
             let byte_idx = self.char_to_byte_index(self.cursor);
             self.input.remove(byte_idx);
+            self.on_input_edited();
         }
     }
 
@@ -329,6 +343,41 @@ impl SearchState {
         self.cursor = self.input.chars().count();
     }
 
+    /// Navigate to previous search history entry.
+    pub fn history_prev(&mut self) {
+        if self.history.is_empty() {
+            return;
+        }
+
+        match self.history_index {
+            None => {
+                self.saved_input = Some(self.input.clone());
+                self.history_index = Some(self.history.len() - 1);
+                self.input = self.history[self.history.len() - 1].clone();
+            }
+            Some(idx) if idx > 0 => {
+                self.history_index = Some(idx - 1);
+                self.input = self.history[idx - 1].clone();
+            }
+            _ => {}
+        }
+        self.cursor = self.char_count();
+    }
+
+    /// Navigate to next search history entry.
+    pub fn history_next(&mut self) {
+        if let Some(idx) = self.history_index {
+            if idx + 1 < self.history.len() {
+                self.history_index = Some(idx + 1);
+                self.input = self.history[idx + 1].clone();
+            } else {
+                self.history_index = None;
+                self.input = self.saved_input.take().unwrap_or_default();
+            }
+            self.cursor = self.char_count();
+        }
+    }
+
     /// Convert character index to byte index
     fn char_to_byte_index(&self, char_idx: usize) -> usize {
         self.input
@@ -338,16 +387,43 @@ impl SearchState {
             .unwrap_or(self.input.len())
     }
 
+    fn char_count(&self) -> usize {
+        self.input.chars().count()
+    }
+
     /// Execute search and save pattern
     pub fn execute(&mut self) -> Option<String> {
         if self.input.is_empty() {
             // Use last pattern if input is empty
             self.last_pattern.clone()
         } else {
-            self.last_pattern = Some(self.input.clone());
+            let pattern = self.input.clone();
+            self.record_history(pattern.clone());
+            self.last_pattern = Some(pattern.clone());
             self.last_direction = self.direction;
-            Some(self.input.clone())
+            Some(pattern)
         }
+    }
+
+    fn record_history(&mut self, pattern: String) {
+        if let Some(existing_idx) = self.history.iter().position(|entry| entry == &pattern) {
+            self.history.remove(existing_idx);
+        }
+        self.history.push(pattern);
+        if self.history.len() > MAX_SEARCH_HISTORY_ENTRIES {
+            let extra = self
+                .history
+                .len()
+                .saturating_sub(MAX_SEARCH_HISTORY_ENTRIES);
+            self.history.drain(0..extra);
+        }
+        self.history_index = None;
+        self.saved_input = None;
+    }
+
+    fn on_input_edited(&mut self) {
+        self.history_index = None;
+        self.saved_input = None;
     }
 
     /// Get the display string for the search prompt

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -504,6 +504,22 @@ vim_default = true
             }),
             "search prompt Ctrl+e should appear in :Keymaps"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("search")
+                    && item.display.contains("<Up>")
+                    && item.display.contains("history")
+            }),
+            "search prompt Up history mapping should appear in :Keymaps"
+        );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("search")
+                    && item.display.contains("<Down>")
+                    && item.display.contains("history")
+            }),
+            "search prompt Down history mapping should appear in :Keymaps"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -2197,6 +2197,20 @@ desc = "Move to end of search input"
 status = "implemented"
 vim_default = true
 
+[[search.editing]]
+key = "<Up>"
+action = "search_prompt_history_prev"
+desc = "Navigate to previous search history entry"
+status = "implemented"
+vim_default = true
+
+[[search.editing]]
+key = "<Down>"
+action = "search_prompt_history_next"
+desc = "Navigate to next search history entry"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # COMMAND MODE (Ex commands)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7807,6 +7807,14 @@ fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
         (KeyModifiers::CONTROL, KeyCode::Char('e')) => {
             editor.search.move_to_end();
         }
+        (KeyModifiers::NONE, KeyCode::Up) => {
+            editor.search.history_prev();
+            editor.update_incremental_search();
+        }
+        (KeyModifiers::NONE, KeyCode::Down) => {
+            editor.search.history_next();
+            editor.update_incremental_search();
+        }
 
         // Regular character - accept any modifier for printable chars
         (_, KeyCode::Char(c)) if !c.is_control() => {
@@ -9776,6 +9784,18 @@ mod tests {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)
     }
 
+    fn enter_key() -> KeyEvent {
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
+    }
+
+    fn up_key() -> KeyEvent {
+        KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)
+    }
+
+    fn down_key() -> KeyEvent {
+        KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)
+    }
+
     fn esc_key() -> KeyEvent {
         KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
     }
@@ -9835,6 +9855,68 @@ mod tests {
         assert_eq!(editor.mode, Mode::Search);
         assert_eq!(editor.search.input, "naive");
         assert_eq!(editor.search.cursor, "naive".chars().count());
+    }
+
+    #[test]
+    fn search_up_down_navigates_search_history() {
+        let mut editor = Editor::default();
+
+        editor.enter_search_forward();
+        editor.search.input = "alpha".to_string();
+        editor.search.cursor = "alpha".chars().count();
+        handle_key(&mut editor, enter_key());
+
+        editor.enter_search_forward();
+        editor.search.input = "beta".to_string();
+        editor.search.cursor = "beta".chars().count();
+        handle_key(&mut editor, enter_key());
+
+        editor.enter_search_forward();
+        handle_key(&mut editor, up_key());
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "beta");
+        assert_eq!(editor.search.cursor, "beta".chars().count());
+
+        handle_key(&mut editor, up_key());
+        assert_eq!(editor.search.input, "alpha");
+        assert_eq!(editor.search.cursor, "alpha".chars().count());
+
+        handle_key(&mut editor, down_key());
+        assert_eq!(editor.search.input, "beta");
+        assert_eq!(editor.search.cursor, "beta".chars().count());
+
+        handle_key(&mut editor, down_key());
+        assert_eq!(editor.search.input, "");
+        assert_eq!(editor.search.cursor, 0);
+    }
+
+    #[test]
+    fn search_history_restores_in_progress_input_and_resets_after_edit() {
+        let mut editor = Editor::default();
+
+        editor.enter_search_forward();
+        editor.search.input = "stored".to_string();
+        editor.search.cursor = "stored".chars().count();
+        handle_key(&mut editor, enter_key());
+
+        editor.enter_search_forward();
+        editor.search.input = "draft".to_string();
+        editor.search.cursor = "draft".chars().count();
+        handle_key(&mut editor, up_key());
+        assert_eq!(editor.search.input, "stored");
+
+        handle_key(&mut editor, down_key());
+        assert_eq!(editor.search.input, "draft");
+        assert_eq!(editor.search.cursor, "draft".chars().count());
+
+        handle_key(&mut editor, up_key());
+        handle_key(&mut editor, key('x'));
+        assert_eq!(editor.search.input, "storedx");
+        assert_eq!(editor.search.cursor, "storedx".chars().count());
+
+        handle_key(&mut editor, down_key());
+        assert_eq!(editor.search.input, "storedx");
+        assert_eq!(editor.search.cursor, "storedx".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Up/Down history navigation while editing / and ? search prompts.
- Store executed non-empty search patterns in bounded, deduplicated search history.
- Update :Keymaps, KEYBINDINGS, generated config comments, and KEYBINDS_ROADMAP.
