### PR TITLE
feat: add explorer sidebar width controls

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -22,6 +22,15 @@ To disable the leader popup while keeping leader mappings active:
 show_leader_popup = false
 ```
 
+### Configuring Explorer Width
+
+The file explorer sidebar is `35` columns wide by default. To change that:
+
+```toml
+[explorer]
+width = 42
+```
+
 ### Remapping Keys in Normal Mode
 
 Want `H` to go to the start of the line and `L` to go to the end? Add this:
@@ -750,6 +759,9 @@ When the file explorer sidebar is focused:
 | `?` | Show explorer keymaps |
 | `-` | Go to parent directory |
 | `Ctrl+l` | Focus editor and keep explorer open |
+| `>` | Widen explorer sidebar |
+| `<` | Narrow explorer sidebar |
+| `=` | Reset explorer sidebar width |
 | `a` | Create file or directory |
 | `r` | Rename selected item |
 | `d` | Delete selected item |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -9,6 +9,8 @@ pub mod languages;
 use serde::Deserialize;
 use std::path::PathBuf;
 
+use crate::explorer::DEFAULT_EXPLORER_WIDTH;
+
 pub use keymap::{CommandModeAction, KeymapLookup, LeaderAction, LeaderHint};
 pub use languages::{load_languages_config, FormatterConfig, LanguageConfig, LanguagesConfig};
 
@@ -19,6 +21,7 @@ pub struct Settings {
     pub editor: EditorSettings,
     pub theme: ThemeSettings,
     pub terminal: TerminalSettings,
+    pub explorer: ExplorerSettings,
     pub keymap: KeymapSettings,
     pub finder: FinderSettings,
     pub lsp: LspSettings,
@@ -31,6 +34,7 @@ impl Default for Settings {
             editor: EditorSettings::default(),
             theme: ThemeSettings::default(),
             terminal: TerminalSettings::default(),
+            explorer: ExplorerSettings::default(),
             keymap: KeymapSettings::default(),
             finder: FinderSettings::default(),
             lsp: LspSettings::default(),
@@ -122,6 +126,22 @@ impl Default for ThemeSettings {
     fn default() -> Self {
         Self {
             colorscheme: "onedark".to_string(),
+        }
+    }
+}
+
+/// File explorer settings
+#[derive(Debug, Clone, Deserialize)]
+#[serde(default)]
+pub struct ExplorerSettings {
+    /// Width of the file explorer sidebar in terminal columns.
+    pub width: u16,
+}
+
+impl Default for ExplorerSettings {
+    fn default() -> Self {
+        Self {
+            width: DEFAULT_EXPLORER_WIDTH,
         }
     }
 }
@@ -868,6 +888,13 @@ fn default_config_template() -> &'static str {
 #   "*-build"   - ends with -build (matches aws-build, my-build, etc.)
 #   "tmp*"      - starts with tmp
 #   "*test*"    - contains test
+
+# ============================================================================
+# FILE EXPLORER
+# ============================================================================
+# [explorer]
+# width = 35                  # Sidebar width in terminal columns
+#
 
 # ============================================================================
 # KEYMAP CUSTOMIZATION

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1358,6 +1358,7 @@ impl Editor {
     pub fn new(settings: Settings) -> Self {
         let (keymap, keymap_errors) = KeymapLookup::from_settings(&settings.keymap);
         let finder = FuzzyFinder::from_settings(&settings.finder);
+        let explorer_width = settings.explorer.width;
 
         // Initialize theme manager with bundled + user themes
         let mut theme_manager = ThemeManager::new();
@@ -1423,7 +1424,7 @@ impl Editor {
             show_diagnostic_float: false,
             search_matches: Vec::new(),
             project_root: None,
-            explorer: FileExplorer::new(),
+            explorer: FileExplorer::with_width(explorer_width),
             harpoon: crate::harpoon::Harpoon::new(),
             pending_format: false,
             save_after_format: false,
@@ -9179,6 +9180,27 @@ impl Editor {
         self.refresh_explorer_git_statuses();
         self.update_pane_rects();
         self.mode = Mode::Explorer;
+    }
+
+    /// Increase the file explorer sidebar width.
+    pub fn widen_explorer(&mut self) {
+        self.explorer.widen();
+        self.update_pane_rects();
+        self.set_status(format!("Explorer width: {}", self.explorer.width));
+    }
+
+    /// Decrease the file explorer sidebar width.
+    pub fn narrow_explorer(&mut self) {
+        self.explorer.narrow();
+        self.update_pane_rects();
+        self.set_status(format!("Explorer width: {}", self.explorer.width));
+    }
+
+    /// Reset the file explorer sidebar width to the configured default.
+    pub fn reset_explorer_width(&mut self) {
+        self.explorer.set_width(self.settings.explorer.width);
+        self.update_pane_rects();
+        self.set_status(format!("Explorer width: {}", self.explorer.width));
     }
 
     /// Close the file explorer sidebar

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -4,6 +4,11 @@ use std::path::{Path, PathBuf};
 
 use crate::git::{GitFileStatus, GitRepo};
 
+pub const DEFAULT_EXPLORER_WIDTH: u16 = 35;
+pub const MIN_EXPLORER_WIDTH: u16 = 20;
+pub const MAX_EXPLORER_WIDTH: u16 = 80;
+pub const EXPLORER_WIDTH_STEP: u16 = 5;
+
 /// Pending action in the file explorer
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExplorerAction {
@@ -161,7 +166,7 @@ impl Default for FileExplorer {
             selected: 0,
             flat_view: Vec::new(),
             visible: false,
-            width: 35,
+            width: DEFAULT_EXPLORER_WIDTH,
             pending_action: None,
             input_buffer: String::new(),
             input_cursor: 0,
@@ -180,6 +185,28 @@ impl Default for FileExplorer {
 impl FileExplorer {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn with_width(width: u16) -> Self {
+        let mut explorer = Self::default();
+        explorer.set_width(width);
+        explorer
+    }
+
+    pub fn clamp_width(width: u16) -> u16 {
+        width.clamp(MIN_EXPLORER_WIDTH, MAX_EXPLORER_WIDTH)
+    }
+
+    pub fn set_width(&mut self, width: u16) {
+        self.width = Self::clamp_width(width);
+    }
+
+    pub fn widen(&mut self) {
+        self.set_width(self.width.saturating_add(EXPLORER_WIDTH_STEP));
+    }
+
+    pub fn narrow(&mut self) {
+        self.set_width(self.width.saturating_sub(EXPLORER_WIDTH_STEP));
     }
 
     /// Set the root directory and build the tree

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -446,6 +446,14 @@ vim_default = true
             }),
             "explorer search Ctrl+w mapping should appear"
         );
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains(">")
+                    && item.display.to_lowercase().contains("widen")
+            }),
+            "explorer width resize mappings should appear"
+        );
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1624,6 +1624,24 @@ action = "focus_editor"
 desc = "Focus editor and keep explorer open"
 status = "implemented"
 
+[[explorer.layout]]
+key = ">"
+action = "widen_sidebar"
+desc = "Widen explorer sidebar"
+status = "implemented"
+
+[[explorer.layout]]
+key = "<"
+action = "narrow_sidebar"
+desc = "Narrow explorer sidebar"
+status = "implemented"
+
+[[explorer.layout]]
+key = "="
+action = "reset_sidebar_width"
+desc = "Reset explorer sidebar width"
+status = "implemented"
+
 [[explorer.files]]
 key = "a"
 action = "create"

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8724,6 +8724,17 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
             editor.unfocus_explorer();
         }
 
+        // Resize explorer sidebar
+        (KeyModifiers::SHIFT, KeyCode::Char('>')) | (KeyModifiers::NONE, KeyCode::Char('>')) => {
+            editor.widen_explorer();
+        }
+        (KeyModifiers::SHIFT, KeyCode::Char('<')) | (KeyModifiers::NONE, KeyCode::Char('<')) => {
+            editor.narrow_explorer();
+        }
+        (KeyModifiers::NONE, KeyCode::Char('=')) => {
+            editor.reset_explorer_width();
+        }
+
         // Add file/folder
         (KeyModifiers::NONE, KeyCode::Char('a')) => {
             editor.explorer.start_add();
@@ -10143,6 +10154,40 @@ mod tests {
 
         handle_key(&mut editor, ctrl_key('b'));
         assert_eq!(editor.explorer.selected, 10);
+    }
+
+    #[test]
+    fn explorer_width_keys_resize_and_reset_sidebar() {
+        let settings: Settings = toml::from_str(
+            r#"
+            [explorer]
+            width = 42
+            "#,
+        )
+        .expect("parse settings");
+        let mut editor = Editor::new(settings);
+        editor.set_size(100, 24);
+        editor.open_explorer();
+
+        assert_eq!(editor.explorer.width, 42);
+        assert_eq!(editor.panes()[0].rect.x, 43);
+
+        handle_key(&mut editor, key('>'));
+        assert_eq!(editor.mode, Mode::Explorer);
+        assert_eq!(editor.explorer.width, 47);
+        assert_eq!(editor.panes()[0].rect.x, 48);
+
+        handle_key(&mut editor, key('<'));
+        assert_eq!(editor.explorer.width, 42);
+        assert_eq!(editor.panes()[0].rect.x, 43);
+
+        handle_key(&mut editor, key('>'));
+        handle_key(&mut editor, key('>'));
+        assert_eq!(editor.explorer.width, 52);
+
+        handle_key(&mut editor, key('='));
+        assert_eq!(editor.explorer.width, 42);
+        assert_eq!(editor.panes()[0].rect.x, 43);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds configurable Explorer sidebar width via [explorer] width.
- Adds Explorer-focused >, <, and = controls to widen, narrow, and reset the sidebar.
- Documents the controls and exposes them in :Keymaps.

## Test Plan
- cargo fmt --check
- git diff --check
- cargo test --quiet
- Manual: cargo run -- /private/tmp/nevi_explorer_width_manual, then verified Explorer >, <, and = behavior.