### PR TITLE
feat: make explorer keybindings configurable

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -31,6 +31,31 @@ The file explorer sidebar is `35` columns wide by default. To change that:
 width = 42
 ```
 
+### Remapping Explorer Keys
+
+Explorer-mode keys can be remapped separately from global normal-mode keys:
+
+```toml
+[[keymap.explorer]]
+key = "o"
+action = "toggle_or_open"
+desc = "Toggle directory or open file"
+
+[[keymap.explorer]]
+key = "<C-r>"
+action = "refresh"
+desc = "Refresh explorer"
+```
+
+User mappings replace the shipped default for the same Explorer action. Supported
+actions are: `close`, `move_down`, `move_up`, `move_to_top`, `move_to_bottom`,
+`half_page_down`, `half_page_up`, `page_down`, `page_up`, `toggle_or_open`,
+`expand_or_open`, `collapse_or_parent`, `toggle_expand`, `collapse_all`,
+`refresh`, `show_explorer_keymaps`, `go_to_parent`, `focus_editor`,
+`widen_sidebar`, `narrow_sidebar`, `reset_sidebar_width`, `create`, `rename`,
+`delete`, `copy`, `cut`, `paste`, `search`, `next_match`, and
+`previous_match`.
+
 ### Remapping Keys in Normal Mode
 
 Want `H` to go to the start of the line and `L` to go to the end? Add this:

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -1,9 +1,9 @@
 //! Keymap parsing and lookup for custom key remappings
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
-use super::KeymapSettings;
+use super::{ExplorerModeMapping, KeymapSettings};
 
 /// Action to execute from a leader mapping
 #[derive(Debug, Clone)]
@@ -60,6 +60,41 @@ pub enum CommandModeAction {
     PopupPrev,
 }
 
+/// Action for file explorer mode keybindings.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExplorerModeAction {
+    Close,
+    MoveDown,
+    MoveUp,
+    MoveToTop,
+    MoveToBottom,
+    HalfPageDown,
+    HalfPageUp,
+    PageDown,
+    PageUp,
+    ToggleOrOpen,
+    ExpandOrOpen,
+    CollapseOrParent,
+    ToggleExpand,
+    CollapseAll,
+    Refresh,
+    ShowExplorerKeymaps,
+    GoToParent,
+    FocusEditor,
+    WidenSidebar,
+    NarrowSidebar,
+    ResetSidebarWidth,
+    Create,
+    Rename,
+    Delete,
+    Copy,
+    Cut,
+    Paste,
+    Search,
+    NextMatch,
+    PreviousMatch,
+}
+
 /// Lookup table for custom key remappings
 #[derive(Debug, Clone)]
 pub struct KeymapLookup {
@@ -71,6 +106,10 @@ pub struct KeymapLookup {
     insert: HashMap<KeyEvent, KeyEvent>,
     /// Command mode mappings: key -> command-line UX action
     command: HashMap<KeyEvent, CommandModeAction>,
+    /// Explorer mode mappings: key -> explorer action
+    explorer: HashMap<KeyEvent, ExplorerModeAction>,
+    /// Explorer mode multi-key sequences, such as `gg`.
+    explorer_sequences: HashMap<String, ExplorerModeAction>,
     /// Leader key (None if not configured)
     leader_key: Option<KeyEvent>,
     /// Leader mappings: key sequence -> action
@@ -86,6 +125,8 @@ impl Default for KeymapLookup {
             visual: HashMap::new(),
             insert: HashMap::new(),
             command: HashMap::new(),
+            explorer: HashMap::new(),
+            explorer_sequences: HashMap::new(),
             leader_key: None,
             leader_mappings: HashMap::new(),
             leader_metadata: HashMap::new(),
@@ -100,7 +141,10 @@ impl KeymapLookup {
         let mut visual = HashMap::new();
         let mut insert = HashMap::new();
         let mut command = HashMap::new();
+        let (explorer, explorer_sequences, explorer_errors) =
+            parse_explorer_mode_mappings(&settings.explorer);
         let mut errors = Vec::new();
+        errors.extend(explorer_errors);
 
         for entry in &settings.normal {
             if let Some(from) = parse_key_notation(&entry.from) {
@@ -207,6 +251,8 @@ impl KeymapLookup {
                 visual,
                 insert,
                 command,
+                explorer,
+                explorer_sequences,
                 leader_key,
                 leader_mappings,
                 leader_metadata,
@@ -233,6 +279,33 @@ impl KeymapLookup {
     /// Look up a command-mode mapping for command-line UX actions.
     pub fn get_command_action(&self, key: KeyEvent) -> Option<CommandModeAction> {
         self.command.get(&key).copied()
+    }
+
+    /// Look up an explorer-mode mapping for file explorer actions.
+    pub fn get_explorer_action(&self, key: KeyEvent) -> Option<ExplorerModeAction> {
+        if let Some(action) = self.explorer.get(&key).copied() {
+            return Some(action);
+        }
+
+        for fallback in normalized_char_key_candidates(key) {
+            if let Some(action) = self.explorer.get(&fallback).copied() {
+                return Some(action);
+            }
+        }
+
+        None
+    }
+
+    /// Look up a complete explorer-mode key sequence.
+    pub fn get_explorer_sequence_action(&self, sequence: &str) -> Option<ExplorerModeAction> {
+        self.explorer_sequences.get(sequence).copied()
+    }
+
+    /// Check if an explorer-mode sequence could continue.
+    pub fn is_explorer_sequence_prefix(&self, sequence: &str) -> bool {
+        self.explorer_sequences
+            .keys()
+            .any(|key| key.starts_with(sequence) && key != sequence)
     }
 
     /// Check if there are any normal mode mappings
@@ -332,6 +405,121 @@ impl KeymapLookup {
     }
 }
 
+fn normalized_char_key_candidates(key: KeyEvent) -> Vec<KeyEvent> {
+    let KeyCode::Char(c) = key.code else {
+        return Vec::new();
+    };
+
+    let mut candidates = Vec::new();
+    if c.is_ascii_uppercase() {
+        candidates.push(KeyEvent::new(
+            KeyCode::Char(c),
+            key.modifiers | KeyModifiers::SHIFT,
+        ));
+        let mut without_shift = key.modifiers;
+        without_shift.remove(KeyModifiers::SHIFT);
+        candidates.push(KeyEvent::new(KeyCode::Char(c), without_shift));
+    } else if !c.is_ascii_alphabetic() {
+        let mut without_shift = key.modifiers;
+        without_shift.remove(KeyModifiers::SHIFT);
+        candidates.push(KeyEvent::new(KeyCode::Char(c), without_shift));
+        candidates.push(KeyEvent::new(
+            KeyCode::Char(c),
+            key.modifiers | KeyModifiers::SHIFT,
+        ));
+    }
+
+    candidates
+}
+
+fn parse_explorer_mode_mappings(
+    user_mappings: &[ExplorerModeMapping],
+) -> (
+    HashMap<KeyEvent, ExplorerModeAction>,
+    HashMap<String, ExplorerModeAction>,
+    Vec<String>,
+) {
+    let mut errors = Vec::new();
+    let mut valid_user_mappings = Vec::new();
+
+    for mapping in user_mappings {
+        let Some(action) = parse_explorer_mode_action(&mapping.action) else {
+            errors.push(format!(
+                "Keymap: invalid explorer mode action '{}'",
+                mapping.action
+            ));
+            continue;
+        };
+
+        match parse_explorer_binding(&mapping.key) {
+            Some(binding) => valid_user_mappings.push((mapping.key.clone(), binding, action)),
+            None => errors.push(format!(
+                "Keymap: invalid explorer mode key '{}'",
+                mapping.key
+            )),
+        }
+    }
+
+    let overridden_actions: HashSet<ExplorerModeAction> = valid_user_mappings
+        .iter()
+        .map(|(_, _, action)| *action)
+        .collect();
+
+    let mut combined = Vec::new();
+    for mapping in KeymapSettings::default().explorer {
+        let Some(action) = parse_explorer_mode_action(&mapping.action) else {
+            continue;
+        };
+        if !overridden_actions.contains(&action) {
+            if let Some(binding) = parse_explorer_binding(&mapping.key) {
+                combined.push((mapping.key, binding, action));
+            }
+        }
+    }
+    combined.extend(valid_user_mappings);
+
+    let mut keys = HashMap::new();
+    let mut sequences = HashMap::new();
+    for (raw_key, binding, action) in combined {
+        match binding {
+            ExplorerBinding::Key(key) => {
+                keys.insert(key, action);
+            }
+            ExplorerBinding::Sequence => {
+                sequences.insert(raw_key, action);
+            }
+        }
+    }
+
+    (keys, sequences, errors)
+}
+
+enum ExplorerBinding {
+    Key(KeyEvent),
+    Sequence,
+}
+
+fn parse_explorer_binding(key: &str) -> Option<ExplorerBinding> {
+    if let Some(event) = parse_key_notation(key) {
+        return Some(ExplorerBinding::Key(event));
+    }
+
+    if is_plain_explorer_sequence(key) {
+        return Some(ExplorerBinding::Sequence);
+    }
+
+    None
+}
+
+fn is_plain_explorer_sequence(key: &str) -> bool {
+    !key.starts_with('<')
+        && !key.ends_with('>')
+        && key.chars().count() > 1
+        && key
+            .chars()
+            .all(|ch| !ch.is_control() && !ch.is_whitespace())
+}
+
 /// Parse an action string into a LeaderAction
 fn parse_action(action: &str) -> LeaderAction {
     // If it starts with ':', it's a command
@@ -387,6 +575,42 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
         "complete_prev" => Some(CommandModeAction::CompletePrev),
         "popup_next" => Some(CommandModeAction::PopupNext),
         "popup_prev" => Some(CommandModeAction::PopupPrev),
+        _ => None,
+    }
+}
+
+fn parse_explorer_mode_action(action: &str) -> Option<ExplorerModeAction> {
+    match action.trim().to_lowercase().as_str() {
+        "close" => Some(ExplorerModeAction::Close),
+        "move_down" => Some(ExplorerModeAction::MoveDown),
+        "move_up" => Some(ExplorerModeAction::MoveUp),
+        "move_to_top" => Some(ExplorerModeAction::MoveToTop),
+        "move_to_bottom" => Some(ExplorerModeAction::MoveToBottom),
+        "half_page_down" => Some(ExplorerModeAction::HalfPageDown),
+        "half_page_up" => Some(ExplorerModeAction::HalfPageUp),
+        "page_down" => Some(ExplorerModeAction::PageDown),
+        "page_up" => Some(ExplorerModeAction::PageUp),
+        "toggle_or_open" => Some(ExplorerModeAction::ToggleOrOpen),
+        "expand_or_open" => Some(ExplorerModeAction::ExpandOrOpen),
+        "collapse_or_parent" => Some(ExplorerModeAction::CollapseOrParent),
+        "toggle_expand" => Some(ExplorerModeAction::ToggleExpand),
+        "collapse_all" => Some(ExplorerModeAction::CollapseAll),
+        "refresh" => Some(ExplorerModeAction::Refresh),
+        "show_explorer_keymaps" => Some(ExplorerModeAction::ShowExplorerKeymaps),
+        "go_to_parent" => Some(ExplorerModeAction::GoToParent),
+        "focus_editor" => Some(ExplorerModeAction::FocusEditor),
+        "widen_sidebar" => Some(ExplorerModeAction::WidenSidebar),
+        "narrow_sidebar" => Some(ExplorerModeAction::NarrowSidebar),
+        "reset_sidebar_width" => Some(ExplorerModeAction::ResetSidebarWidth),
+        "create" => Some(ExplorerModeAction::Create),
+        "rename" => Some(ExplorerModeAction::Rename),
+        "delete" => Some(ExplorerModeAction::Delete),
+        "copy" => Some(ExplorerModeAction::Copy),
+        "cut" => Some(ExplorerModeAction::Cut),
+        "paste" => Some(ExplorerModeAction::Paste),
+        "search" => Some(ExplorerModeAction::Search),
+        "next_match" => Some(ExplorerModeAction::NextMatch),
+        "previous_match" | "prev_match" => Some(ExplorerModeAction::PreviousMatch),
         _ => None,
     }
 }
@@ -582,6 +806,7 @@ mod tests {
             visual: vec![],
             insert: vec![],
             command_mappings: vec![],
+            explorer: vec![],
             leader_mappings: vec![super::super::LeaderMapping {
                 key: "m".to_string(),
                 action: ":HarpoonAdd".to_string(),
@@ -616,6 +841,7 @@ mod tests {
             visual: vec![],
             insert: vec![],
             command_mappings: vec![],
+            explorer: vec![],
             leader_mappings: vec![super::super::LeaderMapping {
                 key: "w".to_string(),
                 action: ":w<CR>".to_string(),

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 
 use crate::explorer::DEFAULT_EXPLORER_WIDTH;
 
-pub use keymap::{CommandModeAction, KeymapLookup, LeaderAction, LeaderHint};
+pub use keymap::{CommandModeAction, ExplorerModeAction, KeymapLookup, LeaderAction, LeaderHint};
 pub use languages::{load_languages_config, FormatterConfig, LanguageConfig, LanguagesConfig};
 
 /// Main settings structure
@@ -242,6 +242,8 @@ pub struct KeymapSettings {
     pub insert: Vec<KeymapEntry>,
     /// Command mode mappings for command-line UX actions
     pub command_mappings: Vec<CommandModeMapping>,
+    /// Explorer mode mappings for file explorer actions
+    pub explorer: Vec<ExplorerModeMapping>,
     /// Leader key mappings (e.g., <leader>w -> :w<CR>)
     pub leader_mappings: Vec<LeaderMapping>,
 }
@@ -307,6 +309,7 @@ impl Default for KeymapSettings {
                     desc: Some("Select previous popup item".to_string()),
                 },
             ],
+            explorer: default_explorer_mappings(),
             leader_mappings: vec![
                 // LSP actions
                 LeaderMapping {
@@ -508,6 +511,80 @@ pub struct CommandModeMapping {
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
     pub desc: Option<String>,
+}
+
+/// An explorer-mode mapping for file explorer actions
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExplorerModeMapping {
+    /// Key notation (e.g., "j", "<Down>", "gg", "?")
+    pub key: String,
+    /// Action name (move_down, refresh, create, widen_sidebar, etc.)
+    pub action: String,
+    /// Optional description for docs/which-key style UIs
+    #[serde(default)]
+    pub desc: Option<String>,
+}
+
+fn default_explorer_mappings() -> Vec<ExplorerModeMapping> {
+    let mappings = [
+        ("<Esc>", "close", "Close explorer"),
+        ("<C-[>", "close", "Close explorer"),
+        ("q", "close", "Close explorer"),
+        ("j", "move_down", "Move down"),
+        ("<Down>", "move_down", "Move down"),
+        ("k", "move_up", "Move up"),
+        ("<Up>", "move_up", "Move up"),
+        ("gg", "move_to_top", "Move to top"),
+        ("G", "move_to_bottom", "Move to bottom"),
+        ("<C-d>", "half_page_down", "Move half page down"),
+        ("<C-u>", "half_page_up", "Move half page up"),
+        ("<C-f>", "page_down", "Move page down"),
+        ("<C-b>", "page_up", "Move page up"),
+        ("<CR>", "toggle_or_open", "Toggle directory or open file"),
+        ("l", "expand_or_open", "Expand directory or open file"),
+        ("<Right>", "expand_or_open", "Expand directory or open file"),
+        (
+            "h",
+            "collapse_or_parent",
+            "Collapse directory or go to parent",
+        ),
+        (
+            "<Left>",
+            "collapse_or_parent",
+            "Collapse directory or go to parent",
+        ),
+        ("<Tab>", "toggle_expand", "Toggle expand/collapse"),
+        ("W", "collapse_all", "Collapse all directories"),
+        ("R", "refresh", "Refresh explorer and git status"),
+        ("?", "show_explorer_keymaps", "Show explorer keymaps"),
+        ("-", "go_to_parent", "Go to parent directory"),
+        (
+            "<C-l>",
+            "focus_editor",
+            "Focus editor and keep explorer open",
+        ),
+        (">", "widen_sidebar", "Widen explorer sidebar"),
+        ("<", "narrow_sidebar", "Narrow explorer sidebar"),
+        ("=", "reset_sidebar_width", "Reset explorer sidebar width"),
+        ("a", "create", "Create file or directory"),
+        ("r", "rename", "Rename selected item"),
+        ("d", "delete", "Delete selected item"),
+        ("c", "copy", "Copy selected item"),
+        ("x", "cut", "Cut selected item"),
+        ("p", "paste", "Paste copied/cut item"),
+        ("/", "search", "Search explorer"),
+        ("n", "next_match", "Next search match"),
+        ("N", "previous_match", "Previous search match"),
+    ];
+
+    mappings
+        .into_iter()
+        .map(|(key, action, desc)| ExplorerModeMapping {
+            key: key.to_string(),
+            action: action.to_string(),
+            desc: Some(desc.to_string()),
+        })
+        .collect()
 }
 
 /// LSP (Language Server Protocol) settings
@@ -1249,6 +1326,25 @@ fn default_config_template() -> &'static str {
 # [[keymap.command_mappings]]
 # key = "<C-j>"
 # action = "popup_next"
+#
+# To override file explorer mode bindings:
+# [[keymap.explorer]]
+# key = "o"
+# action = "toggle_or_open"
+# desc = "Toggle directory or open file"
+#
+# [[keymap.explorer]]
+# key = "<C-r>"
+# action = "refresh"
+# desc = "Refresh explorer"
+#
+# Explorer action names:
+# close, move_down, move_up, move_to_top, move_to_bottom, half_page_down,
+# half_page_up, page_down, page_up, toggle_or_open, expand_or_open,
+# collapse_or_parent, toggle_expand, collapse_all, refresh,
+# show_explorer_keymaps, go_to_parent, focus_editor, widen_sidebar,
+# narrow_sidebar, reset_sidebar_width, create, rename, delete, copy, cut,
+# paste, search, next_match, previous_match
 
 # ============================================================================
 # LSP (Language Server Protocol)
@@ -1351,6 +1447,9 @@ pub fn load_config() -> Settings {
                 // Merge command mode mappings: defaults + user overrides by action
                 user_settings.keymap.command_mappings =
                     merge_command_mappings(&user_settings.keymap.command_mappings);
+                // Merge explorer mode mappings: defaults + user overrides by action
+                user_settings.keymap.explorer =
+                    merge_explorer_mappings(&user_settings.keymap.explorer);
                 // Merge LSP server configs so partial per-server overrides keep defaults.
                 user_settings.lsp.servers =
                     merge_lsp_servers_with_defaults(user_settings.lsp.servers);
@@ -1446,6 +1545,27 @@ fn merge_command_mappings(user_mappings: &[CommandModeMapping]) -> Vec<CommandMo
 
     // Start with defaults that aren't overridden by user action
     let mut merged: Vec<CommandModeMapping> = defaults
+        .into_iter()
+        .filter(|m| !user_actions.contains(m.action.as_str()))
+        .collect();
+
+    // Add all user mappings
+    merged.extend(user_mappings.iter().cloned());
+
+    merged
+}
+
+/// Merge user explorer-mode mappings with defaults.
+/// User mappings take precedence for the same action.
+fn merge_explorer_mappings(user_mappings: &[ExplorerModeMapping]) -> Vec<ExplorerModeMapping> {
+    let defaults = KeymapSettings::default().explorer;
+
+    // Collect user-defined action ids for quick lookup
+    let user_actions: std::collections::HashSet<&str> =
+        user_mappings.iter().map(|m| m.action.as_str()).collect();
+
+    // Start with defaults that aren't overridden by user action
+    let mut merged: Vec<ExplorerModeMapping> = defaults
         .into_iter()
         .filter(|m| !user_actions.contains(m.action.as_str()))
         .collect();

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -882,6 +882,8 @@ pub struct Editor {
     pub keymap: KeymapLookup,
     /// Leader key sequence being built (None if not in leader mode)
     pub leader_sequence: Option<String>,
+    /// Explorer-mode key sequence being built (for bindings like `gg`)
+    pub explorer_key_sequence: Option<String>,
     /// When leader mode started (for timeout tracking)
     pub leader_sequence_start: Option<Instant>,
     /// Action to execute when leader timeout expires
@@ -1407,6 +1409,7 @@ impl Editor {
             settings,
             keymap,
             leader_sequence: None,
+            explorer_key_sequence: None,
             leader_sequence_start: None,
             leader_pending_action: None,
             pending_external_command: None,

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use serde::Deserialize;
 
 use super::FinderItem;
-use crate::config::{KeymapEntry, KeymapSettings, LeaderMapping};
+use crate::config::{ExplorerModeMapping, KeymapEntry, KeymapSettings, LeaderMapping};
 
 /// Raw entry as stored in KEYBINDS.toml. Mode + category come from the table path.
 #[derive(Debug, Clone, Deserialize)]
@@ -135,6 +135,7 @@ pub fn display_row(entry: &KeybindEntry) -> String {
 ///   live), minus any the user has remapped;
 /// - the user's own normal/visual/insert remaps, from `keymap`;
 /// - command-line UX mappings from `keymap.command_mappings`;
+/// - explorer-mode mappings from `keymap.explorer`;
 /// - commands from the live `COMMAND_SPECS` registry;
 /// - leader bindings from `keymap.leader_mappings` (the active, merged set).
 ///
@@ -145,10 +146,11 @@ pub fn keymap_finder_items(keymap: &KeymapSettings) -> Vec<FinderItem> {
     // Drop built-in rows the user has remapped; show their remap instead.
     let mut entries: Vec<KeybindEntry> = raw_key_entries()
         .into_iter()
-        .filter(|entry| !is_remapped(keymap, &entry.mode, &entry.key))
+        .filter(|entry| !is_remapped(keymap, entry))
         .collect();
     entries.extend(remap_entries(keymap));
     entries.extend(command_mode_entries(keymap));
+    entries.extend(explorer_mode_entries(keymap));
     entries.extend(command_entries());
     entries.extend(leader_entries(&keymap.leader_mappings));
     entries.iter().map(entry_to_item).collect()
@@ -156,12 +158,28 @@ pub fn keymap_finder_items(keymap: &KeymapSettings) -> Vec<FinderItem> {
 
 /// True if the user has remapped `key` in the given mode, so the built-in
 /// default row should be replaced by the user's remap.
-fn is_remapped(keymap: &KeymapSettings, mode: &str, key: &str) -> bool {
-    match mode {
-        "normal" => keymap.normal.iter().any(|entry| entry.from == key),
-        "visual" => keymap.visual.iter().any(|entry| entry.from == key),
-        "insert" => keymap.insert.iter().any(|entry| entry.from == key),
-        "cmdline" => keymap.command_mappings.iter().any(|entry| entry.key == key),
+fn is_remapped(keymap: &KeymapSettings, entry: &KeybindEntry) -> bool {
+    match entry.mode.as_str() {
+        "normal" => keymap
+            .normal
+            .iter()
+            .any(|mapping| mapping.from == entry.key),
+        "visual" => keymap
+            .visual
+            .iter()
+            .any(|mapping| mapping.from == entry.key),
+        "insert" => keymap
+            .insert
+            .iter()
+            .any(|mapping| mapping.from == entry.key),
+        "cmdline" => keymap
+            .command_mappings
+            .iter()
+            .any(|mapping| mapping.key == entry.key),
+        "explorer" => keymap
+            .explorer
+            .iter()
+            .any(|mapping| mapping.action == entry.action),
         _ => false,
     }
 }
@@ -262,6 +280,27 @@ fn command_mode_entries(keymap: &KeymapSettings) -> Vec<KeybindEntry> {
             }
         })
         .collect()
+}
+
+/// Rows for file explorer mappings from the live config.
+fn explorer_mode_entries(keymap: &KeymapSettings) -> Vec<KeybindEntry> {
+    keymap.explorer.iter().map(explorer_mapping_entry).collect()
+}
+
+fn explorer_mapping_entry(mapping: &ExplorerModeMapping) -> KeybindEntry {
+    let desc = mapping
+        .desc
+        .clone()
+        .unwrap_or_else(|| mapping.action.clone());
+    KeybindEntry {
+        mode: "explorer".to_string(),
+        category: String::new(),
+        key: mapping.key.clone(),
+        action: mapping.action.clone(),
+        desc,
+        status: "implemented".to_string(),
+        vim_default: false,
+    }
 }
 
 /// Render one entry as an inert finder item (empty path, no metadata) so Enter
@@ -453,6 +492,34 @@ vim_default = true
                     && item.display.to_lowercase().contains("widen")
             }),
             "explorer width resize mappings should appear"
+        );
+    }
+
+    #[test]
+    fn picker_overlays_user_explorer_mappings_by_action() {
+        let mut keymap = KeymapSettings::default();
+        keymap.explorer = vec![ExplorerModeMapping {
+            key: "o".to_string(),
+            action: "widen_sidebar".to_string(),
+            desc: Some("Widen explorer sidebar".to_string()),
+        }];
+
+        let items = keymap_finder_items(&keymap);
+        assert!(
+            items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains("o")
+                    && item.display.to_lowercase().contains("widen")
+            }),
+            "custom explorer mapping should appear in :Keymaps"
+        );
+        assert!(
+            !items.iter().any(|item| {
+                item.display.contains("expl")
+                    && item.display.contains(">")
+                    && item.display.to_lowercase().contains("widen")
+            }),
+            "default explorer binding should be hidden when the action is remapped"
         );
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8552,16 +8552,6 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
-    if editor.explorer.take_goto_top_sequence() {
-        if matches!(
-            (key.modifiers, key.code),
-            (KeyModifiers::NONE, KeyCode::Char('g'))
-        ) {
-            editor.explorer.move_to_top();
-            return;
-        }
-    }
-
     // Handle leader key sequences (same as normal mode)
     if let Some(ref mut sequence) = editor.leader_sequence {
         if key.code == KeyCode::Esc {
@@ -8597,6 +8587,26 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
+    if let Some(ref mut sequence) = editor.explorer_key_sequence {
+        if let Some(part) = explorer_sequence_part(key) {
+            sequence.push_str(&part);
+            let seq = sequence.clone();
+
+            if let Some(action) = editor.keymap.get_explorer_sequence_action(&seq) {
+                editor.explorer_key_sequence = None;
+                execute_explorer_mode_action(editor, action);
+                return;
+            }
+
+            if editor.keymap.is_explorer_sequence_prefix(&seq) {
+                return;
+            }
+        }
+
+        editor.explorer_key_sequence = None;
+        return;
+    }
+
     // Check if this key is the leader key
     if editor.keymap.has_leader_mappings() && editor.keymap.is_leader_key(key) {
         editor.leader_sequence = Some(String::new());
@@ -8604,183 +8614,107 @@ fn handle_explorer_mode(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
-    match (key.modifiers, key.code) {
-        // Close explorer
-        (KeyModifiers::NONE, KeyCode::Esc)
-        | (KeyModifiers::CONTROL, KeyCode::Char('['))
-        | (KeyModifiers::NONE, KeyCode::Char('q')) => {
-            editor.close_explorer();
+    if let Some(part) = explorer_sequence_part(key) {
+        if editor.keymap.is_explorer_sequence_prefix(&part) {
+            editor.explorer_key_sequence = Some(part);
+            return;
         }
 
-        // Move down
-        (KeyModifiers::NONE, KeyCode::Char('j')) | (KeyModifiers::NONE, KeyCode::Down) => {
-            editor.explorer.move_down();
+        if let Some(action) = editor.keymap.get_explorer_sequence_action(&part) {
+            execute_explorer_mode_action(editor, action);
+            return;
         }
+    }
 
-        // Move up
-        (KeyModifiers::NONE, KeyCode::Char('k')) | (KeyModifiers::NONE, KeyCode::Up) => {
-            editor.explorer.move_up();
-        }
+    if let Some(action) = editor.keymap.get_explorer_action(key) {
+        execute_explorer_mode_action(editor, action);
+    }
+}
 
-        // gg - move to top
-        (KeyModifiers::NONE, KeyCode::Char('g')) => {
-            editor.explorer.start_goto_top_sequence();
-        }
+fn explorer_sequence_part(key: KeyEvent) -> Option<String> {
+    match key {
+        KeyEvent {
+            code: KeyCode::Char(c),
+            modifiers,
+            ..
+        } if modifiers.is_empty() || modifiers == KeyModifiers::SHIFT => Some(c.to_string()),
+        _ => None,
+    }
+}
 
-        // G - move to bottom
-        (KeyModifiers::SHIFT, KeyCode::Char('G')) | (KeyModifiers::NONE, KeyCode::Char('G')) => {
-            editor.explorer.move_to_bottom();
-        }
+fn execute_explorer_mode_action(editor: &mut Editor, action: crate::config::ExplorerModeAction) {
+    use crate::config::ExplorerModeAction;
 
-        // Ctrl+d / Ctrl+u - half-page movement
-        (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
-            editor
-                .explorer
-                .move_page_down(explorer_half_page_rows(editor));
-        }
-        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
-            editor
-                .explorer
-                .move_page_up(explorer_half_page_rows(editor));
-        }
-
-        // Ctrl+f / Ctrl+b - page movement
-        (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
-            editor
-                .explorer
-                .move_page_down(explorer_visible_rows(editor));
-        }
-        (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
-            editor.explorer.move_page_up(explorer_visible_rows(editor));
-        }
-
-        // Enter - toggle directory or open file
-        (KeyModifiers::NONE, KeyCode::Enter) => {
-            if let Some(path) = editor.explorer_selected_path() {
-                if path.is_dir() {
-                    // Toggle directory expand/collapse
-                    editor.explorer.toggle_expand();
-                } else {
-                    // Open file and switch to normal mode
-                    let path_clone = path.clone();
-                    if let Err(e) = editor.open_file(path_clone) {
-                        editor.set_status(format!("Error opening file: {}", e));
-                    } else {
-                        editor.mode = Mode::Normal;
-                    }
-                }
-            }
-        }
-
-        // l/Right - expand directory or open file
-        (KeyModifiers::NONE, KeyCode::Char('l')) | (KeyModifiers::NONE, KeyCode::Right) => {
-            if let Some(path) = editor.explorer_selected_path() {
-                if path.is_dir() {
-                    editor.explorer.expand();
-                } else {
-                    let path_clone = path.clone();
-                    if let Err(e) = editor.open_file(path_clone) {
-                        editor.set_status(format!("Error opening file: {}", e));
-                    } else {
-                        editor.mode = Mode::Normal;
-                    }
-                }
-            }
-        }
-
-        // Collapse directory or go to parent
-        (KeyModifiers::NONE, KeyCode::Char('h')) | (KeyModifiers::NONE, KeyCode::Left) => {
-            editor.explorer.collapse();
-        }
-
-        // Toggle expand/collapse
-        (KeyModifiers::NONE, KeyCode::Tab) => {
-            editor.explorer.toggle_expand();
-        }
-
-        // Collapse all
-        (KeyModifiers::SHIFT, KeyCode::Char('W')) | (KeyModifiers::NONE, KeyCode::Char('W')) => {
-            editor.explorer.collapse_all();
-        }
-
-        // Refresh
-        (KeyModifiers::SHIFT, KeyCode::Char('R')) => {
+    match action {
+        ExplorerModeAction::Close => editor.close_explorer(),
+        ExplorerModeAction::MoveDown => editor.explorer.move_down(),
+        ExplorerModeAction::MoveUp => editor.explorer.move_up(),
+        ExplorerModeAction::MoveToTop => editor.explorer.move_to_top(),
+        ExplorerModeAction::MoveToBottom => editor.explorer.move_to_bottom(),
+        ExplorerModeAction::HalfPageDown => editor
+            .explorer
+            .move_page_down(explorer_half_page_rows(editor)),
+        ExplorerModeAction::HalfPageUp => editor
+            .explorer
+            .move_page_up(explorer_half_page_rows(editor)),
+        ExplorerModeAction::PageDown => editor
+            .explorer
+            .move_page_down(explorer_visible_rows(editor)),
+        ExplorerModeAction::PageUp => editor.explorer.move_page_up(explorer_visible_rows(editor)),
+        ExplorerModeAction::ToggleOrOpen => toggle_or_open_explorer_selection(editor),
+        ExplorerModeAction::ExpandOrOpen => expand_or_open_explorer_selection(editor),
+        ExplorerModeAction::CollapseOrParent => editor.explorer.collapse(),
+        ExplorerModeAction::ToggleExpand => editor.explorer.toggle_expand(),
+        ExplorerModeAction::CollapseAll => editor.explorer.collapse_all(),
+        ExplorerModeAction::Refresh => {
             editor.explorer.refresh();
             editor.refresh_explorer_git_statuses();
         }
+        ExplorerModeAction::ShowExplorerKeymaps => editor.open_keymaps_picker_with_query("expl"),
+        ExplorerModeAction::GoToParent => editor.explorer.go_to_parent(),
+        ExplorerModeAction::FocusEditor => editor.unfocus_explorer(),
+        ExplorerModeAction::WidenSidebar => editor.widen_explorer(),
+        ExplorerModeAction::NarrowSidebar => editor.narrow_explorer(),
+        ExplorerModeAction::ResetSidebarWidth => editor.reset_explorer_width(),
+        ExplorerModeAction::Create => editor.explorer.start_add(),
+        ExplorerModeAction::Rename => editor.explorer.start_rename(),
+        ExplorerModeAction::Delete => editor.explorer.start_delete(),
+        ExplorerModeAction::Copy => editor.explorer.copy_selected(),
+        ExplorerModeAction::Cut => editor.explorer.cut_selected(),
+        ExplorerModeAction::Paste => execute_explorer_paste(editor),
+        ExplorerModeAction::Search => editor.explorer.start_search(),
+        ExplorerModeAction::NextMatch => editor.explorer.next_match(),
+        ExplorerModeAction::PreviousMatch => editor.explorer.prev_match(),
+    }
+}
 
-        // Help / discoverability
-        (KeyModifiers::SHIFT, KeyCode::Char('?')) | (KeyModifiers::NONE, KeyCode::Char('?')) => {
-            editor.open_keymaps_picker_with_query("expl");
+fn toggle_or_open_explorer_selection(editor: &mut Editor) {
+    if let Some(path) = editor.explorer_selected_path() {
+        if path.is_dir() {
+            editor.explorer.toggle_expand();
+        } else {
+            let path_clone = path.clone();
+            if let Err(e) = editor.open_file(path_clone) {
+                editor.set_status(format!("Error opening file: {}", e));
+            } else {
+                editor.mode = Mode::Normal;
+            }
         }
+    }
+}
 
-        // Go to parent directory
-        (KeyModifiers::NONE, KeyCode::Char('-')) => {
-            editor.explorer.go_to_parent();
+fn expand_or_open_explorer_selection(editor: &mut Editor) {
+    if let Some(path) = editor.explorer_selected_path() {
+        if path.is_dir() {
+            editor.explorer.expand();
+        } else {
+            let path_clone = path.clone();
+            if let Err(e) = editor.open_file(path_clone) {
+                editor.set_status(format!("Error opening file: {}", e));
+            } else {
+                editor.mode = Mode::Normal;
+            }
         }
-
-        // Focus editor (keep explorer open)
-        (KeyModifiers::CONTROL, KeyCode::Char('l')) => {
-            editor.unfocus_explorer();
-        }
-
-        // Resize explorer sidebar
-        (KeyModifiers::SHIFT, KeyCode::Char('>')) | (KeyModifiers::NONE, KeyCode::Char('>')) => {
-            editor.widen_explorer();
-        }
-        (KeyModifiers::SHIFT, KeyCode::Char('<')) | (KeyModifiers::NONE, KeyCode::Char('<')) => {
-            editor.narrow_explorer();
-        }
-        (KeyModifiers::NONE, KeyCode::Char('=')) => {
-            editor.reset_explorer_width();
-        }
-
-        // Add file/folder
-        (KeyModifiers::NONE, KeyCode::Char('a')) => {
-            editor.explorer.start_add();
-        }
-
-        // Rename
-        (KeyModifiers::NONE, KeyCode::Char('r')) => {
-            editor.explorer.start_rename();
-        }
-
-        // Delete
-        (KeyModifiers::NONE, KeyCode::Char('d')) => {
-            editor.explorer.start_delete();
-        }
-
-        // Search
-        (KeyModifiers::NONE, KeyCode::Char('/')) => {
-            editor.explorer.start_search();
-        }
-
-        // Next search match
-        (KeyModifiers::NONE, KeyCode::Char('n')) => {
-            editor.explorer.next_match();
-        }
-
-        // Previous search match
-        (KeyModifiers::SHIFT, KeyCode::Char('N')) => {
-            editor.explorer.prev_match();
-        }
-
-        // Copy
-        (KeyModifiers::NONE, KeyCode::Char('c')) => {
-            editor.explorer.copy_selected();
-        }
-
-        // Cut
-        (KeyModifiers::NONE, KeyCode::Char('x')) => {
-            editor.explorer.cut_selected();
-        }
-
-        // Paste
-        (KeyModifiers::NONE, KeyCode::Char('p')) => {
-            execute_explorer_paste(editor);
-        }
-
-        _ => {}
     }
 }
 
@@ -10188,6 +10122,61 @@ mod tests {
         handle_key(&mut editor, key('='));
         assert_eq!(editor.explorer.width, 42);
         assert_eq!(editor.panes()[0].rect.x, 43);
+    }
+
+    #[test]
+    fn explorer_keymap_can_rebind_sidebar_width_action() {
+        let settings: Settings = toml::from_str(
+            r#"
+            [[keymap.explorer]]
+            key = "o"
+            action = "widen_sidebar"
+            desc = "Widen explorer sidebar"
+            "#,
+        )
+        .expect("parse settings");
+        let mut editor = Editor::new(settings);
+        editor.set_size(100, 24);
+        editor.open_explorer();
+
+        assert_eq!(editor.explorer.width, 35);
+
+        handle_key(&mut editor, key('o'));
+        assert_eq!(editor.mode, Mode::Explorer);
+        assert_eq!(editor.explorer.width, 40);
+
+        handle_key(&mut editor, key('>'));
+        assert_eq!(
+            editor.explorer.width, 40,
+            "user binding should replace the default for the same explorer action"
+        );
+    }
+
+    #[test]
+    fn invalid_explorer_keymap_keeps_default_binding_and_reports_error() {
+        let settings: Settings = toml::from_str(
+            r#"
+            [[keymap.explorer]]
+            key = "<Nope>"
+            action = "widen_sidebar"
+            desc = "Widen explorer sidebar"
+            "#,
+        )
+        .expect("parse settings");
+        let mut editor = Editor::new(settings);
+        editor.set_size(100, 24);
+        editor.open_explorer();
+
+        handle_key(&mut editor, key('>'));
+        assert_eq!(editor.explorer.width, 40);
+
+        let errors = editor.take_startup_errors();
+        assert!(
+            errors
+                .iter()
+                .any(|error| error.contains("invalid explorer mode key '<Nope>'")),
+            "expected invalid explorer keymap error, got {errors:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds [[keymap.explorer]] support for configurable Explorer-mode keybindings.
- Keeps shipped Explorer defaults while allowing user mappings to replace defaults by action.
- Updates :Keymaps, generated config comments, and KEYBINDINGS.md for Explorer remaps.

