### PR TITLE
feat: add config discoverability commands

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -914,6 +914,8 @@ While typing an Ex command after `:`.
 | `:Theme {name}` / `:theme {name}` / `:colorscheme {name}` | Set theme |
 | `:LazyGit` / `:lg` | Open lazygit |
 | `:checkhealth` / `:CheckHealth` / `:Health` | Open editor health report with config, profiling, and LSP summary |
+| `:ConfigOpen` / `:config` / `:configopen` | Open the user config file, creating it first if needed |
+| `:ConfigDefaults` / `:configdefaults` | View the latest built-in default config template without changing user config |
 | `:!{command}` | Run external shell command |
 | `:Terminal` / `:term` | Toggle floating terminal |
 | `:TerminalNew [name]` / `:termnew [name]` | Create floating terminal session |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ nevi file1.rs file2.rs
 - `:q` - Quit
 - `:wq` - Save and quit
 - `:checkhealth` / `:Health` - Open editor health report
+- `:ConfigOpen` / `:config` - Open your user config file
+- `:ConfigDefaults` - View the latest built-in default config template
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
@@ -156,7 +158,13 @@ enabled = true
 enabled = true
 ```
 
-See the generated config file at `~/.config/nevi/config.toml` for all available options with documentation.
+Run `:ConfigOpen` (or `:config`) to open your user config file from inside
+Nevi. Run `:ConfigDefaults` to view the latest built-in default config template
+without changing your existing config. Existing config files stay user-owned;
+Nevi does not rewrite them when new defaults are added.
+
+See the generated config file at `~/.config/nevi/config.toml` for all available
+options with documentation.
 
 ## Custom Themes
 
@@ -325,9 +333,10 @@ summary includes count, retained sample count, total, average, p50, p95, and max
 microseconds for metrics such as key handling, syntax updates, full renders, and
 terminal-only renders.
 
-Run `:checkhealth` (or `:Health`) inside Nevi to see config paths, LSP settings,
-profiling status, and any profile summary from `/tmp/nevi_profile.log`. Profile
-summaries are written when a profiled Nevi session exits.
+Run `:checkhealth` (or `:Health`) inside Nevi to see config paths, config
+discoverability commands, LSP settings, profiling status, and any profile
+summary from `/tmp/nevi_profile.log`. Profile summaries are written when a
+profiled Nevi session exits.
 
 ## License
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -142,6 +142,10 @@ pub enum Command {
     Keymaps,
     /// :checkhealth - Open the editor health report
     CheckHealth,
+    /// :ConfigOpen - Open the user config file
+    ConfigOpen,
+    /// :ConfigDefaults - Open the latest default config template
+    ConfigDefaults,
     /// :marks - Show all marks
     Marks,
     /// :delmarks {marks} - Delete specified marks
@@ -597,6 +601,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "ConfigOpen",
+        aliases: &["configopen", "config", "ConfigEdit", "configedit"],
+        description: "Open user config file",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "ConfigDefaults",
+        aliases: &["configdefaults", "defaults"],
+        description: "Open latest default config template",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "marks",
         aliases: &[],
         description: "Show all marks",
@@ -1016,6 +1032,8 @@ pub fn parse_command(input: &str) -> Command {
         "Themes" | "themes" => Command::Themes,
         "Keymaps" | "keymaps" | "keys" => Command::Keymaps,
         "checkhealth" | "CheckHealth" | "Health" | "health" => Command::CheckHealth,
+        "ConfigOpen" | "configopen" | "config" | "ConfigEdit" | "configedit" => Command::ConfigOpen,
+        "ConfigDefaults" | "configdefaults" | "defaults" => Command::ConfigDefaults,
 
         // Marks commands
         "marks" => Command::Marks,
@@ -1763,6 +1781,43 @@ mod tests {
         assert!(
             rows.iter().any(|(name, _)| name == ":checkhealth"),
             "expected :checkhealth in command cheatsheet rows"
+        );
+    }
+
+    #[test]
+    fn config_commands_are_parseable_and_suggested() {
+        assert!(matches!(parse_command("ConfigOpen"), Command::ConfigOpen));
+        assert!(matches!(parse_command("configopen"), Command::ConfigOpen));
+        assert!(matches!(parse_command("config"), Command::ConfigOpen));
+        assert!(matches!(
+            parse_command("ConfigDefaults"),
+            Command::ConfigDefaults
+        ));
+        assert!(matches!(
+            parse_command("configdefaults"),
+            Command::ConfigDefaults
+        ));
+
+        let suggestions = command_suggestions("config", 8);
+        assert!(
+            suggestions.iter().any(|item| item.command == "ConfigOpen"),
+            "expected ConfigOpen to match config query"
+        );
+        assert!(
+            suggestions
+                .iter()
+                .any(|item| item.command == "ConfigDefaults"),
+            "expected ConfigDefaults to match config query"
+        );
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":ConfigOpen"),
+            "expected :ConfigOpen in command cheatsheet rows"
+        );
+        assert!(
+            rows.iter().any(|(name, _)| name == ":ConfigDefaults"),
+            "expected :ConfigDefaults in command cheatsheet rows"
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1403,23 +1403,37 @@ fn default_config_template() -> &'static str {
 "##
 }
 
-/// Ensure config directory and template file exist
-fn ensure_config_exists() {
+/// Latest generated config template text.
+pub fn default_config_template_text() -> &'static str {
+    default_config_template()
+}
+
+/// Ensure config directory and template file exist, returning the config path.
+pub fn ensure_config_file_exists() -> Result<PathBuf, String> {
     let Some(path) = config_path() else {
-        return;
+        return Err("Could not determine config path".to_string());
     };
 
     // Create config directory if it doesn't exist
     if let Some(parent) = path.parent() {
         if !parent.exists() {
-            let _ = std::fs::create_dir_all(parent);
+            std::fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create config directory: {}", e))?;
         }
     }
 
     // Create template config if it doesn't exist
     if !path.exists() {
-        let _ = std::fs::write(&path, default_config_template());
+        std::fs::write(&path, default_config_template())
+            .map_err(|e| format!("Failed to create config file: {}", e))?;
     }
+
+    Ok(path)
+}
+
+/// Ensure config directory and template file exist.
+fn ensure_config_exists() {
+    let _ = ensure_config_file_exists();
 }
 
 /// Load settings from the config file

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1647,6 +1647,29 @@ impl Editor {
         ));
     }
 
+    /// Open the user's config file, creating the default template first if needed.
+    pub fn open_user_config_file(&mut self) -> Result<std::path::PathBuf, String> {
+        let path = crate::config::ensure_config_file_exists()?;
+        self.open_file(path.clone())
+            .map_err(|e| format!("Failed to open config: {}", e))?;
+        Ok(path)
+    }
+
+    /// Open the latest generated default config template in the read-only preview overlay.
+    pub fn open_config_defaults_preview(&mut self) {
+        let source = format!(
+            "```toml\n{}\n```",
+            crate::config::default_config_template_text()
+        );
+        let rendered = crate::markdown_preview::render_markdown(&source);
+        let width = crate::markdown_preview::preview_content_width(self.term_width);
+        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::with_title(
+            rendered,
+            width,
+            "Config Defaults",
+        ));
+    }
+
     /// Close the floating Markdown preview.
     pub fn close_markdown_preview(&mut self) {
         self.markdown_preview = None;

--- a/src/health.rs
+++ b/src/health.rs
@@ -125,10 +125,12 @@ pub fn build_health_report(input: &HealthReportInput) -> String {
         path_label(input.config_path.as_ref())
     ));
     report.push_str(&format!(
-        "- Languages file: {} ({})\n\n",
+        "- Languages file: {} ({})\n",
         file_status_label(&input.languages_status),
         path_label(input.languages_path.as_ref())
     ));
+    report.push_str("- Open user config: `:ConfigOpen`\n");
+    report.push_str("- View latest default config: `:ConfigDefaults`\n\n");
 
     report.push_str("## Performance\n");
     report.push_str(&format!(
@@ -383,6 +385,8 @@ mod tests {
         assert!(report.contains("# Nevi Health"));
         assert!(report.contains("/home/me/.config/nevi/config.toml"));
         assert!(report.contains("Configuration file: ok"));
+        assert!(report.contains(":ConfigOpen"));
+        assert!(report.contains(":ConfigDefaults"));
         assert!(report.contains("Languages file: missing"));
         assert!(report.contains("Profiling: disabled"));
         assert!(report.contains("/tmp/nevi_profile.log"));

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9583,6 +9583,14 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_health_report();
             CommandResult::Ok
         }
+        Command::ConfigOpen => match editor.open_user_config_file() {
+            Ok(path) => CommandResult::Message(format!("Opened config: {}", path.display())),
+            Err(message) => CommandResult::Error(message),
+        },
+        Command::ConfigDefaults => {
+            editor.open_config_defaults_preview();
+            CommandResult::Ok
+        }
 
         Command::Marks => {
             editor.open_finder_marks();
@@ -10510,6 +10518,31 @@ mod tests {
         assert!(text.contains("Configuration"));
         assert!(text.contains("Performance"));
         assert!(text.contains("LSP"));
+    }
+
+    #[test]
+    fn configdefaults_command_opens_default_config_preview() {
+        let mut editor = Editor::default();
+
+        execute_command(
+            &mut editor,
+            crate::commands::parse_command("ConfigDefaults"),
+        );
+
+        let preview = editor
+            .markdown_preview
+            .as_ref()
+            .expect("config defaults preview");
+        assert_eq!(preview.title, "Config Defaults");
+        let text = preview
+            .lines
+            .iter()
+            .map(|line| line.plain_text())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(text.contains("# Nevi Configuration"));
+        assert!(text.contains("show_leader_popup"));
+        assert!(text.contains("explorer"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add :ConfigOpen/:config for opening the user config file, creating it first if needed.
- Add :ConfigDefaults for viewing the latest built-in config template in a read-only preview.
- Surface both commands in command completion, :Keymaps, :checkhealth, README, and KEYBINDINGS.

## Test Plan
- [x] cargo test --quiet
- [x] Manual test: :ConfigDefaults opens the Config Defaults preview
- [x] Manual test: :ConfigOpen/:config opens ~/.config/nevi/config.toml
- [x] Manual test: :checkhealth and :Keymaps show the new config commands