### PR TITLE
feat: add command-line literal key insertion

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -827,6 +827,7 @@ While typing an Ex command after `:`.
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+u` | Delete from cursor to beginning of command line |
 | `Ctrl+r {reg}` | Insert register contents |
+| `Ctrl+v` / `Ctrl+q` | Insert the next key literally |
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete longest common command prefix |
 | `Ctrl+a` | Insert all matching command completions |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 297 keybinds implemented, 70 planned Vim/Neovim parity defaults.**
+**Status: 299 keybinds implemented, 66 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,10 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+n` | Select the next command-line history/completion entry with Vim-compatible semantics |
-| `Ctrl+p` | Select the previous command-line history/completion entry with Vim-compatible semantics |
-| `Ctrl+v` | Insert the next character literally |
-| `Ctrl+q` | Insert the next character literally |
 | `Ctrl+k` | Enter a digraph |
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1170,6 +1170,8 @@ pub struct CommandLine {
     pub history_popup_index: usize,
     /// Waiting for a register name after command-line Ctrl+r
     pub pending_register: bool,
+    /// Waiting to insert the next key literally after command-line Ctrl+v/Ctrl+q
+    pub pending_literal: bool,
 }
 
 impl CommandLine {
@@ -1205,6 +1207,7 @@ impl CommandLine {
         self.history_popup_items.clear();
         self.history_popup_index = 0;
         self.pending_register = false;
+        self.pending_literal = false;
     }
 
     /// Convert char index to byte index
@@ -1619,7 +1622,17 @@ impl CommandLine {
 
     /// Get display string (with ':' prefix)
     pub fn display(&self) -> String {
-        format!(":{}", self.input)
+        format!(":{}", display_command_text(&self.input))
+    }
+
+    /// Get the display cursor column for the command-line row.
+    pub fn display_cursor_col(&self) -> usize {
+        let prefix = self
+            .input
+            .chars()
+            .take(self.cursor.min(self.char_count()))
+            .collect::<String>();
+        1 + display_command_text(&prefix).chars().count()
     }
 
     fn on_input_edited(&mut self) {
@@ -1724,6 +1737,22 @@ impl CommandLine {
         let mut contents = self.history.join("\n");
         contents.push('\n');
         let _ = fs::write(path, contents);
+    }
+}
+
+fn display_command_text(input: &str) -> String {
+    input.chars().map(display_command_char).collect()
+}
+
+fn display_command_char(ch: char) -> String {
+    let code = ch as u32;
+    if code == 0x7f {
+        "^?".to_string()
+    } else if code <= 0x1f {
+        let visible = char::from_u32(code + 0x40).unwrap_or('?');
+        format!("^{visible}")
+    } else {
+        ch.to_string()
     }
 }
 

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -42,6 +42,8 @@ pub enum CommandModeAction {
     HistoryToggle,
     /// Insert the next typed register into the command line
     InsertRegister,
+    /// Insert the next typed key literally into the command line
+    InsertLiteral,
     /// Show available command-line completions
     ListCompletions,
     /// Complete the longest common command-line completion prefix
@@ -567,6 +569,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
     match action.trim().to_lowercase().as_str() {
         "history_toggle" => Some(CommandModeAction::HistoryToggle),
         "insert_register" => Some(CommandModeAction::InsertRegister),
+        "insert_literal" => Some(CommandModeAction::InsertLiteral),
         "list_completions" => Some(CommandModeAction::ListCompletions),
         "complete_longest_common_prefix" => Some(CommandModeAction::CompleteLongestCommonPrefix),
         "insert_all_completions" => Some(CommandModeAction::InsertAllCompletions),
@@ -749,6 +752,26 @@ mod tests {
         let key = parse_key_notation("<C-r>").unwrap();
         assert_eq!(key.code, KeyCode::Char('r'));
         assert_eq!(key.modifiers, KeyModifiers::CONTROL);
+    }
+
+    #[test]
+    fn default_command_mappings_include_literal_next_char() {
+        use super::super::KeymapSettings;
+
+        let (lookup, errors) = KeymapLookup::from_settings(&KeymapSettings::default());
+        assert!(errors.is_empty(), "default keymap should parse cleanly");
+
+        let ctrl_v = KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL);
+        let ctrl_q = KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL);
+
+        assert_eq!(
+            lookup.get_command_action(ctrl_v),
+            Some(CommandModeAction::InsertLiteral)
+        );
+        assert_eq!(
+            lookup.get_command_action(ctrl_q),
+            Some(CommandModeAction::InsertLiteral)
+        );
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -264,6 +264,16 @@ impl Default for KeymapSettings {
                     desc: Some("Insert register contents".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-v>".to_string(),
+                    action: "insert_literal".to_string(),
+                    desc: Some("Insert next key literally".to_string()),
+                },
+                CommandModeMapping {
+                    key: "<C-q>".to_string(),
+                    action: "insert_literal".to_string(),
+                    desc: Some("Insert next key literally".to_string()),
+                },
+                CommandModeMapping {
                     key: "<A-r>".to_string(),
                     action: "history_toggle".to_string(),
                     desc: Some("Toggle command history window".to_string()),
@@ -506,7 +516,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, open_command_line_window, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, insert_literal, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, open_command_line_window, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1274,6 +1284,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+w           - Delete word before cursor
 # Ctrl+u           - Delete from cursor to beginning of command line
 # Ctrl+r {reg}     - Insert register contents
+# Ctrl+v / Ctrl+q  - Insert next key literally
 # Ctrl+d           - List command-line completions
 # Ctrl+l           - Complete longest common command prefix
 # Ctrl+a           - Insert all matching command completions
@@ -1322,6 +1333,11 @@ fn default_config_template() -> &'static str {
 # key = "<A-r>"
 # action = "history_toggle"
 # desc = "Open command history with Alt+r"
+#
+# [[keymap.command_mappings]]
+# key = "<C-v>"
+# action = "insert_literal"
+# desc = "Insert next key literally"
 #
 # [[keymap.command_mappings]]
 # key = "<C-j>"

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2311,7 +2311,7 @@ impl Terminal {
         match editor.mode {
             Mode::Command => {
                 // Cursor in command line
-                let cmd_cursor_col = 1 + editor.command_line.cursor; // +1 for ':'
+                let cmd_cursor_col = editor.command_line.display_cursor_col();
                 execute!(
                     self.stdout,
                     cursor::MoveTo(cmd_cursor_col as u16, editor.term_height - 1),
@@ -7627,6 +7627,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::InsertRegister => {
             editor.command_line.pending_register = true;
         }
+        CommandModeAction::InsertLiteral => {
+            editor.command_line.pending_literal = true;
+        }
         CommandModeAction::ListCompletions => {
             editor.command_line.list_completions();
         }
@@ -7664,6 +7667,14 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
 }
 
 fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
+    if editor.command_line.pending_literal {
+        editor.command_line.pending_literal = false;
+        if let Some(ch) = command_literal_char(key) {
+            editor.command_line.insert_char(ch);
+        }
+        return;
+    }
+
     if editor.command_line.pending_register {
         editor.command_line.pending_register = false;
         match (key.modifiers, key.code) {
@@ -7767,6 +7778,45 @@ fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
 
         _ => {}
     }
+}
+
+fn command_literal_char(key: KeyEvent) -> Option<char> {
+    match key.code {
+        KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
+            control_literal_char(c).or(Some(c))
+        }
+        KeyCode::Char(c) => Some(c),
+        KeyCode::Enter => Some('\r'),
+        KeyCode::Tab => Some('\t'),
+        KeyCode::BackTab => Some('\t'),
+        KeyCode::Backspace => Some('\u{8}'),
+        KeyCode::Esc => Some('\u{1b}'),
+        KeyCode::Delete => Some('\u{7f}'),
+        _ => None,
+    }
+}
+
+fn control_literal_char(ch: char) -> Option<char> {
+    let byte = if ch.is_ascii_alphabetic() {
+        ch.to_ascii_uppercase() as u8
+    } else if ch.is_ascii() {
+        ch as u8
+    } else {
+        return None;
+    };
+
+    let code = match byte {
+        b' ' | b'@' => 0x00,
+        b'A'..=b'Z' => byte - b'@',
+        b'[' => 0x1b,
+        b'\\' => 0x1c,
+        b']' => 0x1d,
+        b'^' => 0x1e,
+        b'_' => 0x1f,
+        b'?' => 0x7f,
+        _ => return None,
+    };
+    char::from_u32(code as u32)
 }
 
 fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
@@ -10006,6 +10056,40 @@ mod tests {
         handle_key(&mut editor, alt_key('r'));
 
         assert_ne!(editor.command_line.popup_mode, CommandPopupMode::History);
+    }
+
+    #[test]
+    fn command_ctrl_v_inserts_next_control_key_literally() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write keep");
+
+        handle_key(&mut editor, ctrl_key('v'));
+        handle_key(&mut editor, ctrl_key('u'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write keep\u{15}");
+        assert_eq!(editor.command_line.display(), ":write keep^U");
+        assert_eq!(
+            editor.command_line.cursor,
+            "write keep\u{15}".chars().count()
+        );
+    }
+
+    #[test]
+    fn command_ctrl_q_inserts_next_control_key_literally() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("write keep");
+
+        handle_key(&mut editor, ctrl_key('q'));
+        handle_key(&mut editor, ctrl_key('w'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "write keep\u{17}");
+        assert_eq!(editor.command_line.display(), ":write keep^W");
+        assert_eq!(
+            editor.command_line.cursor,
+            "write keep\u{17}".chars().count()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim-style command-line Ctrl+v/Ctrl+q literal next-key insertion.
- Add configurable command-mode insert_literal action with default <C-v> and <C-q> mappings.
- Update keybinding docs, default config template, and roadmap counts/planned list.

## Test Plan
- [x] cargo test --quiet
- [x] git diff --check
- [x] Manual test: :write keep then Ctrl+v Ctrl+u inserts ^U instead of clearing the line
- [x] Manual test: :write keep then Ctrl+q Ctrl+w inserts ^W instead of deleting the word