### PR TITLE
feat: add command-line digraph insertion

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -828,6 +828,7 @@ While typing an Ex command after `:`.
 | `Ctrl+u` | Delete from cursor to beginning of command line |
 | `Ctrl+r {reg}` | Insert register contents |
 | `Ctrl+v` / `Ctrl+q` | Insert the next key literally |
+| `Ctrl+k {char1}{char2}` | Insert a Vim-compatible digraph, for example `a:` -> `ä` |
 | `Ctrl+d` | List command-line completions |
 | `Ctrl+l` | Complete longest common command prefix |
 | `Ctrl+a` | Insert all matching command completions |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 299 keybinds implemented, 66 planned Vim/Neovim parity defaults.**
+**Status: 300 keybinds implemented, 65 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -28,7 +28,6 @@ These apply while editing the command prompt after `:`.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+k` | Enter a digraph |
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |
 | `q?` | Open `?` search history in the command-line window |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1172,6 +1172,16 @@ pub struct CommandLine {
     pub pending_register: bool,
     /// Waiting to insert the next key literally after command-line Ctrl+v/Ctrl+q
     pub pending_literal: bool,
+    /// Waiting for one or two digraph characters after command-line Ctrl+k
+    pub pending_digraph: PendingDigraph,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum PendingDigraph {
+    #[default]
+    None,
+    First,
+    Second(char),
 }
 
 impl CommandLine {
@@ -1208,6 +1218,7 @@ impl CommandLine {
         self.history_popup_index = 0;
         self.pending_register = false;
         self.pending_literal = false;
+        self.pending_digraph = PendingDigraph::None;
     }
 
     /// Convert char index to byte index

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -44,6 +44,8 @@ pub enum CommandModeAction {
     InsertRegister,
     /// Insert the next typed key literally into the command line
     InsertLiteral,
+    /// Insert a digraph into the command line
+    InsertDigraph,
     /// Show available command-line completions
     ListCompletions,
     /// Complete the longest common command-line completion prefix
@@ -570,6 +572,7 @@ fn parse_command_mode_action(action: &str) -> Option<CommandModeAction> {
         "history_toggle" => Some(CommandModeAction::HistoryToggle),
         "insert_register" => Some(CommandModeAction::InsertRegister),
         "insert_literal" => Some(CommandModeAction::InsertLiteral),
+        "insert_digraph" => Some(CommandModeAction::InsertDigraph),
         "list_completions" => Some(CommandModeAction::ListCompletions),
         "complete_longest_common_prefix" => Some(CommandModeAction::CompleteLongestCommonPrefix),
         "insert_all_completions" => Some(CommandModeAction::InsertAllCompletions),
@@ -771,6 +774,21 @@ mod tests {
         assert_eq!(
             lookup.get_command_action(ctrl_q),
             Some(CommandModeAction::InsertLiteral)
+        );
+    }
+
+    #[test]
+    fn default_command_mappings_include_digraph_entry() {
+        use super::super::KeymapSettings;
+
+        let (lookup, errors) = KeymapLookup::from_settings(&KeymapSettings::default());
+        assert!(errors.is_empty(), "default keymap should parse cleanly");
+
+        let ctrl_k = KeyEvent::new(KeyCode::Char('k'), KeyModifiers::CONTROL);
+
+        assert_eq!(
+            lookup.get_command_action(ctrl_k),
+            Some(CommandModeAction::InsertDigraph)
         );
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -274,6 +274,11 @@ impl Default for KeymapSettings {
                     desc: Some("Insert next key literally".to_string()),
                 },
                 CommandModeMapping {
+                    key: "<C-k>".to_string(),
+                    action: "insert_digraph".to_string(),
+                    desc: Some("Insert digraph".to_string()),
+                },
+                CommandModeMapping {
                     key: "<A-r>".to_string(),
                     action: "history_toggle".to_string(),
                     desc: Some("Toggle command history window".to_string()),
@@ -516,7 +521,7 @@ pub struct LeaderMapping {
 pub struct CommandModeMapping {
     /// Key notation (e.g., "<C-r>", "<A-r>", "<Tab>", "<BackTab>")
     pub key: String,
-    /// Action name (insert_register, insert_literal, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, open_command_line_window, complete, complete_prev, popup_next, popup_prev)
+    /// Action name (insert_register, insert_literal, insert_digraph, history_toggle, list_completions, complete_longest_common_prefix, insert_all_completions, open_command_line_window, complete, complete_prev, popup_next, popup_prev)
     pub action: String,
     /// Optional description for docs/which-key style UIs
     #[serde(default)]
@@ -1285,6 +1290,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+u           - Delete from cursor to beginning of command line
 # Ctrl+r {reg}     - Insert register contents
 # Ctrl+v / Ctrl+q  - Insert next key literally
+# Ctrl+k {c1}{c2}  - Insert Vim-compatible digraph (example: a: -> ä)
 # Ctrl+d           - List command-line completions
 # Ctrl+l           - Complete longest common command prefix
 # Ctrl+a           - Insert all matching command completions
@@ -1338,6 +1344,11 @@ fn default_config_template() -> &'static str {
 # key = "<C-v>"
 # action = "insert_literal"
 # desc = "Insert next key literally"
+#
+# [[keymap.command_mappings]]
+# key = "<C-k>"
+# action = "insert_digraph"
+# desc = "Insert digraph"
 #
 # [[keymap.command_mappings]]
 # key = "<C-j>"

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -55,7 +55,7 @@ fn finder_preview_match_ranges(line: &str, query: &str) -> Vec<(usize, usize)> {
     ranges
 }
 
-use crate::commands::{parse_command, Command, CommandPopupMode, CommandResult};
+use crate::commands::{parse_command, Command, CommandPopupMode, CommandResult, PendingDigraph};
 use crate::config::{CommandModeAction, LeaderAction};
 use crate::editor::{
     Editor, ExpressionRegisterTarget, LspAction, Mode, Pane, PaneDirection, SplitLayout,
@@ -7630,6 +7630,9 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
         CommandModeAction::InsertLiteral => {
             editor.command_line.pending_literal = true;
         }
+        CommandModeAction::InsertDigraph => {
+            editor.command_line.pending_digraph = PendingDigraph::First;
+        }
         CommandModeAction::ListCompletions => {
             editor.command_line.list_completions();
         }
@@ -7667,6 +7670,11 @@ fn execute_command_mode_action(editor: &mut Editor, action: CommandModeAction) {
 }
 
 fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
+    if editor.command_line.pending_digraph != PendingDigraph::None {
+        handle_command_digraph_key(editor, key);
+        return;
+    }
+
     if editor.command_line.pending_literal {
         editor.command_line.pending_literal = false;
         if let Some(ch) = command_literal_char(key) {
@@ -7780,6 +7788,39 @@ fn handle_command_mode(editor: &mut Editor, key: KeyEvent) {
     }
 }
 
+fn handle_command_digraph_key(editor: &mut Editor, key: KeyEvent) {
+    match editor.command_line.pending_digraph {
+        PendingDigraph::None => {}
+        PendingDigraph::First => {
+            if let Some(first) = command_digraph_char(key) {
+                editor.command_line.pending_digraph = PendingDigraph::Second(first);
+            } else {
+                editor.command_line.pending_digraph = PendingDigraph::None;
+            }
+        }
+        PendingDigraph::Second(first) => {
+            editor.command_line.pending_digraph = PendingDigraph::None;
+            let Some(second) = command_digraph_char(key) else {
+                return;
+            };
+            if let Some(ch) = vim_latin1_digraph(first, second) {
+                editor.command_line.insert_char(ch);
+            } else {
+                editor.set_status(format!("Unknown digraph: {first}{second}"));
+            }
+        }
+    }
+}
+
+fn command_digraph_char(key: KeyEvent) -> Option<char> {
+    match (key.modifiers, key.code) {
+        (KeyModifiers::NONE, KeyCode::Char(ch))
+        | (KeyModifiers::SHIFT, KeyCode::Char(ch))
+        | (KeyModifiers::ALT, KeyCode::Char(ch)) => Some(ch),
+        _ => None,
+    }
+}
+
 fn command_literal_char(key: KeyEvent) -> Option<char> {
     match key.code {
         KeyCode::Char(c) if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -7817,6 +7858,85 @@ fn control_literal_char(ch: char) -> Option<char> {
         _ => return None,
     };
     char::from_u32(code as u32)
+}
+
+fn vim_latin1_digraph(first: char, second: char) -> Option<char> {
+    match (first, second) {
+        ('A', '!') => Some('À'),
+        ('A', '\'') => Some('Á'),
+        ('A', '>') => Some('Â'),
+        ('A', '?') => Some('Ã'),
+        ('A', ':') => Some('Ä'),
+        ('A', 'A') => Some('Å'),
+        ('A', 'E') => Some('Æ'),
+        ('C', ',') => Some('Ç'),
+        ('E', '!') => Some('È'),
+        ('E', '\'') => Some('É'),
+        ('E', '>') => Some('Ê'),
+        ('E', ':') => Some('Ë'),
+        ('I', '!') => Some('Ì'),
+        ('I', '\'') => Some('Í'),
+        ('I', '>') => Some('Î'),
+        ('I', ':') => Some('Ï'),
+        ('N', '?') => Some('Ñ'),
+        ('O', '!') => Some('Ò'),
+        ('O', '\'') => Some('Ó'),
+        ('O', '>') => Some('Ô'),
+        ('O', '?') => Some('Õ'),
+        ('O', ':') => Some('Ö'),
+        ('O', '/') => Some('Ø'),
+        ('U', '!') => Some('Ù'),
+        ('U', '\'') => Some('Ú'),
+        ('U', '>') => Some('Û'),
+        ('U', ':') => Some('Ü'),
+        ('Y', '\'') => Some('Ý'),
+        ('T', 'H') => Some('Þ'),
+        ('s', 's') => Some('ß'),
+        ('a', '!') => Some('à'),
+        ('a', '\'') => Some('á'),
+        ('a', '>') => Some('â'),
+        ('a', '?') => Some('ã'),
+        ('a', ':') => Some('ä'),
+        ('a', 'a') => Some('å'),
+        ('a', 'e') => Some('æ'),
+        ('c', ',') => Some('ç'),
+        ('e', '!') => Some('è'),
+        ('e', '\'') => Some('é'),
+        ('e', '>') => Some('ê'),
+        ('e', ':') => Some('ë'),
+        ('i', '!') => Some('ì'),
+        ('i', '\'') => Some('í'),
+        ('i', '>') => Some('î'),
+        ('i', ':') => Some('ï'),
+        ('n', '?') => Some('ñ'),
+        ('o', '!') => Some('ò'),
+        ('o', '\'') => Some('ó'),
+        ('o', '>') => Some('ô'),
+        ('o', '?') => Some('õ'),
+        ('o', ':') => Some('ö'),
+        ('o', '/') => Some('ø'),
+        ('u', '!') => Some('ù'),
+        ('u', '\'') => Some('ú'),
+        ('u', '>') => Some('û'),
+        ('u', ':') => Some('ü'),
+        ('y', '\'') => Some('ý'),
+        ('t', 'h') => Some('þ'),
+        ('y', ':') => Some('ÿ'),
+        ('<', '<') => Some('«'),
+        ('>', '>') => Some('»'),
+        ('!', 'I') => Some('¡'),
+        ('?', 'I') => Some('¿'),
+        ('C', 'o') => Some('©'),
+        ('R', 'g') => Some('®'),
+        ('+', '-') => Some('±'),
+        ('D', 'G') => Some('°'),
+        ('*', 'X') => Some('×'),
+        ('-', ':') => Some('÷'),
+        ('1', '2') => Some('½'),
+        ('1', '4') => Some('¼'),
+        ('3', '4') => Some('¾'),
+        _ => None,
+    }
 }
 
 fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
@@ -10090,6 +10210,34 @@ mod tests {
             editor.command_line.cursor,
             "write keep\u{17}".chars().count()
         );
+    }
+
+    #[test]
+    fn command_ctrl_k_inserts_vim_digraph() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("echo ");
+
+        handle_key(&mut editor, ctrl_key('k'));
+        handle_key(&mut editor, key('a'));
+        handle_key(&mut editor, key(':'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "echo ä");
+        assert_eq!(editor.command_line.cursor, "echo ä".chars().count());
+    }
+
+    #[test]
+    fn command_ctrl_k_inserts_second_vim_digraph() {
+        let mut editor = Editor::default();
+        editor.enter_command_mode_with_input("echo ");
+
+        handle_key(&mut editor, ctrl_key('k'));
+        handle_key(&mut editor, key('n'));
+        handle_key(&mut editor, key('?'));
+
+        assert_eq!(editor.mode, Mode::Command);
+        assert_eq!(editor.command_line.input, "echo ñ");
+        assert_eq!(editor.command_line.cursor, "echo ñ".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim-style command-line Ctrl+k digraph insertion.
- Add configurable command-mode insert_digraph action with default Ctrl+k mapping.
- Add common Vim-compatible Latin-1 digraph mappings and update docs/roadmap.

## Test Plan
- [x] cargo test --quiet
- [x] git diff --check
- [x] Manual test: :echo<Space> then Ctrl+k a : inserts ä
- [x] Manual test: :echo<Space> then Ctrl+k n ? inserts ñ