### PR TITLE
feat: add search prompt editing defaults

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -378,6 +378,9 @@ While typing a `/` or `?` search prompt.
 |-----|--------|
 | `Ctrl+b` | Move to beginning of search input |
 | `Ctrl+e` | Move to end of search input |
+| `Ctrl+w` | Delete word before cursor |
+| `Ctrl+u` | Delete from cursor to beginning of search input |
+| `Ctrl+r {reg}` | Insert register contents |
 | `Up` | Navigate to previous search history entry |
 | `Down` | Navigate to next search history entry |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 300 keybinds implemented, 65 planned Vim/Neovim parity defaults.**
+**Status: 303 keybinds implemented, 62 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -31,16 +31,6 @@ These apply while editing the command prompt after `:`.
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |
 | `q?` | Open `?` search history in the command-line window |
-
-### Search Prompt Defaults
-
-These apply while editing `/` and `?` search prompts.
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `Ctrl+w` | Delete the word before the cursor |
-| `Ctrl+u` | Delete from cursor back to the start of the search input |
-| `Ctrl+r {reg}` | Insert register contents into the search prompt |
 
 ### Window Management Extras
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1303,6 +1303,9 @@ fn default_config_template() -> &'static str {
 # Search prompt mode (while typing `/` or `?`):
 # Ctrl+b           - Move to beginning of search input
 # Ctrl+e           - Move to end of search input
+# Ctrl+w           - Delete word before cursor
+# Ctrl+u           - Delete from cursor to beginning of search input
+# Ctrl+r {reg}     - Insert register contents
 # Up/Down          - Navigate search history
 #
 # ============================================================================

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -279,6 +279,8 @@ pub struct SearchState {
     pub history_index: Option<usize>,
     /// In-progress search input saved before history navigation begins.
     pub saved_input: Option<String>,
+    /// Waiting for a register name after search prompt Ctrl+r
+    pub pending_register: bool,
 }
 
 impl SearchState {
@@ -288,6 +290,7 @@ impl SearchState {
         self.cursor = 0;
         self.history_index = None;
         self.saved_input = None;
+        self.pending_register = false;
     }
 
     /// Start a new search
@@ -297,6 +300,7 @@ impl SearchState {
         self.direction = direction;
         self.history_index = None;
         self.saved_input = None;
+        self.pending_register = false;
     }
 
     /// Insert a character at cursor (cursor is character index, not byte index)
@@ -305,6 +309,18 @@ impl SearchState {
         let byte_idx = self.char_to_byte_index(self.cursor);
         self.input.insert(byte_idx, ch);
         self.cursor += 1;
+        self.on_input_edited();
+    }
+
+    /// Insert text at the search prompt cursor.
+    pub fn insert_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+
+        let byte_idx = self.char_to_byte_index(self.cursor);
+        self.input.insert_str(byte_idx, text);
+        self.cursor += text.chars().count();
         self.on_input_edited();
     }
 
@@ -317,6 +333,60 @@ impl SearchState {
             self.input.remove(byte_idx);
             self.on_input_edited();
         }
+    }
+
+    /// Delete the word before the cursor, matching Vim search prompt Ctrl+w.
+    pub fn delete_word_before(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let chars: Vec<char> = self.input.chars().collect();
+        let start_cursor = self.cursor.min(chars.len());
+        let mut cursor = start_cursor;
+
+        while cursor > 0 && chars[cursor - 1].is_whitespace() {
+            cursor -= 1;
+        }
+
+        if cursor > 0 {
+            let delete_word_chars = chars[cursor - 1].is_alphanumeric() || chars[cursor - 1] == '_';
+            if delete_word_chars {
+                while cursor > 0
+                    && (chars[cursor - 1].is_alphanumeric() || chars[cursor - 1] == '_')
+                {
+                    cursor -= 1;
+                }
+            } else {
+                while cursor > 0 {
+                    let ch = chars[cursor - 1];
+                    if ch.is_whitespace() || ch.is_alphanumeric() || ch == '_' {
+                        break;
+                    }
+                    cursor -= 1;
+                }
+            }
+        }
+
+        if cursor < start_cursor {
+            let start_byte = self.char_to_byte_index(cursor);
+            let end_byte = self.char_to_byte_index(start_cursor);
+            self.input.replace_range(start_byte..end_byte, "");
+            self.cursor = cursor;
+            self.on_input_edited();
+        }
+    }
+
+    /// Delete from the cursor back to the start of the search prompt.
+    pub fn delete_to_start(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+
+        let end_byte = self.char_to_byte_index(self.cursor);
+        self.input.replace_range(0..end_byte, "");
+        self.cursor = 0;
+        self.on_input_edited();
     }
 
     /// Move cursor left
@@ -3821,6 +3891,22 @@ impl Editor {
         }
 
         self.command_line.insert_text(&text);
+        true
+    }
+
+    /// Insert text from a register at the search prompt cursor.
+    pub fn insert_register_text_into_search_prompt(&mut self, register: char) -> bool {
+        let Some(content) = self.register_content_for_paste(Some(register)) else {
+            return false;
+        };
+        let text = match content {
+            RegisterContent::Chars(text) | RegisterContent::Lines(text) => text,
+        };
+        if text.is_empty() {
+            return false;
+        }
+
+        self.search.insert_text(&text);
         true
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7940,6 +7940,20 @@ fn vim_latin1_digraph(first: char, second: char) -> Option<char> {
 }
 
 fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
+    if editor.search.pending_register {
+        editor.search.pending_register = false;
+        match (key.modifiers, key.code) {
+            (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {}
+            (_, KeyCode::Char(register)) => {
+                if editor.insert_register_text_into_search_prompt(register) {
+                    editor.update_incremental_search();
+                }
+            }
+            _ => {}
+        }
+        return;
+    }
+
     match (key.modifiers, key.code) {
         // Cancel search
         (KeyModifiers::NONE, KeyCode::Esc)
@@ -7984,6 +7998,17 @@ fn handle_search_mode(editor: &mut Editor, key: KeyEvent) {
         (KeyModifiers::NONE, KeyCode::Down) => {
             editor.search.history_next();
             editor.update_incremental_search();
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('w')) => {
+            editor.search.delete_word_before();
+            editor.update_incremental_search();
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
+            editor.search.delete_to_start();
+            editor.update_incremental_search();
+        }
+        (KeyModifiers::CONTROL, KeyCode::Char('r')) => {
+            editor.search.pending_register = true;
         }
 
         // Regular character - accept any modifier for printable chars
@@ -10040,6 +10065,66 @@ mod tests {
         handle_key(&mut editor, down_key());
         assert_eq!(editor.search.input, "storedx");
         assert_eq!(editor.search.cursor, "storedx".chars().count());
+    }
+
+    #[test]
+    fn search_ctrl_w_deletes_word_before_search_prompt_cursor() {
+        let mut editor = Editor::default();
+        editor.enter_search_forward();
+        editor.search.input = "foo bar baz".to_string();
+        editor.search.cursor = "foo bar baz".chars().count();
+
+        handle_key(&mut editor, ctrl_key('w'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "foo bar ");
+        assert_eq!(editor.search.cursor, "foo bar ".chars().count());
+    }
+
+    #[test]
+    fn search_ctrl_w_skips_trailing_spaces_before_deleting_word() {
+        let mut editor = Editor::default();
+        editor.enter_search_forward();
+        editor.search.input = "foo bar   ".to_string();
+        editor.search.cursor = "foo bar   ".chars().count();
+
+        handle_key(&mut editor, ctrl_key('w'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "foo ");
+        assert_eq!(editor.search.cursor, "foo ".chars().count());
+    }
+
+    #[test]
+    fn search_ctrl_u_deletes_from_search_prompt_cursor_to_start() {
+        let mut editor = Editor::default();
+        editor.enter_search_forward();
+        editor.search.input = "foo bar baz".to_string();
+        editor.search.cursor = "foo bar ".chars().count();
+
+        handle_key(&mut editor, ctrl_key('u'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "baz");
+        assert_eq!(editor.search.cursor, 0);
+    }
+
+    #[test]
+    fn search_ctrl_r_inserts_named_register_text_at_search_cursor() {
+        let mut editor = Editor::default();
+        editor
+            .registers
+            .yank(Some('a'), RegisterContent::Chars("needle".to_string()));
+        editor.enter_search_backward();
+        editor.search.input = "foo bar".to_string();
+        editor.search.cursor = "foo ".chars().count();
+
+        handle_key(&mut editor, ctrl_key('r'));
+        handle_key(&mut editor, key('a'));
+
+        assert_eq!(editor.mode, Mode::Search);
+        assert_eq!(editor.search.input, "foo needlebar");
+        assert_eq!(editor.search.cursor, "foo needle".chars().count());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim-style search prompt Ctrl+w and Ctrl+u editing defaults.
- Add search prompt Ctrl+r register insertion.
- Update keybinding docs, generated config comments, and the keybind roadmap status.

## Test Plan
- [x] cargo test --quiet
- [x] git diff --check
- [x] Manual test: / prompt Ctrl+w deletes the word before the cursor
- [x] Manual test: / prompt Ctrl+u deletes back to the start of the prompt
- [x] Manual test: / prompt Ctrl+r {reg} inserts register contents