### PR TITLE
feat: add visual block insert and append

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -480,6 +480,8 @@ Record and replay sequences of commands.
 | `p` | Paste over selection |
 | `o` | Swap to other end of selection |
 | `O` | Swap to other corner in visual block mode |
+| `I` | Insert before the visual block on each selected line |
+| `A` | Append after the visual block on each selected line |
 | `>` | Indent selection |
 | `<` | Dedent selection |
 | `gc` | Toggle comment on selection |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 303 keybinds implemented, 62 planned Vim/Neovim parity defaults.**
+**Status: 305 keybinds implemented, 62 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1198,6 +1198,7 @@ fn default_config_template() -> &'static str {
 # p                - Paste over selection
 # o                - Swap selection end
 # O                - Swap to other corner in visual block mode
+# I/A              - Insert/append across selected visual block lines
 # >/<              - Indent/dedent selection
 # gc               - Toggle comment
 # S{char}          - Surround selection

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -208,6 +208,15 @@ pub struct LastVisualSelection {
     pub cursor_col: usize,
 }
 
+/// Pending Visual Block insert/append replay state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VisualBlockEdit {
+    pub top: usize,
+    pub bottom: usize,
+    pub insert_col: usize,
+    pub primary_line: usize,
+}
+
 impl VisualSelection {
     pub fn new(line: usize, col: usize) -> Self {
         Self {
@@ -1024,6 +1033,8 @@ pub struct Editor {
     pub marks: Marks,
     /// Last visual selection for gv command
     pub last_visual_selection: Option<LastVisualSelection>,
+    /// Pending block insert/append started from Visual Block mode.
+    pub pending_visual_block_edit: Option<VisualBlockEdit>,
     /// Macro recording and playback state
     pub macros: MacroState,
     /// Last insert position for `gi` command (line, col)
@@ -1515,6 +1526,7 @@ impl Editor {
             markdown_preview: None,
             marks: Marks::new(),
             last_visual_selection: None,
+            pending_visual_block_edit: None,
             macros: MacroState::new(),
             last_insert_position: None,
             last_inserted_text: None,
@@ -4069,6 +4081,7 @@ impl Editor {
     /// Exit to normal mode
     pub fn enter_normal_mode(&mut self) {
         if self.mode == Mode::Insert {
+            self.replay_pending_visual_block_edit();
             self.finish_insert_session();
         }
 
@@ -4087,6 +4100,31 @@ impl Editor {
             self.cursor.col -= 1;
         }
         self.clamp_cursor();
+    }
+
+    fn replay_pending_visual_block_edit(&mut self) {
+        let Some(block_edit) = self.pending_visual_block_edit.take() else {
+            return;
+        };
+        let inserted_text = self.current_inserted_text.clone();
+        if inserted_text.is_empty() {
+            return;
+        }
+
+        for line_idx in (block_edit.top..=block_edit.bottom).rev() {
+            if line_idx == block_edit.primary_line {
+                continue;
+            }
+
+            let line_len = self.buffers[self.current_buffer_idx].line_len(line_idx);
+            let insert_col = block_edit.insert_col.min(line_len);
+            self.undo_stack.record_change(Change::insert(
+                line_idx,
+                insert_col,
+                inserted_text.clone(),
+            ));
+            self.buffers[self.current_buffer_idx].insert_str(line_idx, insert_col, &inserted_text);
+        }
     }
 
     /// Insert a character at cursor position
@@ -5927,6 +5965,51 @@ impl Editor {
     pub fn enter_visual_block_mode(&mut self) {
         self.mode = Mode::VisualBlock;
         self.visual = VisualSelection::new(self.cursor.line, self.cursor.col);
+    }
+
+    /// Enter insert mode for a Visual Block `I` or `A` edit.
+    pub fn enter_visual_block_insert_mode(&mut self, append: bool) {
+        if self.mode != Mode::VisualBlock {
+            return;
+        }
+
+        let (top, left, bottom, right) = self
+            .visual
+            .get_block_range(self.cursor.line, self.cursor.col);
+        let insert_col = if append {
+            right.saturating_add(1)
+        } else {
+            left
+        };
+        let primary_line = top.min(
+            self.buffers[self.current_buffer_idx]
+                .len_lines()
+                .saturating_sub(1),
+        );
+        let primary_col =
+            insert_col.min(self.buffers[self.current_buffer_idx].line_len(primary_line));
+
+        self.last_visual_selection = Some(LastVisualSelection {
+            mode: self.mode,
+            anchor_line: self.visual.anchor_line,
+            anchor_col: self.visual.anchor_col,
+            cursor_line: self.cursor.line,
+            cursor_col: self.cursor.col,
+        });
+        self.pending_visual_block_edit = Some(VisualBlockEdit {
+            top,
+            bottom,
+            insert_col,
+            primary_line,
+        });
+
+        self.mode = Mode::Insert;
+        self.begin_insert_session();
+        self.cursor.line = primary_line;
+        self.cursor.col = primary_col;
+        self.last_insert_position = Some((self.cursor.line, self.cursor.col));
+        self.begin_change();
+        self.scroll_to_cursor();
     }
 
     /// Exit visual mode

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1394,6 +1394,20 @@ desc = "Go to other corner (block mode)"
 status = "implemented"
 vim_default = true
 
+[[visual.editing]]
+key = "I"
+action = "visual_block_insert"
+desc = "Insert before each selected block line"
+status = "implemented"
+vim_default = true
+
+[[visual.editing]]
+key = "A"
+action = "visual_block_append"
+desc = "Append after each selected block line"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # LEADER MAPPINGS (ALL IMPLEMENTED)
 # ============================================================================

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8135,6 +8135,12 @@ fn handle_visual_mode(editor: &mut Editor, key: KeyEvent) {
             let register = editor.input_state.take_register();
             editor.visual_paste(register);
         }
+        (KeyModifiers::SHIFT, KeyCode::Char('I')) if editor.mode == Mode::VisualBlock => {
+            editor.enter_visual_block_insert_mode(false);
+        }
+        (KeyModifiers::SHIFT, KeyCode::Char('A')) if editor.mode == Mode::VisualBlock => {
+            editor.enter_visual_block_insert_mode(true);
+        }
         (KeyModifiers::SHIFT, KeyCode::Char('S')) => {
             editor.input_state.pending_visual_surround = true;
         }
@@ -12030,6 +12036,57 @@ mod tests {
         );
         assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
         assert_eq!(editor.get_visual_range(), (0, 0, 1, 2));
+    }
+
+    #[test]
+    fn visual_block_i_inserts_typed_text_on_each_selected_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha\nbravo\ncharlie\n");
+        editor.cursor.col = 1;
+
+        handle_key(&mut editor, ctrl_key('v'));
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, shift_key('I'));
+
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+
+        handle_key(&mut editor, key('X'));
+        handle_key(&mut editor, key('Y'));
+        handle_key(&mut editor, esc_key());
+
+        assert_eq!(editor.buffer().content(), "aXYlpha\nbXYravo\ncXYharlie\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+
+        handle_key(&mut editor, key('u'));
+
+        assert_eq!(editor.buffer().content(), "alpha\nbravo\ncharlie\n");
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+    }
+
+    #[test]
+    fn visual_block_a_appends_typed_text_after_each_selected_block() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha\nbravo\ncharlie\n");
+        editor.cursor.col = 1;
+
+        handle_key(&mut editor, ctrl_key('v'));
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('l'));
+        handle_key(&mut editor, shift_key('A'));
+
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 3));
+
+        handle_key(&mut editor, key('_'));
+        handle_key(&mut editor, esc_key());
+
+        assert_eq!(editor.buffer().content(), "alp_ha\nbra_vo\ncha_rlie\n");
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 3));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Visual Block `I` insert and `A` append behavior across selected lines.
- Keep the repeated block edit in one undo group.
- Document the bindings in KEYBINDINGS, :Keymaps metadata, generated config comments, and the roadmap count.

## Test Plan
- `cargo test visual_block --quiet`
- `cargo test --quiet`
- Manual: opened `/private/tmp/nevi_visual_block_editing.txt` and verified Visual Block `I`/`A` workflows
