### PR TITLE
feat: add window resize keybinds

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -641,6 +641,12 @@ Split and navigate between windows.
 | `Ctrl+w k` | Move to window above |
 | `Ctrl+w l` | Move to window on the right |
 | `Ctrl+w =` | Make all windows equal size |
+| `Ctrl+w +` | Increase current split height |
+| `Ctrl+w -` | Decrease current split height |
+| `Ctrl+w >` | Increase current split width |
+| `Ctrl+w <` | Decrease current split width |
+| `Ctrl+w _` | Maximize current split height |
+| `Ctrl+w \|` | Maximize current split width |
 | `Ctrl+w r` | Rotate windows down/right |
 | `Ctrl+w R` | Rotate windows up/left |
 | `Ctrl+w x` | Exchange current window with next |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 305 keybinds implemented, 62 planned Vim/Neovim parity defaults.**
+**Status: 311 keybinds implemented, 56 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -39,12 +39,6 @@ Vim window sizing and window-moving defaults.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+w _` | Maximize current split height |
-| `Ctrl+w \|` | Maximize current split width |
-| `Ctrl+w +` | Increase current split height |
-| `Ctrl+w -` | Decrease current split height |
-| `Ctrl+w >` | Increase current split width |
-| `Ctrl+w <` | Decrease current split width |
 | `Ctrl+w H` | Move current window to the far left |
 | `Ctrl+w J` | Move current window to the bottom |
 | `Ctrl+w K` | Move current window to the top |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1166,6 +1166,9 @@ fn default_config_template() -> &'static str {
 # Ctrl+w h/j/k/l   - Move to window left/down/up/right
 # Ctrl+h/j/k/l     - Move directly to window left/down/up/right
 # Ctrl+w =         - Make all windows equal size
+# Ctrl+w +/-       - Increase/decrease current split height
+# Ctrl+w >/<       - Increase/decrease current split width
+# Ctrl+w _/|       - Maximize current split height/width
 # Ctrl+w r/R       - Rotate windows down-right / up-left
 # Ctrl+w x         - Exchange current window with next
 #

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -158,6 +158,8 @@ pub struct Pane {
     pub h_offset: usize,
     /// Screen region for this pane
     pub rect: Rect,
+    /// Relative size in the active split axis.
+    pub size_weight: u16,
 }
 
 impl Pane {
@@ -168,9 +170,14 @@ impl Pane {
             viewport_offset: 0,
             h_offset: 0,
             rect: Rect::default(),
+            size_weight: 1,
         }
     }
 }
+
+const WINDOW_RESIZE_STEP: u16 = 5;
+const MIN_WINDOW_WIDTH: u16 = 10;
+const MIN_WINDOW_HEIGHT: u16 = 3;
 
 /// Split layout orientation for panes
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -2547,6 +2554,7 @@ impl Editor {
         // Create new pane
         let new_pane = Pane::new(new_buffer_idx);
         self.panes.push(new_pane);
+        self.reset_window_size_weights();
 
         // Update pane layout
         self.update_pane_rects();
@@ -2604,6 +2612,7 @@ impl Editor {
             if self.active_pane >= self.panes.len() {
                 self.active_pane = self.panes.len() - 1;
             }
+            self.reset_window_size_weights();
             self.update_pane_rects();
             self.load_pane_state();
             self.set_status(format!(
@@ -2624,6 +2633,7 @@ impl Editor {
             let current_pane = self.panes[self.active_pane].clone();
             self.panes = vec![current_pane];
             self.active_pane = 0;
+            self.reset_window_size_weights();
             self.update_pane_rects();
             self.set_status("Only pane remaining");
         }
@@ -2631,8 +2641,158 @@ impl Editor {
 
     /// Make all pane rectangles equal according to the current split layout.
     pub fn equalize_windows(&mut self) {
+        self.reset_window_size_weights();
         self.update_pane_rects();
         self.set_status("Windows equalized");
+    }
+
+    /// Increase current window height.
+    pub fn increase_window_height(&mut self) {
+        self.adjust_window_size(SplitLayout::Horizontal, true);
+    }
+
+    /// Decrease current window height.
+    pub fn decrease_window_height(&mut self) {
+        self.adjust_window_size(SplitLayout::Horizontal, false);
+    }
+
+    /// Increase current window width.
+    pub fn increase_window_width(&mut self) {
+        self.adjust_window_size(SplitLayout::Vertical, true);
+    }
+
+    /// Decrease current window width.
+    pub fn decrease_window_width(&mut self) {
+        self.adjust_window_size(SplitLayout::Vertical, false);
+    }
+
+    /// Maximize current window height.
+    pub fn maximize_window_height(&mut self) {
+        self.maximize_window_size(SplitLayout::Horizontal);
+    }
+
+    /// Maximize current window width.
+    pub fn maximize_window_width(&mut self) {
+        self.maximize_window_size(SplitLayout::Vertical);
+    }
+
+    fn adjust_window_size(&mut self, layout: SplitLayout, increase: bool) {
+        if self.panes.len() <= 1 {
+            self.set_status("Only one window");
+            return;
+        }
+        if self.split_layout != layout {
+            self.set_status(Self::split_axis_unavailable_status(layout));
+            return;
+        }
+
+        self.capture_current_window_size_weights();
+        let Some(neighbor) = self.window_resize_neighbor() else {
+            self.set_status("Only one window");
+            return;
+        };
+
+        let min_size = Self::minimum_window_axis_size(layout);
+        let active = self.active_pane;
+        let mut weights: Vec<u16> = self
+            .panes
+            .iter()
+            .map(|pane| pane.size_weight.max(1))
+            .collect();
+        let amount = if increase {
+            WINDOW_RESIZE_STEP.min(weights[neighbor].saturating_sub(min_size))
+        } else {
+            WINDOW_RESIZE_STEP.min(weights[active].saturating_sub(min_size))
+        };
+
+        if amount == 0 {
+            self.set_status("Window size unchanged");
+            return;
+        }
+
+        if increase {
+            weights[active] = weights[active].saturating_add(amount);
+            weights[neighbor] = weights[neighbor].saturating_sub(amount);
+        } else {
+            weights[active] = weights[active].saturating_sub(amount);
+            weights[neighbor] = weights[neighbor].saturating_add(amount);
+        }
+
+        self.apply_window_size_weights(&weights);
+        self.update_pane_rects();
+        self.set_status("Window resized");
+    }
+
+    fn maximize_window_size(&mut self, layout: SplitLayout) {
+        if self.panes.len() <= 1 {
+            self.set_status("Only one window");
+            return;
+        }
+        if self.split_layout != layout {
+            self.set_status(Self::split_axis_unavailable_status(layout));
+            return;
+        }
+
+        self.capture_current_window_size_weights();
+        let min_size = Self::minimum_window_axis_size(layout);
+        let total: u16 = self.panes.iter().map(|pane| pane.size_weight.max(1)).sum();
+        let other_count = self.panes.len().saturating_sub(1) as u16;
+        let min_total_for_others = min_size.saturating_mul(other_count);
+
+        if total <= min_total_for_others {
+            self.set_status("Window size unchanged");
+            return;
+        }
+
+        let mut weights = vec![min_size; self.panes.len()];
+        weights[self.active_pane] = total - min_total_for_others;
+        self.apply_window_size_weights(&weights);
+        self.update_pane_rects();
+        self.set_status("Window maximized");
+    }
+
+    fn window_resize_neighbor(&self) -> Option<usize> {
+        if self.active_pane + 1 < self.panes.len() {
+            Some(self.active_pane + 1)
+        } else {
+            self.active_pane.checked_sub(1)
+        }
+    }
+
+    fn reset_window_size_weights(&mut self) {
+        for pane in &mut self.panes {
+            pane.size_weight = 1;
+        }
+    }
+
+    fn capture_current_window_size_weights(&mut self) {
+        let layout = self.split_layout;
+        for pane in &mut self.panes {
+            pane.size_weight = match layout {
+                SplitLayout::Vertical => pane.rect.width.max(1),
+                SplitLayout::Horizontal => pane.rect.height.max(1),
+            };
+        }
+    }
+
+    fn apply_window_size_weights(&mut self, weights: &[u16]) {
+        for (pane, weight) in self.panes.iter_mut().zip(weights.iter().copied()) {
+            pane.size_weight = weight.max(1);
+        }
+    }
+
+    fn minimum_window_axis_size(layout: SplitLayout) -> u16 {
+        match layout {
+            SplitLayout::Vertical => MIN_WINDOW_WIDTH,
+            SplitLayout::Horizontal => MIN_WINDOW_HEIGHT,
+        }
+    }
+
+    fn split_axis_unavailable_status(layout: SplitLayout) -> &'static str {
+        match layout {
+            SplitLayout::Vertical => "No vertical split",
+            SplitLayout::Horizontal => "No horizontal split",
+        }
     }
 
     /// Rotate pane order down/right according to the current split layout.
@@ -2934,7 +3094,6 @@ impl Editor {
     }
 
     /// Update pane rects based on current layout
-    /// For now, uses simple even splits - horizontal for 2 panes
     pub fn update_pane_rects(&mut self) {
         let text_height = self.text_rows() as u16;
         let num_panes = self.panes.len() as u16;
@@ -2951,42 +3110,57 @@ impl Editor {
         };
 
         let available_width = self.term_width.saturating_sub(explorer_offset);
+        let weights: Vec<u16> = self
+            .panes
+            .iter()
+            .map(|pane| pane.size_weight.max(1))
+            .collect();
 
         match self.split_layout {
             SplitLayout::Vertical => {
                 // Side-by-side panes
-                let pane_width = available_width / num_panes;
-                let remainder = available_width % num_panes;
+                let widths = Self::split_lengths_by_weights(available_width, &weights);
 
                 let mut x = explorer_offset;
-                for (i, pane) in self.panes.iter_mut().enumerate() {
-                    // Add remainder to last pane
-                    let w = if i as u16 == num_panes - 1 {
-                        pane_width + remainder
-                    } else {
-                        pane_width
-                    };
+                for (pane, w) in self.panes.iter_mut().zip(widths) {
                     pane.rect = Rect::new(x, 0, w, text_height);
                     x += w;
                 }
             }
             SplitLayout::Horizontal => {
                 // Stacked panes
-                let pane_height = text_height / num_panes;
-                let remainder = text_height % num_panes;
+                let heights = Self::split_lengths_by_weights(text_height, &weights);
 
                 let mut y = 0u16;
-                for (i, pane) in self.panes.iter_mut().enumerate() {
-                    let h = if i as u16 == num_panes - 1 {
-                        pane_height + remainder
-                    } else {
-                        pane_height
-                    };
+                for (pane, h) in self.panes.iter_mut().zip(heights) {
                     pane.rect = Rect::new(explorer_offset, y, available_width, h);
                     y += h;
                 }
             }
         }
+    }
+
+    fn split_lengths_by_weights(total: u16, weights: &[u16]) -> Vec<u16> {
+        if weights.is_empty() {
+            return Vec::new();
+        }
+
+        let weight_sum: u32 = weights.iter().map(|weight| (*weight).max(1) as u32).sum();
+        if weight_sum == 0 {
+            return vec![0; weights.len()];
+        }
+
+        let mut lengths: Vec<u16> = weights
+            .iter()
+            .map(|weight| {
+                ((total as u32 * (*weight).max(1) as u32) / weight_sum).min(u16::MAX as u32) as u16
+            })
+            .collect();
+        let assigned: u16 = lengths.iter().copied().sum();
+        if let Some(last) = lengths.last_mut() {
+            *last = last.saturating_add(total.saturating_sub(assigned));
+        }
+        lengths
     }
 
     /// Clamp cursor to valid buffer positions

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1178,6 +1178,48 @@ status = "implemented"
 vim_default = true
 
 [[normal.window]]
+key = "<C-w>+"
+action = "increase_window_height"
+desc = "Increase current split height"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>-"
+action = "decrease_window_height"
+desc = "Decrease current split height"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>>"
+action = "increase_window_width"
+desc = "Increase current split width"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w><"
+action = "decrease_window_width"
+desc = "Decrease current split width"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>_"
+action = "maximize_window_height"
+desc = "Maximize current split height"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>|"
+action = "maximize_window_width"
+desc = "Maximize current split width"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
 key = "<C-w>r"
 action = "rotate_windows"
 desc = "Rotate windows down/right"

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -217,6 +217,12 @@ pub enum KeyAction {
     WindowRotateDownRight,
     WindowRotateUpLeft,
     WindowExchangeNext,
+    WindowIncreaseHeight,
+    WindowDecreaseHeight,
+    WindowIncreaseWidth,
+    WindowDecreaseWidth,
+    WindowMaximizeHeight,
+    WindowMaximizeWidth,
     /// Go to definition (gd)
     GotoDefinition,
     /// Go to declaration (gD)
@@ -1650,6 +1656,13 @@ impl InputState {
             (KeyModifiers::NONE, KeyCode::Char('o')) => KeyAction::WindowCloseOthers,
             // Equalize
             (KeyModifiers::NONE, KeyCode::Char('=')) => KeyAction::WindowEqualize,
+            // Resize/maximize
+            (_, KeyCode::Char('+')) => KeyAction::WindowIncreaseHeight,
+            (_, KeyCode::Char('-')) => KeyAction::WindowDecreaseHeight,
+            (_, KeyCode::Char('>')) => KeyAction::WindowIncreaseWidth,
+            (_, KeyCode::Char('<')) => KeyAction::WindowDecreaseWidth,
+            (_, KeyCode::Char('_')) => KeyAction::WindowMaximizeHeight,
+            (_, KeyCode::Char('|')) => KeyAction::WindowMaximizeWidth,
             // Rotate
             (KeyModifiers::NONE, KeyCode::Char('r')) => KeyAction::WindowRotateDownRight,
             (KeyModifiers::SHIFT, KeyCode::Char('R')) => KeyAction::WindowRotateUpLeft,
@@ -2485,6 +2498,30 @@ mod tests {
         match run(&[ctrl('w'), key('x')]) {
             KeyAction::WindowExchangeNext => {}
             other => panic!("expected WindowExchangeNext, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('+')]) {
+            KeyAction::WindowIncreaseHeight => {}
+            other => panic!("expected WindowIncreaseHeight, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('-')]) {
+            KeyAction::WindowDecreaseHeight => {}
+            other => panic!("expected WindowDecreaseHeight, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('>')]) {
+            KeyAction::WindowIncreaseWidth => {}
+            other => panic!("expected WindowIncreaseWidth, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('<')]) {
+            KeyAction::WindowDecreaseWidth => {}
+            other => panic!("expected WindowDecreaseWidth, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('_')]) {
+            KeyAction::WindowMaximizeHeight => {}
+            other => panic!("expected WindowMaximizeHeight, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('|')]) {
+            KeyAction::WindowMaximizeWidth => {}
+            other => panic!("expected WindowMaximizeWidth, got {:?}", other),
         }
         match run(&[ctrl('w'), key('w')]) {
             KeyAction::WindowNext => {}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6861,6 +6861,30 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.exchange_window_with_next();
         }
 
+        KeyAction::WindowIncreaseHeight => {
+            editor.increase_window_height();
+        }
+
+        KeyAction::WindowDecreaseHeight => {
+            editor.decrease_window_height();
+        }
+
+        KeyAction::WindowIncreaseWidth => {
+            editor.increase_window_width();
+        }
+
+        KeyAction::WindowDecreaseWidth => {
+            editor.decrease_window_width();
+        }
+
+        KeyAction::WindowMaximizeHeight => {
+            editor.maximize_window_height();
+        }
+
+        KeyAction::WindowMaximizeWidth => {
+            editor.maximize_window_width();
+        }
+
         KeyAction::GotoDefinition => {
             editor.pending_lsp_action = Some(crate::editor::LspAction::GotoDefinition);
         }
@@ -11032,6 +11056,80 @@ mod tests {
 
         assert_eq!(editor.panes().len(), 2);
         assert_eq!(editor.status_message.as_deref(), Some("Windows equalized"));
+    }
+
+    #[test]
+    fn normal_ctrl_w_width_keys_resize_and_maximize_vertical_windows() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("split");
+
+        assert_eq!(editor.active_pane_idx(), 1);
+        assert_eq!(editor.panes()[0].rect.width, 50);
+        assert_eq!(editor.panes()[1].rect.width, 50);
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('>'));
+
+        assert_eq!(editor.panes()[0].rect.width, 45);
+        assert_eq!(editor.panes()[1].rect.width, 55);
+        assert_eq!(editor.status_message.as_deref(), Some("Window resized"));
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('<'));
+
+        assert_eq!(editor.panes()[0].rect.width, 50);
+        assert_eq!(editor.panes()[1].rect.width, 50);
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('|'));
+
+        assert_eq!(editor.panes()[0].rect.width, 10);
+        assert_eq!(editor.panes()[1].rect.width, 90);
+        assert_eq!(editor.status_message.as_deref(), Some("Window maximized"));
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('='));
+
+        assert_eq!(editor.panes()[0].rect.width, 50);
+        assert_eq!(editor.panes()[1].rect.width, 50);
+    }
+
+    #[test]
+    fn normal_ctrl_w_height_keys_resize_and_maximize_horizontal_windows() {
+        let mut editor = Editor::default();
+        editor.set_size(100, 22);
+        editor.hsplit(None).expect("split");
+
+        assert_eq!(editor.active_pane_idx(), 1);
+        assert_eq!(editor.panes()[0].rect.height, 10);
+        assert_eq!(editor.panes()[1].rect.height, 10);
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('+'));
+
+        assert_eq!(editor.panes()[0].rect.height, 5);
+        assert_eq!(editor.panes()[1].rect.height, 15);
+        assert_eq!(editor.status_message.as_deref(), Some("Window resized"));
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('-'));
+
+        assert_eq!(editor.panes()[0].rect.height, 10);
+        assert_eq!(editor.panes()[1].rect.height, 10);
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('_'));
+
+        assert_eq!(editor.panes()[0].rect.height, 3);
+        assert_eq!(editor.panes()[1].rect.height, 17);
+        assert_eq!(editor.status_message.as_deref(), Some("Window maximized"));
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, key('='));
+
+        assert_eq!(editor.panes()[0].rect.height, 10);
+        assert_eq!(editor.panes()[1].rect.height, 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add Vim/Neovim window resize defaults: `Ctrl+w +`, `Ctrl+w -`, `Ctrl+w >`, and `Ctrl+w <`.
- Add maximize defaults: `Ctrl+w _` for height and `Ctrl+w |` for width.
- Persist split sizes through pane weights and document the new bindings in KEYBINDINGS, :Keymaps metadata, generated config comments, and the roadmap count.

## Test Plan
- `cargo test window --quiet`
- `cargo test --quiet`
- Manual: opened `/private/tmp/nevi_window_resize_keybinds.txt` and verified vertical/horizontal resize and maximize workflows
