### PR TITLE
feat: add window move keybinds

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -650,6 +650,10 @@ Split and navigate between windows.
 | `Ctrl+w r` | Rotate windows down/right |
 | `Ctrl+w R` | Rotate windows up/left |
 | `Ctrl+w x` | Exchange current window with next |
+| `Ctrl+w H` | Move current window to the far left |
+| `Ctrl+w J` | Move current window to the bottom |
+| `Ctrl+w K` | Move current window to the top |
+| `Ctrl+w L` | Move current window to the far right |
 | `Ctrl+h` / `Ctrl+j` / `Ctrl+k` / `Ctrl+l` | Move directly to neighboring windows |
 
 > **Note:** Currently all splits share the same orientation (all vertical OR all horizontal). Mixed layouts like having one vertical split with a horizontal split inside it are not yet supported.

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 311 keybinds implemented, 56 planned Vim/Neovim parity defaults.**
+**Status: 315 keybinds implemented, 52 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -31,18 +31,6 @@ These apply while editing the command prompt after `:`.
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |
 | `q?` | Open `?` search history in the command-line window |
-
-### Window Management Extras
-
-Nevi already has the core split/navigation defaults. These cover the remaining
-Vim window sizing and window-moving defaults.
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `Ctrl+w H` | Move current window to the far left |
-| `Ctrl+w J` | Move current window to the bottom |
-| `Ctrl+w K` | Move current window to the top |
-| `Ctrl+w L` | Move current window to the far right |
 
 ### Advanced Motions
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1171,6 +1171,7 @@ fn default_config_template() -> &'static str {
 # Ctrl+w _/|       - Maximize current split height/width
 # Ctrl+w r/R       - Rotate windows down-right / up-left
 # Ctrl+w x         - Exchange current window with next
+# Ctrl+w H/J/K/L   - Move current window far left/bottom/top/far right
 #
 # ----------------------------------------------------------------------------
 # NORMAL MODE - Harpoon

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2854,6 +2854,44 @@ impl Editor {
         self.set_status("Windows exchanged");
     }
 
+    /// Move the current window to the far left, switching to a vertical layout.
+    pub fn move_window_far_left(&mut self) {
+        self.move_window_to_edge(SplitLayout::Vertical, false, "Window moved far left");
+    }
+
+    /// Move the current window to the far right, switching to a vertical layout.
+    pub fn move_window_far_right(&mut self) {
+        self.move_window_to_edge(SplitLayout::Vertical, true, "Window moved far right");
+    }
+
+    /// Move the current window to the top, switching to a horizontal layout.
+    pub fn move_window_top(&mut self) {
+        self.move_window_to_edge(SplitLayout::Horizontal, false, "Window moved top");
+    }
+
+    /// Move the current window to the bottom, switching to a horizontal layout.
+    pub fn move_window_bottom(&mut self) {
+        self.move_window_to_edge(SplitLayout::Horizontal, true, "Window moved bottom");
+    }
+
+    fn move_window_to_edge(&mut self, layout: SplitLayout, to_end: bool, status: &'static str) {
+        if self.panes.len() <= 1 {
+            self.set_status("Only one window");
+            return;
+        }
+
+        self.save_pane_state();
+        let pane = self.panes.remove(self.active_pane);
+        self.split_layout = layout;
+        let target = if to_end { self.panes.len() } else { 0 };
+        self.panes.insert(target, pane);
+        self.active_pane = target;
+        self.reset_window_size_weights();
+        self.update_pane_rects();
+        self.load_pane_state();
+        self.set_status(status);
+    }
+
     /// Move to a pane in the specified direction
     pub fn move_to_pane_direction(&mut self, direction: PaneDirection) {
         // Special case: if moving left with only one pane and explorer is visible, focus explorer
@@ -9815,7 +9853,7 @@ impl Default for Editor {
 
 #[cfg(test)]
 mod tests {
-    use super::{Editor, JumpList, Mode};
+    use super::{Editor, JumpList, Mode, SplitLayout};
     use crate::input::Motion;
     use crate::lsp::types::{
         CodeActionItem, CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity, TextEdit,
@@ -10058,6 +10096,96 @@ mod tests {
         assert_eq!(editor.active_pane, 1);
         assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
         assert_eq!(editor.status_message.as_deref(), Some("Windows exchanged"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn move_window_to_edges_reorders_active_pane_and_switches_axis() {
+        let tmp = unique_temp_dir("nevi_move_window_edges");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        let third = tmp.join("third.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+        std::fs::write(&third, "third\n").expect("write third");
+
+        let mut editor = Editor::default();
+        editor.open_file(first).expect("open first");
+        editor.vsplit(Some(second)).expect("split second");
+        editor.vsplit(Some(third)).expect("split third");
+        editor.prev_pane();
+        let active_buffer = editor.panes[editor.active_pane].buffer_idx;
+
+        editor.move_window_far_left();
+
+        assert_eq!(editor.split_layout(), SplitLayout::Vertical);
+        assert_eq!(editor.active_pane, 0);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![1, 0, 2]
+        );
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Window moved far left")
+        );
+
+        editor.move_window_far_right();
+
+        assert_eq!(editor.split_layout(), SplitLayout::Vertical);
+        assert_eq!(editor.active_pane, 2);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 1]
+        );
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Window moved far right")
+        );
+
+        editor.move_window_top();
+
+        assert_eq!(editor.split_layout(), SplitLayout::Horizontal);
+        assert_eq!(editor.active_pane, 0);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![1, 0, 2]
+        );
+        assert_eq!(editor.status_message.as_deref(), Some("Window moved top"));
+
+        editor.move_window_bottom();
+
+        assert_eq!(editor.split_layout(), SplitLayout::Horizontal);
+        assert_eq!(editor.active_pane, 2);
+        assert_eq!(editor.panes[editor.active_pane].buffer_idx, active_buffer);
+        assert_eq!(
+            editor
+                .panes
+                .iter()
+                .map(|pane| pane.buffer_idx)
+                .collect::<Vec<_>>(),
+            vec![0, 2, 1]
+        );
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Window moved bottom")
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1240,6 +1240,34 @@ desc = "Exchange current window with next"
 status = "implemented"
 vim_default = true
 
+[[normal.window]]
+key = "<C-w>H"
+action = "move_window_far_left"
+desc = "Move current window to far left"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>J"
+action = "move_window_bottom"
+desc = "Move current window to bottom"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>K"
+action = "move_window_top"
+desc = "Move current window to top"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>L"
+action = "move_window_far_right"
+desc = "Move current window to far right"
+status = "implemented"
+vim_default = true
+
 # ============================================================================
 # INSERT MODE
 # ============================================================================

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -217,6 +217,10 @@ pub enum KeyAction {
     WindowRotateDownRight,
     WindowRotateUpLeft,
     WindowExchangeNext,
+    WindowMoveFarLeft,
+    WindowMoveFarRight,
+    WindowMoveTop,
+    WindowMoveBottom,
     WindowIncreaseHeight,
     WindowDecreaseHeight,
     WindowIncreaseWidth,
@@ -1647,7 +1651,8 @@ impl InputState {
             }
             // Cycle through windows
             (KeyModifiers::NONE, KeyCode::Char('w')) => KeyAction::WindowNext,
-            (KeyModifiers::SHIFT, KeyCode::Char('W')) => KeyAction::WindowPrev,
+            (KeyModifiers::SHIFT, KeyCode::Char('W' | 'w'))
+            | (KeyModifiers::NONE, KeyCode::Char('W')) => KeyAction::WindowPrev,
             // Splits
             (KeyModifiers::NONE, KeyCode::Char('v')) => KeyAction::WindowSplitVertical,
             (KeyModifiers::NONE, KeyCode::Char('s')) => KeyAction::WindowSplitHorizontal,
@@ -1665,9 +1670,19 @@ impl InputState {
             (_, KeyCode::Char('|')) => KeyAction::WindowMaximizeWidth,
             // Rotate
             (KeyModifiers::NONE, KeyCode::Char('r')) => KeyAction::WindowRotateDownRight,
-            (KeyModifiers::SHIFT, KeyCode::Char('R')) => KeyAction::WindowRotateUpLeft,
+            (KeyModifiers::SHIFT, KeyCode::Char('R' | 'r'))
+            | (KeyModifiers::NONE, KeyCode::Char('R')) => KeyAction::WindowRotateUpLeft,
             // Exchange
             (KeyModifiers::NONE, KeyCode::Char('x')) => KeyAction::WindowExchangeNext,
+            // Move current window to an edge
+            (KeyModifiers::SHIFT, KeyCode::Char('H' | 'h'))
+            | (KeyModifiers::NONE, KeyCode::Char('H')) => KeyAction::WindowMoveFarLeft,
+            (KeyModifiers::SHIFT, KeyCode::Char('J' | 'j'))
+            | (KeyModifiers::NONE, KeyCode::Char('J')) => KeyAction::WindowMoveBottom,
+            (KeyModifiers::SHIFT, KeyCode::Char('K' | 'k'))
+            | (KeyModifiers::NONE, KeyCode::Char('K')) => KeyAction::WindowMoveTop,
+            (KeyModifiers::SHIFT, KeyCode::Char('L' | 'l'))
+            | (KeyModifiers::NONE, KeyCode::Char('L')) => KeyAction::WindowMoveFarRight,
             // Escape cancels
             (_, KeyCode::Esc) => KeyAction::Pending,
             _ => KeyAction::Unknown,
@@ -2499,6 +2514,22 @@ mod tests {
             KeyAction::WindowExchangeNext => {}
             other => panic!("expected WindowExchangeNext, got {:?}", other),
         }
+        match run(&[ctrl('w'), shift('H')]) {
+            KeyAction::WindowMoveFarLeft => {}
+            other => panic!("expected WindowMoveFarLeft, got {:?}", other),
+        }
+        match run(&[ctrl('w'), shift('J')]) {
+            KeyAction::WindowMoveBottom => {}
+            other => panic!("expected WindowMoveBottom, got {:?}", other),
+        }
+        match run(&[ctrl('w'), shift('K')]) {
+            KeyAction::WindowMoveTop => {}
+            other => panic!("expected WindowMoveTop, got {:?}", other),
+        }
+        match run(&[ctrl('w'), shift('L')]) {
+            KeyAction::WindowMoveFarRight => {}
+            other => panic!("expected WindowMoveFarRight, got {:?}", other),
+        }
         match run(&[ctrl('w'), key('+')]) {
             KeyAction::WindowIncreaseHeight => {}
             other => panic!("expected WindowIncreaseHeight, got {:?}", other),
@@ -2555,6 +2586,58 @@ mod tests {
         match run(&[key('['), key('h')]) {
             KeyAction::HarpoonPrev => {}
             other => panic!("expected HarpoonPrev, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn window_move_commands_accept_uppercase_chars_without_shift_modifier() {
+        match run(&[ctrl('w'), key('H')]) {
+            KeyAction::WindowMoveFarLeft => {}
+            other => panic!("expected WindowMoveFarLeft, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('J')]) {
+            KeyAction::WindowMoveBottom => {}
+            other => panic!("expected WindowMoveBottom, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('K')]) {
+            KeyAction::WindowMoveTop => {}
+            other => panic!("expected WindowMoveTop, got {:?}", other),
+        }
+        match run(&[ctrl('w'), key('L')]) {
+            KeyAction::WindowMoveFarRight => {}
+            other => panic!("expected WindowMoveFarRight, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn window_move_commands_accept_shift_modifier_with_lowercase_chars() {
+        match run(&[
+            ctrl('w'),
+            KeyEvent::new(KeyCode::Char('h'), KeyModifiers::SHIFT),
+        ]) {
+            KeyAction::WindowMoveFarLeft => {}
+            other => panic!("expected WindowMoveFarLeft, got {:?}", other),
+        }
+        match run(&[
+            ctrl('w'),
+            KeyEvent::new(KeyCode::Char('j'), KeyModifiers::SHIFT),
+        ]) {
+            KeyAction::WindowMoveBottom => {}
+            other => panic!("expected WindowMoveBottom, got {:?}", other),
+        }
+        match run(&[
+            ctrl('w'),
+            KeyEvent::new(KeyCode::Char('k'), KeyModifiers::SHIFT),
+        ]) {
+            KeyAction::WindowMoveTop => {}
+            other => panic!("expected WindowMoveTop, got {:?}", other),
+        }
+        match run(&[
+            ctrl('w'),
+            KeyEvent::new(KeyCode::Char('l'), KeyModifiers::SHIFT),
+        ]) {
+            KeyAction::WindowMoveFarRight => {}
+            other => panic!("expected WindowMoveFarRight, got {:?}", other),
         }
     }
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6461,7 +6461,7 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
 
     // Check for normal mode custom mapping first
     // But skip if we're in a partial sequence (like g; or g,) - let the input state handle it
-    if editor.input_state.partial_key.is_none() {
+    if editor.input_state.partial_key.is_none() && !editor.input_state.pending_window_cmd {
         if let Some(mapping) = editor.keymap.get_normal_mapping(key) {
             let mapping = mapping.clone();
             let t_exec = std::time::Instant::now();
@@ -6859,6 +6859,22 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
 
         KeyAction::WindowExchangeNext => {
             editor.exchange_window_with_next();
+        }
+
+        KeyAction::WindowMoveFarLeft => {
+            editor.move_window_far_left();
+        }
+
+        KeyAction::WindowMoveFarRight => {
+            editor.move_window_far_right();
+        }
+
+        KeyAction::WindowMoveTop => {
+            editor.move_window_top();
+        }
+
+        KeyAction::WindowMoveBottom => {
+            editor.move_window_bottom();
         }
 
         KeyAction::WindowIncreaseHeight => {
@@ -11164,6 +11180,43 @@ mod tests {
         handle_key(&mut editor, key('x'));
 
         assert_eq!(editor.status_message.as_deref(), Some("Windows exchanged"));
+    }
+
+    #[test]
+    fn normal_keymaps_do_not_intercept_pending_window_commands() {
+        let mut settings = Settings::default();
+        settings.keymap.normal.push(KeymapEntry {
+            from: "H".to_string(),
+            to: "^".to_string(),
+        });
+        settings.keymap.normal.push(KeymapEntry {
+            from: "L".to_string(),
+            to: "$".to_string(),
+        });
+        let mut editor = Editor::new(settings);
+        editor.set_size(100, 20);
+        editor.vsplit(None).expect("first split");
+        editor.vsplit(None).expect("second split");
+
+        assert_eq!(editor.active_pane_idx(), 2);
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, shift_key('H'));
+
+        assert_eq!(editor.active_pane_idx(), 0);
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Window moved far left")
+        );
+
+        handle_key(&mut editor, ctrl_key('w'));
+        handle_key(&mut editor, shift_key('L'));
+
+        assert_eq!(editor.active_pane_idx(), 2);
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Window moved far right")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add Ctrl+w H/J/K/L window move actions
- keep Ctrl+w subcommands from being intercepted by normal-mode remaps
- update :Keymaps metadata, generated config comments, keybinding docs, and roadmap counts

