### PR TITLE
feat: open health report in a read-only buffer

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -930,7 +930,7 @@ While typing an Ex command after `:`.
 | `:Themes` | Open theme picker |
 | `:Theme {name}` / `:theme {name}` / `:colorscheme {name}` | Set theme |
 | `:LazyGit` / `:lg` | Open lazygit |
-| `:checkhealth` / `:CheckHealth` / `:Health` | Open editor health report with config, keymap, profiling, and LSP summary |
+| `:checkhealth` / `:CheckHealth` / `:Health` | Open editor health report in a read-only `[health]` buffer |
 | `:ConfigOpen` / `:config` / `:configopen` | Open the user config file, creating it first if needed |
 | `:ConfigDefaults` / `:configdefaults` | View the latest built-in default config template without changing user config |
 | `:!{command}` | Run external shell command |

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ nevi file1.rs file2.rs
 - `:w` - Save
 - `:q` - Quit
 - `:wq` - Save and quit
-- `:checkhealth` / `:Health` - Open editor health report
+- `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config template
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
@@ -357,10 +357,12 @@ summary includes count, retained sample count, total, average, p50, p95, and max
 microseconds for metrics such as key handling, syntax updates, full renders, and
 terminal-only renders.
 
-Run `:checkhealth` (or `:Health`) inside Nevi to see config paths, config
-discoverability commands, keymap overrides and warnings, LSP settings, profiling
-status, and any profile summary from `/tmp/nevi_profile.log`. Profile summaries
-are written when a profiled Nevi session exits.
+Run `:checkhealth` (or `:Health`) inside Nevi to open a read-only `[health]`
+buffer with config paths, config discoverability commands, keymap overrides and
+warnings, LSP settings, profiling status, and any profile summary from
+`/tmp/nevi_profile.log`. Because it is a regular buffer, normal motions, search,
+and yank commands work there. Profile summaries are written when a profiled Nevi
+session exits.
 
 ## License
 

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -19,6 +19,18 @@ pub struct Buffer {
     version: u64,
     /// Last known modification time of the file on disk (for autoread)
     last_mtime: Option<SystemTime>,
+    kind: BufferKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum BufferKind {
+    File,
+    Untitled,
+    Virtual {
+        name: String,
+        read_only: bool,
+        syntax_hint_path: Option<PathBuf>,
+    },
 }
 
 impl Buffer {
@@ -30,6 +42,7 @@ impl Buffer {
             dirty: false,
             version: 0,
             last_mtime: None,
+            kind: BufferKind::Untitled,
         }
     }
 
@@ -50,11 +63,63 @@ impl Buffer {
             dirty: false,
             version: 0,
             last_mtime,
+            kind: BufferKind::File,
         })
+    }
+
+    /// Create a named virtual buffer whose content is not backed by a file.
+    pub fn virtual_read_only(
+        name: impl Into<String>,
+        content: &str,
+        syntax_hint_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            text: Rope::from_str(content),
+            path: None,
+            dirty: false,
+            version: 0,
+            last_mtime: None,
+            kind: BufferKind::Virtual {
+                name: name.into(),
+                read_only: true,
+                syntax_hint_path,
+            },
+        }
+    }
+
+    /// Whether this buffer should reject direct content changes.
+    pub fn is_read_only(&self) -> bool {
+        matches!(
+            self.kind,
+            BufferKind::Virtual {
+                read_only: true,
+                ..
+            }
+        )
+    }
+
+    /// Mark this buffer as file-backed.
+    pub fn set_file_path(&mut self, path: PathBuf) {
+        self.path = Some(path);
+        self.kind = BufferKind::File;
+    }
+
+    /// Path used for syntax detection. Virtual buffers may provide a synthetic hint.
+    pub fn syntax_hint_path(&self) -> Option<&PathBuf> {
+        match &self.kind {
+            BufferKind::Virtual {
+                syntax_hint_path, ..
+            } => syntax_hint_path.as_ref(),
+            BufferKind::File | BufferKind::Untitled => self.path.as_ref(),
+        }
     }
 
     /// Save buffer to its file path
     pub fn save(&mut self) -> anyhow::Result<()> {
+        if self.is_read_only() {
+            anyhow::bail!("Buffer is read-only");
+        }
+
         let path = self
             .path
             .as_ref()
@@ -153,6 +218,9 @@ impl Buffer {
     /// Replace the entire buffer content with new text
     /// Used by external formatters to apply formatting
     pub fn set_content(&mut self, content: &str) {
+        if self.is_read_only() {
+            return;
+        }
         self.text = Rope::from_str(content);
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
@@ -171,6 +239,9 @@ impl Buffer {
 
     /// Insert a character at the given line and column
     pub fn insert_char(&mut self, line: usize, col: usize, ch: char) {
+        if self.is_read_only() {
+            return;
+        }
         let idx = self.line_col_to_char(line, col);
         self.text.insert_char(idx, ch);
         self.dirty = true;
@@ -179,6 +250,9 @@ impl Buffer {
 
     /// Insert a string at the given line and column
     pub fn insert_str(&mut self, line: usize, col: usize, s: &str) {
+        if self.is_read_only() {
+            return;
+        }
         let idx = self.line_col_to_char(line, col);
         self.text.insert(idx, s);
         self.dirty = true;
@@ -187,6 +261,9 @@ impl Buffer {
 
     /// Delete a character at the given line and column
     pub fn delete_char(&mut self, line: usize, col: usize) {
+        if self.is_read_only() {
+            return;
+        }
         let idx = self.line_col_to_char(line, col);
         if idx < self.text.len_chars() {
             self.text.remove(idx..idx + 1);
@@ -203,6 +280,9 @@ impl Buffer {
         end_line: usize,
         end_col: usize,
     ) {
+        if self.is_read_only() {
+            return;
+        }
         let start = self.line_col_to_char(start_line, start_col);
         let end = self.line_col_to_char(end_line, end_col);
         if start < end && end <= self.text.len_chars() {
@@ -214,6 +294,9 @@ impl Buffer {
 
     /// Replace an entire line with new content
     pub fn replace_line(&mut self, line: usize, new_content: &str) {
+        if self.is_read_only() {
+            return;
+        }
         if line >= self.text.len_lines() {
             return;
         }
@@ -248,6 +331,9 @@ impl Buffer {
 
     /// Mark the buffer as modified
     pub fn mark_modified(&mut self) {
+        if self.is_read_only() {
+            return;
+        }
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -274,6 +360,10 @@ impl Buffer {
 
     /// Get the display name for the buffer
     pub fn display_name(&self) -> String {
+        if let BufferKind::Virtual { name, .. } = &self.kind {
+            return name.clone();
+        }
+
         self.path
             .as_ref()
             .and_then(|p| p.file_name())

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1726,14 +1726,55 @@ impl Editor {
         Ok(())
     }
 
-    /// Open a snapshot health report in the read-only preview overlay.
+    /// Open a health report in a read-only virtual buffer.
     pub fn open_health_report(&mut self) {
         let report = crate::health::collect_health_report(&self.settings);
-        let rendered = crate::markdown_preview::render_markdown(&report);
-        let width = crate::markdown_preview::preview_content_width(self.term_width);
-        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::with_title(
-            rendered, width, "Health",
-        ));
+        self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
+    }
+
+    /// Open named content that is not backed by a file and cannot be edited.
+    pub fn open_virtual_read_only_buffer(
+        &mut self,
+        name: impl Into<String>,
+        content: &str,
+        syntax_hint_path: Option<&str>,
+    ) {
+        let new_buffer = Buffer::virtual_read_only(
+            name,
+            content,
+            syntax_hint_path.map(std::path::PathBuf::from),
+        );
+        self.markdown_preview = None;
+
+        if self.buffers[self.current_buffer_idx].is_empty()
+            && self.buffers[self.current_buffer_idx].path.is_none()
+        {
+            self.buffers[self.current_buffer_idx] = new_buffer;
+            self.reset_current_undo_stack();
+        } else {
+            self.remember_current_file_as_alternate();
+            self.save_pane_state();
+            self.buffers.push(new_buffer);
+            self.undo_stacks.push(UndoStack::new());
+            self.current_buffer_idx = self.buffers.len() - 1;
+            self.load_current_undo_stack();
+            if self.active_pane < self.panes.len() {
+                self.panes[self.active_pane].buffer_idx = self.current_buffer_idx;
+            }
+        }
+
+        self.cursor = Cursor::default();
+        self.viewport_offset = 0;
+        self.h_offset = 0;
+        self.reset_current_undo_stack();
+
+        if self.active_pane < self.panes.len() {
+            self.panes[self.active_pane].cursor = self.cursor;
+            self.panes[self.active_pane].viewport_offset = self.viewport_offset;
+            self.panes[self.active_pane].h_offset = self.h_offset;
+        }
+
+        self.sync_syntax_to_current_buffer();
     }
 
     /// Open the user's config file, creating the default template first if needed.
@@ -2345,6 +2386,23 @@ impl Editor {
         &mut self.buffers[self.current_buffer_idx]
     }
 
+    fn reject_read_only_edit(&mut self) -> bool {
+        if self.buffers[self.current_buffer_idx].is_read_only() {
+            self.set_status("Buffer is read-only");
+            return true;
+        }
+        false
+    }
+
+    fn sync_syntax_to_current_buffer(&mut self) {
+        let syntax_hint = self.buffers[self.current_buffer_idx]
+            .syntax_hint_path()
+            .cloned();
+        self.syntax
+            .set_language_from_path_option(syntax_hint.as_ref());
+        self.parse_current_buffer();
+    }
+
     fn save_current_undo_stack(&mut self) {
         if let Some(stack) = self.undo_stacks.get_mut(self.current_buffer_idx) {
             *stack = self.undo_stack.clone();
@@ -2514,9 +2572,7 @@ impl Editor {
             self.current_buffer_idx = self.panes[self.active_pane].buffer_idx;
             self.load_current_undo_stack();
             // Re-parse syntax for the buffer
-            let path = self.buffers[self.current_buffer_idx].path.clone();
-            self.syntax.set_language_from_path_option(path.as_ref());
-            self.parse_current_buffer();
+            self.sync_syntax_to_current_buffer();
         }
     }
 
@@ -3097,7 +3153,7 @@ impl Editor {
 
     /// Set the path of the current buffer (for rename operations)
     pub fn set_buffer_path(&mut self, path: std::path::PathBuf) {
-        self.buffers[self.current_buffer_idx].path = Some(path.clone());
+        self.buffers[self.current_buffer_idx].set_file_path(path.clone());
         // Update syntax highlighting for new filename
         self.syntax.set_language_from_path(&path);
         self.parse_current_buffer();
@@ -3227,6 +3283,9 @@ impl Editor {
     }
 
     fn enter_insert_mode_at_change(&mut self, line: usize, col: usize) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         self.mode = Mode::Insert;
         self.begin_insert_session();
         self.cursor.line = line.min(
@@ -3981,6 +4040,9 @@ impl Editor {
 
     /// Enter insert mode
     pub fn enter_insert_mode(&mut self) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
         self.begin_insert_session();
@@ -3989,6 +4051,9 @@ impl Editor {
 
     /// Enter insert mode after cursor
     pub fn enter_insert_mode_append(&mut self) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
         if line_len > 0 {
             self.cursor.col = (self.cursor.col + 1).min(line_len);
@@ -4001,6 +4066,9 @@ impl Editor {
 
     /// Enter insert mode at end of line
     pub fn enter_insert_mode_end(&mut self) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         self.cursor.col = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
@@ -4010,6 +4078,9 @@ impl Editor {
 
     /// Enter insert mode at start of line (first non-blank)
     pub fn enter_insert_mode_start(&mut self) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         // Find first non-blank character
         let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
         for col in 0..line_len {
@@ -4341,6 +4412,9 @@ impl Editor {
 
     /// Insert a character at cursor position
     pub fn insert_char(&mut self, ch: char) {
+        if self.reject_read_only_edit() {
+            return;
+        }
         if ch == '\n' && self.settings.editor.auto_indent {
             self.insert_newline_with_indent();
         } else if matches!(ch, '}' | ']' | ')') && self.settings.editor.auto_indent {
@@ -4937,6 +5011,10 @@ impl Editor {
 
     /// Save the current buffer
     pub fn save(&mut self) -> anyhow::Result<()> {
+        if self.buffers[self.current_buffer_idx].is_read_only() {
+            self.set_status("Buffer is read-only");
+            anyhow::bail!("Buffer is read-only");
+        }
         self.buffers[self.current_buffer_idx].save()?;
         self.status_message = Some(format!(
             "\"{}\" written",
@@ -5182,7 +5260,10 @@ impl Editor {
 
     /// Save to a specific file
     pub fn save_as(&mut self, path: std::path::PathBuf) -> anyhow::Result<()> {
-        self.buffers[self.current_buffer_idx].path = Some(path);
+        if self.buffers[self.current_buffer_idx].is_read_only() {
+            anyhow::bail!("Buffer is read-only");
+        }
+        self.buffers[self.current_buffer_idx].set_file_path(path);
         self.save()
     }
 
@@ -9680,9 +9761,7 @@ impl Editor {
         self.cursor = Cursor::default();
         self.viewport_offset = 0;
         self.h_offset = 0;
-        let path = self.buffers[self.current_buffer_idx].path.clone();
-        self.syntax.set_language_from_path_option(path.as_ref());
-        self.parse_current_buffer();
+        self.sync_syntax_to_current_buffer();
         true
     }
 
@@ -10257,6 +10336,78 @@ mod tests {
 
         assert!(result.is_err());
         assert!(editor.markdown_preview.is_none());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn health_report_opens_as_read_only_virtual_buffer() {
+        let mut editor = Editor::default();
+
+        editor.open_health_report();
+
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[health]");
+        assert!(editor.buffer().is_read_only());
+        assert!(editor.buffer().path.is_none());
+        assert!(!editor.buffer().dirty);
+        let content = editor.buffer().content();
+        assert!(content.contains("# Nevi Health"));
+        assert!(content.contains("## Configuration"));
+        assert!(content.contains("## Keymaps"));
+        assert!(content.contains("## Performance"));
+        assert!(content.contains("## LSP"));
+    }
+
+    #[test]
+    fn read_only_virtual_buffer_rejects_insert_input() {
+        let mut editor = Editor::default();
+        editor.open_virtual_read_only_buffer("[scratch]", "alpha\n", Some("scratch.md"));
+
+        editor.enter_insert_mode();
+        assert_eq!(editor.mode, Mode::Normal);
+        editor.insert_char('x');
+
+        assert_eq!(editor.buffer().content(), "alpha\n");
+        assert!(!editor.buffer().dirty);
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Buffer is read-only")
+        );
+    }
+
+    #[test]
+    fn read_only_virtual_buffer_rejects_save() {
+        let mut editor = Editor::default();
+        editor.open_virtual_read_only_buffer("[scratch]", "alpha\n", Some("scratch.md"));
+
+        let err = editor.save().expect_err("virtual buffer save should fail");
+
+        assert!(err.to_string().contains("Buffer is read-only"));
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Buffer is read-only")
+        );
+        assert!(!editor.buffer().dirty);
+    }
+
+    #[test]
+    fn virtual_buffer_preserves_syntax_hint_after_buffer_switch() {
+        let tmp = unique_temp_dir("nevi_virtual_buffer_syntax_switch");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let rust = tmp.join("main.rs");
+        std::fs::write(&rust, "fn main() {}\n").expect("write rust");
+
+        let mut editor = Editor::default();
+        editor.open_virtual_read_only_buffer("[scratch]", "# Scratch\n", Some("scratch.md"));
+        assert_eq!(editor.syntax.language_name(), Some("markdown"));
+
+        editor.open_file(rust).expect("open rust file");
+        assert_eq!(editor.syntax.language_name(), Some("rust"));
+
+        assert!(editor.switch_to_buffer(0));
+        assert_eq!(editor.buffer().display_name(), "[scratch]");
+        assert_eq!(editor.syntax.language_name(), Some("markdown"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10864,21 +10864,19 @@ mod tests {
     }
 
     #[test]
-    fn checkhealth_command_opens_health_report_preview() {
+    fn checkhealth_command_opens_health_report_buffer() {
         let mut editor = Editor::default();
 
         execute_command(&mut editor, Command::CheckHealth);
 
-        let preview = editor.markdown_preview.as_ref().expect("health preview");
-        assert_eq!(preview.title, "Health");
-        let text = preview
-            .lines
-            .iter()
-            .map(|line| line.plain_text())
-            .collect::<Vec<_>>()
-            .join("\n");
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[health]");
+        assert!(editor.buffer().is_read_only());
+        assert!(!editor.buffer().dirty);
+        let text = editor.buffer().content();
         assert!(text.contains("Nevi Health"));
         assert!(text.contains("Configuration"));
+        assert!(text.contains("Keymaps"));
         assert!(text.contains("Performance"));
         assert!(text.contains("LSP"));
     }


### PR DESCRIPTION
## Summary
- Add named virtual read-only buffers with syntax hints and edit/save protection.
- Open :checkhealth as a regular read-only [health] buffer instead of the markdown floating reader.
- Update docs to describe the [health] buffer workflow.

## Test Plan
- cargo test --quiet
- git diff --check
- Manual: ran :checkhealth and verified [health] supports normal navigation/search/yank while insert/save are rejected as read-only.