### PR TITLE
feat: open config defaults in a read-only buffer

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -932,7 +932,7 @@ While typing an Ex command after `:`.
 | `:LazyGit` / `:lg` | Open lazygit |
 | `:checkhealth` / `:CheckHealth` / `:Health` | Open read-only `[health]` report with config, keymap, profiling, LSP, and external tools |
 | `:ConfigOpen` / `:config` / `:configopen` | Open the user config file, creating it first if needed |
-| `:ConfigDefaults` / `:configdefaults` | View the latest built-in default config template without changing user config |
+| `:ConfigDefaults` / `:configdefaults` | Open read-only `[config-defaults]` buffer with latest built-in default config |
 | `:!{command}` | Run external shell command |
 | `:Terminal` / `:term` | Toggle floating terminal |
 | `:TerminalNew [name]` / `:termnew [name]` | Create floating terminal session |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ nevi file1.rs file2.rs
 - `:wq` - Save and quit
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
 - `:ConfigOpen` / `:config` - Open your user config file
-- `:ConfigDefaults` - View the latest built-in default config template
+- `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
@@ -185,8 +185,9 @@ enabled = true
 
 Run `:ConfigOpen` (or `:config`) to open your user config file from inside
 Nevi. Run `:ConfigDefaults` to view the latest built-in default config template
-without changing your existing config. Existing config files stay user-owned;
-Nevi does not rewrite them when new defaults are added.
+in a read-only `[config-defaults]` buffer without changing your existing config.
+Existing config files stay user-owned; Nevi does not rewrite them when new
+defaults are added.
 
 See the generated config file at `~/.config/nevi/config.toml` for all available
 options with documentation.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -609,7 +609,7 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         command: "ConfigDefaults",
         aliases: &["configdefaults", "defaults"],
-        description: "Open latest default config template",
+        description: "Open latest default config in read-only buffer",
         takes_args: false,
     },
     CommandSpec {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1785,19 +1785,13 @@ impl Editor {
         Ok(path)
     }
 
-    /// Open the latest generated default config template in the read-only preview overlay.
+    /// Open the latest generated default config template in a read-only virtual buffer.
     pub fn open_config_defaults_preview(&mut self) {
-        let source = format!(
-            "```toml\n{}\n```",
-            crate::config::default_config_template_text()
+        self.open_virtual_read_only_buffer(
+            "[config-defaults]",
+            crate::config::default_config_template_text(),
+            Some("config.toml"),
         );
-        let rendered = crate::markdown_preview::render_markdown(&source);
-        let width = crate::markdown_preview::preview_content_width(self.term_width);
-        self.markdown_preview = Some(crate::markdown_preview::MarkdownPreviewState::with_title(
-            rendered,
-            width,
-            "Config Defaults",
-        ));
     }
 
     /// Close the floating Markdown preview.
@@ -10408,6 +10402,29 @@ mod tests {
         assert!(editor.switch_to_buffer(0));
         assert_eq!(editor.buffer().display_name(), "[scratch]");
         assert_eq!(editor.syntax.language_name(), Some("markdown"));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn config_defaults_buffer_uses_toml_syntax_hint_after_buffer_switch() {
+        let tmp = unique_temp_dir("nevi_config_defaults_syntax_switch");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let rust = tmp.join("main.rs");
+        std::fs::write(&rust, "fn main() {}\n").expect("write rust");
+
+        let mut editor = Editor::default();
+        editor.open_config_defaults_preview();
+        assert_eq!(editor.buffer().display_name(), "[config-defaults]");
+        assert!(editor.buffer().is_read_only());
+        assert_eq!(editor.syntax.language_name(), Some("toml"));
+
+        editor.open_file(rust).expect("open rust file");
+        assert_eq!(editor.syntax.language_name(), Some("rust"));
+
+        assert!(editor.switch_to_buffer(0));
+        assert_eq!(editor.buffer().display_name(), "[config-defaults]");
+        assert_eq!(editor.syntax.language_name(), Some("toml"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10882,7 +10882,7 @@ mod tests {
     }
 
     #[test]
-    fn configdefaults_command_opens_default_config_preview() {
+    fn configdefaults_command_opens_default_config_buffer() {
         let mut editor = Editor::default();
 
         execute_command(
@@ -10890,20 +10890,16 @@ mod tests {
             crate::commands::parse_command("ConfigDefaults"),
         );
 
-        let preview = editor
-            .markdown_preview
-            .as_ref()
-            .expect("config defaults preview");
-        assert_eq!(preview.title, "Config Defaults");
-        let text = preview
-            .lines
-            .iter()
-            .map(|line| line.plain_text())
-            .collect::<Vec<_>>()
-            .join("\n");
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[config-defaults]");
+        assert!(editor.buffer().is_read_only());
+        assert!(editor.buffer().path.is_none());
+        assert!(!editor.buffer().dirty);
+        let text = editor.buffer().content();
         assert!(text.contains("# Nevi Configuration"));
         assert!(text.contains("show_leader_popup"));
         assert!(text.contains("explorer"));
+        assert!(!text.starts_with("```toml"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Change :ConfigDefaults to open a regular read-only virtual buffer named [config-defaults]
- Preserve TOML syntax highlighting for the defaults buffer across buffer switches
- Update command and user docs to describe the new buffer behavior

## Tests
- cargo test --quiet
- git diff --check