### PR TITLE
feat: guard saves against external file changes

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -857,7 +857,8 @@ While typing an Ex command after `:`.
 
 | Command | Action |
 |---------|--------|
-| `:w` / `:write` | Save file |
+| `:w` / `:write` | Save file, refusing to overwrite external disk changes |
+| `:w!` / `:write!` | Force save file, overwriting external disk changes |
 | `:wa` / `:wall` | Save all files |
 | `:q` / `:quit` | Quit |
 | `:q!` / `:quit!` | Force quit (discard changes) |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,8 @@ nevi file1.rs file2.rs
 ```
 
 **Basic commands:**
-- `:w` - Save
+- `:w` - Save, refusing to overwrite external disk changes
+- `:w!` - Force save and overwrite external disk changes
 - `:q` - Quit
 - `:wq` - Save and quit
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,6 +7,8 @@ use std::path::PathBuf;
 pub enum Command {
     /// :w [filename] - Write buffer to file
     Write(Option<PathBuf>),
+    /// :w! [filename] - Force write buffer to file
+    ForceWrite(Option<PathBuf>),
     /// :wa - Write all modified buffers
     WriteAll,
     /// :q - Quit (fails if unsaved changes)
@@ -207,7 +209,13 @@ const COMMAND_SPECS: &[CommandSpec] = &[
     CommandSpec {
         command: "w",
         aliases: &["write"],
-        description: "Write current buffer",
+        description: "Write current buffer unless it changed on disk",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "w!",
+        aliases: &["write!"],
+        description: "Force write current buffer and overwrite disk changes",
         takes_args: false,
     },
     CommandSpec {
@@ -875,6 +883,7 @@ pub fn parse_command(input: &str) -> Command {
     match cmd {
         // Write commands
         "w" | "write" => Command::Write(args.filter(|s| !s.is_empty()).map(PathBuf::from)),
+        "w!" | "write!" => Command::ForceWrite(args.filter(|s| !s.is_empty()).map(PathBuf::from)),
         "wa" | "wall" => Command::WriteAll,
 
         // Quit commands
@@ -1970,6 +1979,16 @@ mod tests {
         assert!(matches!(
             parse_command("termrename 2 test runner"),
             Command::TerminalRename(Some(2), name) if name == "test runner"
+        ));
+    }
+
+    #[test]
+    fn force_write_commands_parse_arguments() {
+        assert!(matches!(parse_command("w!"), Command::ForceWrite(None)));
+        assert!(matches!(parse_command("write!"), Command::ForceWrite(None)));
+        assert!(matches!(
+            parse_command("w! /tmp/nevi-force-save.txt"),
+            Command::ForceWrite(Some(path)) if path == PathBuf::from("/tmp/nevi-force-save.txt")
         ));
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -5005,10 +5005,21 @@ impl Editor {
 
     /// Save the current buffer
     pub fn save(&mut self) -> anyhow::Result<()> {
-        if self.buffers[self.current_buffer_idx].is_read_only() {
-            self.set_status("Buffer is read-only");
-            anyhow::bail!("Buffer is read-only");
-        }
+        self.save_current_buffer(false)
+    }
+
+    /// Check whether the current buffer can be saved without writing it.
+    pub(crate) fn ensure_current_buffer_can_save(&mut self, force: bool) -> anyhow::Result<()> {
+        self.ensure_buffer_can_save(self.current_buffer_idx, force)
+    }
+
+    /// Save the current buffer, intentionally overwriting external disk changes.
+    pub fn save_force(&mut self) -> anyhow::Result<()> {
+        self.save_current_buffer(true)
+    }
+
+    fn save_current_buffer(&mut self, force: bool) -> anyhow::Result<()> {
+        self.ensure_buffer_can_save(self.current_buffer_idx, force)?;
         self.buffers[self.current_buffer_idx].save()?;
         self.status_message = Some(format!(
             "\"{}\" written",
@@ -5017,6 +5028,22 @@ impl Editor {
         // Update git diff after save (file now matches HEAD if no other changes)
         self.update_git_diff();
         self.refresh_explorer_git_statuses();
+        Ok(())
+    }
+
+    fn ensure_buffer_can_save(&mut self, buffer_idx: usize, force: bool) -> anyhow::Result<()> {
+        if self.buffers[buffer_idx].is_read_only() {
+            self.set_status("Buffer is read-only");
+            anyhow::bail!("Buffer is read-only");
+        }
+        if !force
+            && self.buffers[buffer_idx].dirty
+            && self.buffers[buffer_idx].has_external_changes()
+        {
+            let message = "Write blocked: file changed on disk; use :w! to overwrite".to_string();
+            self.set_status(message.clone());
+            anyhow::bail!(message);
+        }
         Ok(())
     }
 
@@ -5261,6 +5288,15 @@ impl Editor {
         self.save()
     }
 
+    /// Save to a specific file, intentionally overwriting external disk changes.
+    pub fn save_as_force(&mut self, path: std::path::PathBuf) -> anyhow::Result<()> {
+        if self.buffers[self.current_buffer_idx].is_read_only() {
+            anyhow::bail!("Buffer is read-only");
+        }
+        self.buffers[self.current_buffer_idx].set_file_path(path);
+        self.save_force()
+    }
+
     /// Reload the current file
     pub fn reload(&mut self) -> anyhow::Result<()> {
         if let Some(path) = self.buffers[self.current_buffer_idx].path.clone() {
@@ -5351,6 +5387,7 @@ impl Editor {
         let mut saved_count = 0;
         for i in 0..self.buffers.len() {
             if self.buffers[i].dirty && self.buffers[i].path.is_some() {
+                self.ensure_buffer_can_save(i, false)?;
                 self.buffers[i].save()?;
                 saved_count += 1;
             }
@@ -5370,6 +5407,7 @@ impl Editor {
 
         for i in 0..self.buffers.len() {
             if self.buffers[i].dirty && self.buffers[i].path.is_some() {
+                self.ensure_buffer_can_save(i, false)?;
                 // Try to format if format_on_save is enabled
                 if format_on_save {
                     if let Some(formatter_config) = self.get_formatter_for_buffer(i).cloned() {
@@ -5404,6 +5442,7 @@ impl Editor {
                     }
                 }
                 // Save the buffer
+                self.ensure_buffer_can_save(i, false)?;
                 self.buffers[i].save()?;
                 saved_count += 1;
             }
@@ -9932,7 +9971,7 @@ mod tests {
         CodeActionItem, CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity, TextEdit,
     };
     use std::path::{Path, PathBuf};
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
         let nanos = SystemTime::now()
@@ -9966,6 +10005,18 @@ mod tests {
             repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[])
                 .expect("initial commit");
         }
+    }
+
+    fn write_until_external_change_is_detected(editor: &Editor, path: &Path, content: &str) {
+        for _ in 0..20 {
+            std::fs::write(path, content).expect("write external change");
+            if editor.buffer().has_external_changes() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        panic!("external change was not detected for {}", path.display());
     }
 
     #[test]
@@ -10383,6 +10434,56 @@ mod tests {
             Some("Buffer is read-only")
         );
         assert!(!editor.buffer().dirty);
+    }
+
+    #[test]
+    fn save_rejects_modified_buffer_when_file_changed_externally() {
+        let tmp = unique_temp_dir("nevi_save_external_change_guard");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+
+        let err = editor.save().expect_err("save should reject stale buffer");
+
+        assert!(err.to_string().contains("changed on disk"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external edit\n"
+        );
+        assert!(editor.buffer().dirty);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn save_all_rejects_modified_buffer_when_file_changed_externally() {
+        let tmp = unique_temp_dir("nevi_save_all_external_change_guard");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+
+        let err = editor
+            .save_all()
+            .expect_err("save_all should reject stale buffer");
+
+        assert!(err.to_string().contains("changed on disk"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external edit\n"
+        );
+        assert!(editor.buffer().dirty);
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -2324,7 +2324,14 @@ vim_default = true
 [[commands.file]]
 key = ":w"
 action = "write"
-desc = "Write (save) current buffer"
+desc = "Write current buffer, refusing to overwrite external disk changes"
+status = "implemented"
+vim_default = true
+
+[[commands.file]]
+key = ":w!"
+action = "force_write"
+desc = "Force write current buffer, overwriting external disk changes"
 status = "implemented"
 vim_default = true
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9236,8 +9236,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             } else if editor.buffer().path.is_some() {
                 // Check if format_on_save is enabled
                 if editor.settings.editor.format_on_save {
+                    if let Err(e) = editor.ensure_current_buffer_can_save(false) {
+                        CommandResult::Error(format!("Error saving: {}", e))
                     // Check for external formatter first
-                    if let Some(formatter_config) = editor.get_current_formatter().cloned() {
+                    } else if let Some(formatter_config) = editor.get_current_formatter().cloned() {
                         // Use external formatter (blocking)
                         let formatter_name = &formatter_config.command;
                         let content = editor.buffer().content();
@@ -9304,6 +9306,22 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
                         Ok(()) => CommandResult::Ok,
                         Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
                     }
+                }
+            } else {
+                CommandResult::Error("No filename".to_string())
+            }
+        }
+
+        Command::ForceWrite(path) => {
+            if let Some(p) = path {
+                match editor.save_as_force(p) {
+                    Ok(()) => CommandResult::Ok,
+                    Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
+                }
+            } else if editor.buffer().path.is_some() {
+                match editor.save_force() {
+                    Ok(()) => CommandResult::Ok,
+                    Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
                 }
             } else {
                 CommandResult::Error("No filename".to_string())
@@ -9959,8 +9977,9 @@ mod tests {
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use crossterm::style::Color;
+    use std::path::Path;
     use std::path::PathBuf;
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     fn key(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
@@ -10705,6 +10724,18 @@ mod tests {
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
     }
 
+    fn write_until_external_change_is_detected(editor: &Editor, path: &Path, content: &str) {
+        for _ in 0..20 {
+            std::fs::write(path, content).expect("write external change");
+            if editor.buffer().has_external_changes() {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+
+        panic!("external change was not detected for {}", path.display());
+    }
+
     fn editor_with_explorer_rows(count: usize) -> Editor {
         let mut editor = Editor::default();
         editor.mode = Mode::Explorer;
@@ -10900,6 +10931,143 @@ mod tests {
         assert!(text.contains("show_leader_popup"));
         assert!(text.contains("explorer"));
         assert!(!text.starts_with("```toml"));
+    }
+
+    #[test]
+    fn force_write_command_overwrites_external_change() {
+        let tmp = unique_temp_dir("nevi_force_write_external_change");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+
+        execute_command(&mut editor, Command::ForceWrite(None));
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "local edit\n"
+        );
+        assert!(!editor.buffer().dirty);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn write_command_rejects_after_focus_external_change_warning() {
+        let tmp = unique_temp_dir("nevi_write_external_change_after_focus");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+        let warning = editor
+            .handle_focus_gained()
+            .expect("focus should report external change warning");
+        editor.set_status(warning);
+
+        execute_command(&mut editor, Command::Write(None));
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external edit\n"
+        );
+        assert!(editor.buffer().dirty);
+        assert!(
+            editor
+                .status_message
+                .as_deref()
+                .is_some_and(|message| message.contains("changed on disk")),
+            "expected changed-on-disk status, got {:?}",
+            editor.status_message
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn colon_write_key_sequence_rejects_after_external_change_warning() {
+        let tmp = unique_temp_dir("nevi_colon_write_external_change_after_focus");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+        let warning = editor
+            .handle_focus_gained()
+            .expect("focus should report external change warning");
+        editor.set_status(warning);
+
+        handle_key(&mut editor, key(':'));
+        handle_key(&mut editor, key('w'));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external edit\n"
+        );
+        assert!(editor.buffer().dirty);
+        assert!(
+            editor
+                .status_message
+                .as_deref()
+                .is_some_and(|message| message.contains("changed on disk")),
+            "expected changed-on-disk status, got {:?}",
+            editor.status_message
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn colon_write_rejects_external_change_before_format_on_save() {
+        let tmp = unique_temp_dir("nevi_colon_write_external_change_format_on_save");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.settings.editor.format_on_save = true;
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+        write_until_external_change_is_detected(&editor, &path, "external edit\n");
+
+        handle_key(&mut editor, key(':'));
+        handle_key(&mut editor, key('w'));
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external edit\n"
+        );
+        assert!(editor.buffer().dirty);
+        assert!(editor.pending_lsp_action.is_none());
+        assert!(!editor.save_after_format);
+        assert!(
+            editor
+                .status_message
+                .as_deref()
+                .is_some_and(|message| message.contains("Write blocked")),
+            "expected write-blocked status, got {:?}",
+            editor.status_message
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Block :w/:wa/:wq save paths when the current file changed on disk while the buffer has local edits
- Add :w! / :write! to explicitly force overwrite external disk changes
- Check the external-change guard before format-on-save queues formatter or LSP formatting
- Update docs and :Keymaps registry for :w and :w!

## Tests
- cargo test --quiet
- git diff --check

Manual check confirmed:
- :w blocks after an external disk edit, including with format_on_save = true
- :w! overwrites intentionally