### PR TITLE
feat: add current buffer fuzzy search

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -675,6 +675,7 @@ the popup, or press `Esc` to cancel.
 | `<leader>e` | Toggle file explorer |
 | `<leader>ff` | Find files (fuzzy finder) |
 | `<leader>fg` | Live grep (search in files) |
+| `<leader>fl` | Find lines in current buffer |
 | `<leader>sw` | Search word under cursor |
 | `<leader>fb` | Find buffers |
 | `<leader>ft` | Theme picker |
@@ -882,6 +883,7 @@ While typing an Ex command after `:`.
 | `:{n}` | Go to line n |
 | `:FindFiles` / `:ff` / `:files` | Open file finder |
 | `:LiveGrep` / `:grep` / `:rg` | Search in files |
+| `:BufferSearch` / `:FindLines` / `:Lines` / `:bl` | Find lines in current buffer |
 | `:SearchWord` / `:sw` | Search word under cursor |
 | `:FindBuffers` / `:fb` / `:buffers` | Open buffer finder |
 | `:FindDiagnostics` / `:diag` / `:fd` | Open diagnostics finder |

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ nevi file1.rs file2.rs
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
+- `<Space>fl` - Find lines in current buffer
 - `<Space>gc` - Git changes picker
 - `<Space>e` - File explorer
 - `<Space>tt` - Terminal picker
@@ -278,6 +279,7 @@ Press `<Space>` by itself to show available leader continuations. Set `[keymap] 
 |-----|--------|
 | `ff` | Find files |
 | `fg` | Live grep |
+| `fl` | Find lines in current buffer |
 | `sw` | Search word under cursor |
 | `fb` | Find buffers |
 | `ft` | Theme picker |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -53,6 +53,8 @@ pub enum Command {
     FindFiles,
     /// :FindBuffers - Open fuzzy finder for buffers
     FindBuffers,
+    /// :BufferSearch - Open fuzzy finder for lines in current buffer
+    BufferSearch,
     /// :LiveGrep - Open fuzzy finder for live grep
     LiveGrep,
     /// :SearchWord - Live grep with word under cursor
@@ -340,6 +342,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         command: "FindBuffers",
         aliases: &["findbuffers", "fb", "buffers"],
         description: "Open buffer finder",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "BufferSearch",
+        aliases: &["buffersearch", "findlines", "lines", "bl"],
+        description: "Find lines in current buffer",
         takes_args: false,
     },
     CommandSpec {
@@ -928,6 +936,9 @@ pub fn parse_command(input: &str) -> Command {
         // Fuzzy finder commands
         "FindFiles" | "findfiles" | "ff" | "files" => Command::FindFiles,
         "FindBuffers" | "findbuffers" | "fb" | "buffers" => Command::FindBuffers,
+        "BufferSearch" | "buffersearch" | "FindLines" | "findlines" | "Lines" | "lines" | "bl" => {
+            Command::BufferSearch
+        }
         "LiveGrep" | "livegrep" | "grep" | "rg" => Command::LiveGrep,
         "SearchWord" | "searchword" | "sw" => Command::SearchWord,
         "FindDiagnostics" | "finddiagnostics" | "diagnostics" | "diag" | "fd" => {
@@ -1803,6 +1814,17 @@ mod tests {
         assert!(matches!(parse_command("Keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keymaps"), Command::Keymaps));
         assert!(matches!(parse_command("keys"), Command::Keymaps));
+    }
+
+    #[test]
+    fn buffer_search_command_is_parseable() {
+        assert!(matches!(
+            parse_command("BufferSearch"),
+            Command::BufferSearch
+        ));
+        assert!(matches!(parse_command("FindLines"), Command::BufferSearch));
+        assert!(matches!(parse_command("Lines"), Command::BufferSearch));
+        assert!(matches!(parse_command("bl"), Command::BufferSearch));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -360,6 +360,11 @@ impl Default for KeymapSettings {
                     desc: Some("Live grep".to_string()),
                 },
                 LeaderMapping {
+                    key: "fl".to_string(),
+                    action: ":BufferSearch".to_string(),
+                    desc: Some("Find lines in current buffer".to_string()),
+                },
+                LeaderMapping {
                     key: "sw".to_string(),
                     action: ":SearchWord".to_string(),
                     desc: Some("Search word under cursor".to_string()),
@@ -1246,6 +1251,7 @@ fn default_config_template() -> &'static str {
 # <leader>e        - Toggle file explorer
 # <leader>ff       - Find files
 # <leader>fg       - Live grep
+# <leader>fl       - Find lines in current buffer
 # <leader>sw       - Search word under cursor (grep)
 # <leader>fb       - Find buffers
 # <leader>ft       - Theme picker

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -9351,6 +9351,25 @@ impl Editor {
         self.mode = Mode::Finder;
     }
 
+    /// Open the fuzzy finder with lines from the current buffer.
+    pub fn open_finder_buffer_lines(&mut self) {
+        let buffer_idx = self.current_buffer_idx;
+        let buffer = &self.buffers[buffer_idx];
+        let path = buffer.path.clone().unwrap_or_default();
+        let lines: Vec<(usize, String)> = (0..buffer.len_lines())
+            .map(|line_idx| {
+                let text = buffer
+                    .line(line_idx)
+                    .map(|line| line.to_string().trim_end_matches('\n').to_string())
+                    .unwrap_or_default();
+                (line_idx, text)
+            })
+            .collect();
+
+        self.finder.open_buffer_lines(buffer_idx, path, lines);
+        self.mode = Mode::Finder;
+    }
+
     /// Open the fuzzy finder in grep mode (live search)
     pub fn open_finder_grep(&mut self) {
         let root = self.working_directory();

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -32,6 +32,7 @@ pub enum FinderMode {
     Files,
     Grep,
     Buffers,
+    BufferLines,
     Diagnostics,
     Harpoon,
     Marks,
@@ -347,6 +348,38 @@ impl FuzzyFinder {
                     FinderItem::new(format!("{}: {}", idx + 1, name), path).with_buffer_idx(idx);
                 item.score = idx as u32;
                 item
+            })
+            .collect();
+        self.filtered = (0..self.items.len()).collect();
+        self.populated = true;
+    }
+
+    pub fn open_buffer_lines(
+        &mut self,
+        buffer_idx: usize,
+        buffer_path: PathBuf,
+        lines: Vec<(usize, String)>,
+    ) {
+        self.mode = FinderMode::BufferLines;
+        self.input_mode = FinderInputMode::Insert;
+        self.query.clear();
+        self.cursor = 0;
+        self.selected = 0;
+        self.scroll_offset = 0;
+        self.clear_preview_cache();
+        self.cancel_grep_search();
+
+        self.items = lines
+            .into_iter()
+            .map(|(line_idx, text)| {
+                FinderItem::new(
+                    format!("{:>4}: {}", line_idx + 1, text),
+                    buffer_path.clone(),
+                )
+                .with_buffer_idx(buffer_idx)
+                .with_line(line_idx + 1)
+                .with_col(0)
+                .with_icon("LN")
             })
             .collect();
         self.filtered = (0..self.items.len()).collect();
@@ -1195,6 +1228,39 @@ mod tests {
         assert!(
             !finder.mode_supports_preview(),
             "keymaps mode has no preview pane"
+        );
+    }
+
+    #[test]
+    fn open_buffer_lines_sets_line_metadata_and_fuzzy_filters() {
+        let mut finder = FuzzyFinder::new();
+        finder.open_buffer_lines(
+            2,
+            PathBuf::from("src/main.rs"),
+            vec![
+                (0, "fn main() {".to_string()),
+                (1, "    println!(\"hello\");".to_string()),
+                (2, "}".to_string()),
+            ],
+        );
+
+        assert_eq!(finder.mode, FinderMode::BufferLines);
+        assert_eq!(finder.filtered.len(), 3);
+        assert_eq!(
+            finder
+                .selected_item()
+                .map(|item| (item.buffer_idx, item.line, item.col)),
+            Some((Some(2), Some(1), Some(0)))
+        );
+
+        for ch in "print".chars() {
+            finder.insert_char(ch);
+        }
+
+        assert_eq!(finder.filtered.len(), 1);
+        assert_eq!(
+            finder.selected_item().map(|item| item.display.as_str()),
+            Some("   2:     println!(\"hello\");")
         );
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5069,6 +5069,7 @@ impl Terminal {
             crate::finder::FinderMode::Files => " Find Files ",
             crate::finder::FinderMode::Grep => " Live Grep ",
             crate::finder::FinderMode::Buffers => " Buffers ",
+            crate::finder::FinderMode::BufferLines => " Buffer Lines ",
             crate::finder::FinderMode::Diagnostics => " Diagnostics ",
             crate::finder::FinderMode::Harpoon => " Harpoon ",
             crate::finder::FinderMode::Marks => " Marks ",
@@ -8418,6 +8419,11 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
                 } else if let Some(buf_idx) = item.buffer_idx {
                     if !editor.switch_to_buffer(buf_idx) {
                         editor.set_status("Buffer not found");
+                    } else if let Some(line_num) = item.line {
+                        editor.cursor.line = line_num.saturating_sub(1);
+                        editor.cursor.col = item.col.unwrap_or(0);
+                        editor.clamp_cursor();
+                        editor.scroll_to_cursor();
                     }
                 } else if item
                     .git_status
@@ -9527,6 +9533,11 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
 
         Command::FindBuffers => {
             editor.open_finder_buffers();
+            CommandResult::Ok
+        }
+
+        Command::BufferSearch => {
+            editor.open_finder_buffer_lines();
             CommandResult::Ok
         }
 
@@ -11517,6 +11528,24 @@ mod tests {
         assert_eq!(editor.current_buffer_index(), 0);
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn finder_enter_jumps_to_selected_buffer_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha\nneedle here\nomega\n");
+        editor.open_finder_buffer_lines();
+
+        for ch in "needle".chars() {
+            editor.finder.insert_char(ch);
+        }
+        handle_key(
+            &mut editor,
+            KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
+        );
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add :BufferSearch / :FindLines / :Lines / :bl for fuzzy-searching lines in the current buffer
- add default <leader>fl mapping and generated config/docs references
- jump to the selected current-buffer line when accepting the finder item

## Tests
- cargo test --quiet
- git diff --check