### PR TITLE
feat: add previewed project replace

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -917,6 +917,15 @@ While typing an Ex command after `:`.
 | `:noh` / `:nohlsearch` | Clear search highlights |
 | `:s/{pattern}/{replacement}/` | Substitute on current line |
 | `:%s/{pattern}/{replacement}/` | Substitute in entire file |
+| `:ProjectReplace/{pattern}/{replacement}/[g]` / `:PReplace/{pattern}/{replacement}/[g]` | Preview project-wide literal replace in a read-only `[project-replace]` buffer |
+| `:ProjectReplaceApply` / `:PReplaceApply` | Apply the last project replace preview |
+
+`ProjectReplace` is preview-first. It does not write files until
+`:ProjectReplaceApply` is run. V1 uses literal matching, respects the file
+finder ignore settings, skips non-UTF-8 files, and blocks apply if a matched
+file has unsaved changes or changed on disk after the preview was created. Use
+an alternate delimiter such as `#` when the pattern or replacement contains `/`,
+for example `:ProjectReplace#/api/v1#/api/v2#g`.
 
 ### LSP
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A fast, native terminal editor where your existing vim/neovim muscle memory just
 - **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
 - **Theme selection** - Multiple built-in colorschemes with easy switching
 - **Fuzzy file finder** - Telescope-style file and content search
+- **Previewed project replace** - Project-wide literal replace with a read-only preview and explicit apply step
 - **Keybinding cheatsheet** - Searchable `:Keymaps` picker (`<Space>fk`) listing every binding with a description
 - **GitHub Copilot integration** - AI-powered completions
 - **File explorer** - Built-in tree view
@@ -148,6 +149,8 @@ nevi file1.rs file2.rs
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
+- `:ProjectReplace/{pattern}/{replacement}/g` - Preview project-wide literal replace
+- `:ProjectReplaceApply` - Apply the last project replace preview
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
 - `<Space>fl` - Find lines in current buffer

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -82,6 +82,17 @@ pub enum Command {
         /// Global flag (replace all on line vs first only)
         global: bool,
     },
+    /// :ProjectReplace/pattern/replacement/flags - Preview project-wide replace
+    ProjectReplace {
+        /// Search pattern
+        pattern: String,
+        /// Replacement string
+        replacement: String,
+        /// Global flag (replace all on line vs first only)
+        global: bool,
+    },
+    /// :ProjectReplaceApply - Apply the last project-wide replace preview
+    ProjectReplaceApply,
     /// :new or :touch - Create a new file
     NewFile(PathBuf),
     /// :delete or :rm - Delete current file (requires confirmation)
@@ -411,6 +422,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         aliases: &[],
         description: "Substitute in entire file",
         takes_args: true,
+    },
+    CommandSpec {
+        command: "ProjectReplace",
+        aliases: &["projectreplace", "PReplace", "preplace"],
+        description: "Preview project-wide replace",
+        takes_args: true,
+    },
+    CommandSpec {
+        command: "ProjectReplaceApply",
+        aliases: &["projectreplaceapply", "PReplaceApply", "preplaceapply"],
+        description: "Apply last project replace preview",
+        takes_args: false,
     },
     CommandSpec {
         command: "new",
@@ -883,6 +906,11 @@ pub fn parse_command(input: &str) -> Command {
         return sub_cmd;
     }
 
+    // Handle project replace command: ProjectReplace/pattern/replacement/flags
+    if let Some(replace_cmd) = parse_project_replace_command(input) {
+        return replace_cmd;
+    }
+
     // Split into command and arguments
     let mut parts = input.splitn(2, char::is_whitespace);
     let cmd = parts.next().unwrap_or("");
@@ -959,6 +987,11 @@ pub fn parse_command(input: &str) -> Command {
 
         // Clear search highlight
         "noh" | "nohlsearch" => Command::NoHighlight,
+
+        // Project-wide replace
+        "ProjectReplaceApply" | "projectreplaceapply" | "PReplaceApply" | "preplaceapply" => {
+            Command::ProjectReplaceApply
+        }
 
         // File management commands
         "new" | "touch" => {
@@ -1130,6 +1163,35 @@ fn parse_substitute_command(input: &str) -> Option<Command> {
         pattern,
         replacement,
         global,
+    })
+}
+
+/// Parse a project replace command: ProjectReplace/pattern/replacement/flags
+fn parse_project_replace_command(input: &str) -> Option<Command> {
+    let rest = ["ProjectReplace", "projectreplace", "PReplace", "preplace"]
+        .iter()
+        .find_map(|prefix| input.strip_prefix(prefix))?
+        .trim_start();
+
+    if rest.is_empty() {
+        return None;
+    }
+
+    let delimiter = rest.chars().next()?;
+    let rest = &rest[delimiter.len_utf8()..];
+    let parts = split_by_delimiter(rest, delimiter);
+    if parts.len() < 2 {
+        return None;
+    }
+
+    let pattern = unescape_delimiter(&parts[0], delimiter);
+    let replacement = unescape_delimiter(&parts[1], delimiter);
+    let flags = if parts.len() > 2 { &parts[2] } else { "" };
+
+    Some(Command::ProjectReplace {
+        pattern,
+        replacement,
+        global: flags.contains('g'),
     })
 }
 
@@ -1834,6 +1896,50 @@ mod tests {
         assert!(matches!(parse_command("FindLines"), Command::BufferSearch));
         assert!(matches!(parse_command("Lines"), Command::BufferSearch));
         assert!(matches!(parse_command("bl"), Command::BufferSearch));
+    }
+
+    #[test]
+    fn project_replace_commands_are_parseable_and_listed() {
+        match parse_command("ProjectReplace/foo/bar/g") {
+            Command::ProjectReplace {
+                pattern,
+                replacement,
+                global,
+            } => {
+                assert_eq!(pattern, "foo");
+                assert_eq!(replacement, "bar");
+                assert!(global);
+            }
+            other => panic!("expected ProjectReplace command, got {other:?}"),
+        }
+
+        match parse_command("PReplace#/api/v1#/api/v2#g") {
+            Command::ProjectReplace {
+                pattern,
+                replacement,
+                global,
+            } => {
+                assert_eq!(pattern, "/api/v1");
+                assert_eq!(replacement, "/api/v2");
+                assert!(global);
+            }
+            other => panic!("expected ProjectReplace command, got {other:?}"),
+        }
+
+        assert!(matches!(
+            parse_command("ProjectReplaceApply"),
+            Command::ProjectReplaceApply
+        ));
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":ProjectReplace"),
+            "expected :ProjectReplace in command cheatsheet rows"
+        );
+        assert!(
+            rows.iter().any(|(name, _)| name == ":ProjectReplaceApply"),
+            "expected :ProjectReplaceApply in command cheatsheet rows"
+        );
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1036,6 +1036,8 @@ pub struct Editor {
     pub theme_picker: Option<ThemePicker>,
     /// Floating rendered Markdown preview state.
     pub markdown_preview: Option<crate::markdown_preview::MarkdownPreviewState>,
+    /// Last project-wide replace preview, pending explicit apply.
+    project_replace_preview: Option<crate::project_replace::ProjectReplacePreview>,
     /// Marks for navigation (m{a-z}, '{a-z}, `{a-z})
     pub marks: Marks,
     /// Last visual selection for gv command
@@ -1531,6 +1533,7 @@ impl Editor {
             theme_manager,
             theme_picker: None,
             markdown_preview: None,
+            project_replace_preview: None,
             marks: Marks::new(),
             last_visual_selection: None,
             pending_visual_block_edit: None,
@@ -1730,6 +1733,118 @@ impl Editor {
     pub fn open_health_report(&mut self) {
         let report = crate::health::collect_health_report(&self.settings, &self.languages_config);
         self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
+    }
+
+    /// Build a project-wide replace preview and open it as a read-only buffer.
+    pub fn preview_project_replace(
+        &mut self,
+        pattern: &str,
+        replacement: &str,
+        global: bool,
+    ) -> Result<usize, String> {
+        let root = self.working_directory();
+        let files = crate::finder::FilePicker::from_settings(&self.settings.finder)
+            .list_files(&root)
+            .into_iter()
+            .map(|item| item.path);
+        let preview = crate::project_replace::build_project_replace_preview(
+            &root,
+            files,
+            pattern,
+            replacement,
+            global,
+            crate::project_replace::PROJECT_REPLACE_MAX_MATCHES,
+        )?;
+        let replacement_count = preview.total_replacements();
+        let rendered = preview.render_markdown();
+        self.project_replace_preview = if replacement_count > 0 {
+            Some(preview)
+        } else {
+            None
+        };
+        self.open_virtual_read_only_buffer(
+            "[project-replace]",
+            &rendered,
+            Some("project-replace.md"),
+        );
+        Ok(replacement_count)
+    }
+
+    /// Apply the last project-wide replace preview.
+    pub fn apply_project_replace_preview(&mut self) -> Result<usize, String> {
+        let preview = self
+            .project_replace_preview
+            .clone()
+            .ok_or_else(|| "No project replace preview to apply".to_string())?;
+
+        if preview.truncated {
+            return Err(
+                "Project replace preview was truncated; refine the pattern before applying"
+                    .to_string(),
+            );
+        }
+
+        let replacement_count = preview.total_replacements();
+        if replacement_count == 0 {
+            return Err("Project replace preview has no replacements".to_string());
+        }
+
+        for file in &preview.files {
+            for buffer in &self.buffers {
+                if buffer.dirty && buffer.path.as_ref() == Some(&file.path) {
+                    return Err(format!(
+                        "Project replace blocked: {} has unsaved changes",
+                        project_replace_display_path(&preview.root, &file.path)
+                    ));
+                }
+            }
+        }
+
+        for file in &preview.files {
+            let current = std::fs::read_to_string(&file.path).map_err(|err| {
+                format!(
+                    "Project replace blocked: failed to read {}: {}",
+                    project_replace_display_path(&preview.root, &file.path),
+                    err
+                )
+            })?;
+            if current != file.original_content {
+                return Err(format!(
+                    "Project replace blocked: {} changed since preview",
+                    project_replace_display_path(&preview.root, &file.path)
+                ));
+            }
+        }
+
+        for file in &preview.files {
+            std::fs::write(&file.path, &file.new_content).map_err(|err| {
+                format!(
+                    "Project replace failed writing {}: {}",
+                    project_replace_display_path(&preview.root, &file.path),
+                    err
+                )
+            })?;
+        }
+
+        for file in &preview.files {
+            for idx in 0..self.buffers.len() {
+                if self.buffers[idx].path.as_ref() == Some(&file.path) && !self.buffers[idx].dirty {
+                    self.buffers[idx].reload().map_err(|err| {
+                        format!(
+                            "Project replace wrote {}, but reload failed: {}",
+                            project_replace_display_path(&preview.root, &file.path),
+                            err
+                        )
+                    })?;
+                    self.reset_undo_stack_for_buffer(idx);
+                }
+            }
+        }
+
+        self.project_replace_preview = None;
+        self.refresh_git_state();
+        self.sync_syntax_to_current_buffer();
+        Ok(replacement_count)
     }
 
     /// Open named content that is not backed by a file and cannot be edited.
@@ -9982,6 +10097,13 @@ impl Default for Editor {
     }
 }
 
+fn project_replace_display_path(root: &std::path::Path, path: &std::path::Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{Editor, JumpList, Mode, SplitLayout};
@@ -10453,6 +10575,115 @@ mod tests {
             Some("Buffer is read-only")
         );
         assert!(!editor.buffer().dirty);
+    }
+
+    #[test]
+    fn project_replace_preview_opens_read_only_buffer_without_mutating_files() {
+        let tmp = unique_temp_dir("nevi_project_replace_editor_preview");
+        std::fs::create_dir_all(tmp.join("src")).expect("create temp tree");
+        let first = tmp.join("src/first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "old one\nold old\n").expect("write first");
+        std::fs::write(&second, "keep old\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(tmp.clone());
+
+        let count = editor
+            .preview_project_replace("old", "new", true)
+            .expect("preview project replace");
+
+        assert_eq!(count, 4);
+        assert_eq!(editor.buffer().display_name(), "[project-replace]");
+        assert!(editor.buffer().is_read_only());
+        let content = editor.buffer().content();
+        assert!(content.contains("# Project Replace Preview"));
+        assert!(content.contains("src/first.txt"));
+        assert!(content.contains("second.txt"));
+        assert!(content.contains("Apply with `:ProjectReplaceApply`"));
+        assert_eq!(
+            std::fs::read_to_string(&first).expect("read first"),
+            "old one\nold old\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&second).expect("read second"),
+            "keep old\n"
+        );
+    }
+
+    #[test]
+    fn project_replace_apply_writes_last_preview() {
+        let tmp = unique_temp_dir("nevi_project_replace_editor_apply");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "old one\nold old\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(tmp.clone());
+
+        editor
+            .preview_project_replace("old", "new", true)
+            .expect("preview project replace");
+        let count = editor
+            .apply_project_replace_preview()
+            .expect("apply project replace");
+
+        assert_eq!(count, 3);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "new one\nnew new\n"
+        );
+    }
+
+    #[test]
+    fn project_replace_apply_blocks_dirty_open_matching_buffer() {
+        let tmp = unique_temp_dir("nevi_project_replace_editor_dirty");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "old one\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(tmp.clone());
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("old local edit\n");
+
+        editor
+            .preview_project_replace("old", "new", true)
+            .expect("preview project replace");
+        let err = editor
+            .apply_project_replace_preview()
+            .expect_err("dirty matching buffer should block apply");
+
+        assert!(err.contains("unsaved changes"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "old one\n"
+        );
+    }
+
+    #[test]
+    fn project_replace_apply_blocks_file_changed_since_preview() {
+        let tmp = unique_temp_dir("nevi_project_replace_editor_stale");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "old one\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(tmp.clone());
+        editor
+            .preview_project_replace("old", "new", true)
+            .expect("preview project replace");
+        std::fs::write(&path, "external old edit\n").expect("write external edit");
+
+        let err = editor
+            .apply_project_replace_preview()
+            .expect_err("stale preview should block apply");
+
+        assert!(err.contains("changed since preview"));
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "external old edit\n"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod input;
 pub mod lsp;
 pub mod markdown_preview;
 pub mod perf;
+pub mod project_replace;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;

--- a/src/project_replace.rs
+++ b/src/project_replace.rs
@@ -1,0 +1,319 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const PROJECT_REPLACE_MAX_MATCHES: usize = 5_000;
+
+#[derive(Clone, Debug)]
+pub struct ProjectReplacePreview {
+    pub root: PathBuf,
+    pub pattern: String,
+    pub replacement: String,
+    pub global: bool,
+    pub files_scanned: usize,
+    pub skipped_files: usize,
+    pub truncated: bool,
+    pub files: Vec<ProjectReplaceFile>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProjectReplaceFile {
+    pub path: PathBuf,
+    pub original_content: String,
+    pub new_content: String,
+    pub line_previews: Vec<ProjectReplaceLinePreview>,
+    pub replacements: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProjectReplaceLinePreview {
+    pub line_number: usize,
+    pub before: String,
+    pub after: String,
+    pub replacements: usize,
+}
+
+impl ProjectReplacePreview {
+    pub fn changed_file_count(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn total_replacements(&self) -> usize {
+        self.files.iter().map(|file| file.replacements).sum()
+    }
+
+    pub fn render_markdown(&self) -> String {
+        let mut output = String::new();
+        output.push_str("# Project Replace Preview\n\n");
+        output.push_str(&format!("Pattern: `{}`\n", self.pattern));
+        output.push_str(&format!("Replacement: `{}`\n", self.replacement));
+        output.push_str(&format!("Scope: `{}`\n", self.root.display()));
+        output.push_str(&format!(
+            "Mode: {}\n",
+            if self.global {
+                "all matches per line"
+            } else {
+                "first match per line"
+            }
+        ));
+        output.push_str(&format!("Files scanned: {}\n", self.files_scanned));
+        output.push_str(&format!("Files skipped: {}\n", self.skipped_files));
+        output.push_str(&format!("Files changed: {}\n", self.changed_file_count()));
+        output.push_str(&format!("Replacements: {}\n\n", self.total_replacements()));
+
+        if self.truncated {
+            output.push_str(
+                "Preview truncated before all matches were collected. Apply is disabled.\n\n",
+            );
+        } else if self.total_replacements() > 0 {
+            output.push_str("Apply with `:ProjectReplaceApply`.\n\n");
+        } else {
+            output.push_str("No matches found.\n\n");
+        }
+
+        for file in &self.files {
+            output.push_str(&format!("## {}\n", display_path(&self.root, &file.path)));
+            output.push_str(&format!("{} replacement(s)\n\n", file.replacements));
+
+            for line in &file.line_previews {
+                output.push_str(&format!(
+                    "- line {}: {} replacement(s)\n",
+                    line.line_number, line.replacements
+                ));
+                output.push_str(&format!("  before: `{}`\n", line.before));
+                output.push_str(&format!("  after:  `{}`\n", line.after));
+            }
+            output.push('\n');
+        }
+
+        output
+    }
+}
+
+pub fn build_project_replace_preview(
+    root: &Path,
+    files: impl IntoIterator<Item = PathBuf>,
+    pattern: &str,
+    replacement: &str,
+    global: bool,
+    max_matches: usize,
+) -> Result<ProjectReplacePreview, String> {
+    if pattern.is_empty() {
+        return Err("ProjectReplace requires a non-empty pattern".to_string());
+    }
+
+    let mut preview = ProjectReplacePreview {
+        root: root.to_path_buf(),
+        pattern: pattern.to_string(),
+        replacement: replacement.to_string(),
+        global,
+        files_scanned: 0,
+        skipped_files: 0,
+        truncated: false,
+        files: Vec::new(),
+    };
+
+    for path in files {
+        if preview.total_replacements() >= max_matches {
+            preview.truncated = true;
+            break;
+        }
+
+        let Ok(original_content) = fs::read_to_string(&path) else {
+            preview.skipped_files += 1;
+            continue;
+        };
+        preview.files_scanned += 1;
+
+        let remaining = max_matches.saturating_sub(preview.total_replacements());
+        let replaced = replace_content(&original_content, pattern, replacement, global, remaining);
+        if replaced.truncated {
+            preview.truncated = true;
+        }
+
+        if replaced.replacements > 0 {
+            let new_content = if replaced.truncated {
+                original_content.clone()
+            } else {
+                replaced.content
+            };
+            preview.files.push(ProjectReplaceFile {
+                path,
+                original_content,
+                new_content,
+                line_previews: replaced.line_previews,
+                replacements: replaced.replacements,
+            });
+        }
+
+        if preview.truncated {
+            break;
+        }
+    }
+
+    Ok(preview)
+}
+
+struct ContentReplacement {
+    content: String,
+    line_previews: Vec<ProjectReplaceLinePreview>,
+    replacements: usize,
+    truncated: bool,
+}
+
+fn replace_content(
+    content: &str,
+    pattern: &str,
+    replacement: &str,
+    global: bool,
+    max_matches: usize,
+) -> ContentReplacement {
+    let mut output = String::with_capacity(content.len());
+    let mut line_previews = Vec::new();
+    let mut replacements = 0;
+    let mut truncated = false;
+
+    for (line_index, line) in content.split_inclusive('\n').enumerate() {
+        let (line_body, line_ending) = split_line_ending(line);
+        let (new_body, count) = replace_line_literal(line_body, pattern, replacement, global);
+
+        if count > 0 {
+            if replacements + count > max_matches {
+                truncated = true;
+                output.push_str(line);
+                break;
+            }
+
+            line_previews.push(ProjectReplaceLinePreview {
+                line_number: line_index + 1,
+                before: line_body.to_string(),
+                after: new_body.clone(),
+                replacements: count,
+            });
+            replacements += count;
+            output.push_str(&new_body);
+            output.push_str(line_ending);
+        } else {
+            output.push_str(line);
+        }
+    }
+
+    ContentReplacement {
+        content: output,
+        line_previews,
+        replacements,
+        truncated,
+    }
+}
+
+fn replace_line_literal(
+    line: &str,
+    pattern: &str,
+    replacement: &str,
+    global: bool,
+) -> (String, usize) {
+    if global {
+        let count = line.matches(pattern).count();
+        if count == 0 {
+            (line.to_string(), 0)
+        } else {
+            (line.replace(pattern, replacement), count)
+        }
+    } else if let Some(_) = line.find(pattern) {
+        (line.replacen(pattern, replacement, 1), 1)
+    } else {
+        (line.to_string(), 0)
+    }
+}
+
+fn split_line_ending(line: &str) -> (&str, &str) {
+    if let Some(stripped) = line.strip_suffix("\r\n") {
+        (stripped, "\r\n")
+    } else if let Some(stripped) = line.strip_suffix('\n') {
+        (stripped, "\n")
+    } else {
+        (line, "")
+    }
+}
+
+fn display_path(root: &Path, path: &Path) -> String {
+    path.strip_prefix(root)
+        .unwrap_or(path)
+        .to_string_lossy()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn project_replace_preview_does_not_mutate_files() {
+        let root = unique_temp_dir("nevi_project_replace_preview");
+        fs::create_dir_all(root.join("src")).expect("create temp tree");
+        let first = root.join("src/first.txt");
+        let second = root.join("second.txt");
+        fs::write(&first, "old one\nold old\n").expect("write first");
+        fs::write(&second, "keep old\n").expect("write second");
+
+        let preview = build_project_replace_preview(
+            &root,
+            vec![first.clone(), second.clone()],
+            "old",
+            "new",
+            true,
+            100,
+        )
+        .expect("build preview");
+
+        assert_eq!(preview.changed_file_count(), 2);
+        assert_eq!(preview.total_replacements(), 4);
+        assert!(!preview.truncated);
+
+        let rendered = preview.render_markdown();
+        assert!(rendered.contains("# Project Replace Preview"));
+        assert!(rendered.contains("Pattern: `old`"));
+        assert!(rendered.contains("Replacement: `new`"));
+        assert!(rendered.contains("src/first.txt"));
+        assert!(rendered.contains("second.txt"));
+        assert!(rendered.contains("Apply with `:ProjectReplaceApply`"));
+
+        assert_eq!(
+            fs::read_to_string(&first).expect("read first"),
+            "old one\nold old\n"
+        );
+        assert_eq!(
+            fs::read_to_string(&second).expect("read second"),
+            "keep old\n"
+        );
+    }
+
+    #[test]
+    fn project_replace_preview_marks_truncated_when_match_cap_is_hit() {
+        let root = unique_temp_dir("nevi_project_replace_truncated");
+        fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("large.txt");
+        fs::write(&path, "old old old\n").expect("write file");
+
+        let preview =
+            build_project_replace_preview(&root, vec![path.clone()], "old", "new", true, 2)
+                .expect("build preview");
+
+        assert!(preview.truncated);
+        assert!(preview.render_markdown().contains("Apply is disabled"));
+        assert_eq!(
+            fs::read_to_string(&path).expect("read file"),
+            "old old old\n"
+        );
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9613,6 +9613,28 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
+        Command::ProjectReplace {
+            pattern,
+            replacement,
+            global,
+        } => match editor.preview_project_replace(&pattern, &replacement, global) {
+            Ok(count) => {
+                if count > 0 {
+                    CommandResult::Message(format!("Previewing {} project replacement(s)", count))
+                } else {
+                    CommandResult::Message(format!("Pattern not found in project: {}", pattern))
+                }
+            }
+            Err(message) => CommandResult::Error(message),
+        },
+
+        Command::ProjectReplaceApply => match editor.apply_project_replace_preview() {
+            Ok(count) => {
+                CommandResult::Message(format!("Applied {} project replacement(s)", count))
+            }
+            Err(message) => CommandResult::Error(message),
+        },
+
         Command::NewFile(path) => {
             // Resolve path relative to project root
             let full_path = if path.is_absolute() {


### PR DESCRIPTION
## Summary
- Add preview-first project-wide literal replace with `:ProjectReplace/{pattern}/{replacement}/[g]`.
- Add `:ProjectReplaceApply` with guards for dirty open buffers, stale disk contents, and truncated previews.
- Document the workflow in `README.md` and `KEYBINDINGS.md`.


