### PR TITLE
feat: add in-memory flight recorder

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -943,6 +943,7 @@ for example `:ProjectReplace#/api/v1#/api/v2#g`.
 | `:Theme {name}` / `:theme {name}` / `:colorscheme {name}` | Set theme |
 | `:LazyGit` / `:lg` | Open lazygit |
 | `:checkhealth` / `:CheckHealth` / `:Health` | Open read-only `[health]` report with config, keymap, profiling, LSP, and external tools |
+| `:FlightRecorder` / `:WhySlow` / `:flight` | Open read-only `[flight-recorder]` report with recent in-memory timing events |
 | `:ConfigOpen` / `:config` / `:configopen` | Open the user config file, creating it first if needed |
 | `:ConfigDefaults` / `:configdefaults` | Open read-only `[config-defaults]` buffer with latest built-in default config |
 | `:!{command}` | Run external shell command |

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ nevi file1.rs file2.rs
 - `:q` - Quit
 - `:wq` - Save and quit
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
+- `:FlightRecorder` / `:WhySlow` - Open recent in-memory timing report in a read-only `[flight-recorder]` buffer
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
@@ -353,8 +354,12 @@ Contributions are welcome! Please feel free to submit issues and pull requests.
 
 ### Performance Profiling
 
-Profiling is opt-in and disabled by default. To capture hot-path timings while
-using Nevi locally:
+Nevi keeps a small in-memory flight recorder for recent hot-path timings. Run
+`:FlightRecorder` or `:WhySlow` to open a read-only `[flight-recorder]` buffer
+with recent render, input, syntax, LSP, finder, and terminal timing events.
+
+Verbose file profiling is opt-in and disabled by default. To capture raw timing
+events while using Nevi locally:
 
 ```bash
 NEVI_PROFILE=1 cargo run --release -- path/to/file

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -157,6 +157,8 @@ pub enum Command {
     Keymaps,
     /// :checkhealth - Open the editor health report
     CheckHealth,
+    /// :FlightRecorder - Open recent performance timing report
+    FlightRecorder,
     /// :ConfigOpen - Open the user config file
     ConfigOpen,
     /// :ConfigDefaults - Open the latest default config template
@@ -640,6 +642,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "FlightRecorder",
+        aliases: &["flightrecorder", "flight", "WhySlow", "whyslow"],
+        description: "Open recent performance timing report",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "ConfigOpen",
         aliases: &["configopen", "config", "ConfigEdit", "configedit"],
         description: "Open user config file",
@@ -1085,6 +1093,9 @@ pub fn parse_command(input: &str) -> Command {
         "Themes" | "themes" => Command::Themes,
         "Keymaps" | "keymaps" | "keys" => Command::Keymaps,
         "checkhealth" | "CheckHealth" | "Health" | "health" => Command::CheckHealth,
+        "FlightRecorder" | "flightrecorder" | "flight" | "WhySlow" | "whyslow" => {
+            Command::FlightRecorder
+        }
         "ConfigOpen" | "configopen" | "config" | "ConfigEdit" | "configedit" => Command::ConfigOpen,
         "ConfigDefaults" | "configdefaults" | "defaults" => Command::ConfigDefaults,
 
@@ -1958,6 +1969,23 @@ mod tests {
         assert!(
             rows.iter().any(|(name, _)| name == ":checkhealth"),
             "expected :checkhealth in command cheatsheet rows"
+        );
+    }
+
+    #[test]
+    fn flight_recorder_commands_are_parseable_and_listed() {
+        assert!(matches!(
+            parse_command("FlightRecorder"),
+            Command::FlightRecorder
+        ));
+        assert!(matches!(parse_command("flight"), Command::FlightRecorder));
+        assert!(matches!(parse_command("WhySlow"), Command::FlightRecorder));
+        assert!(matches!(parse_command("whyslow"), Command::FlightRecorder));
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":FlightRecorder"),
+            "expected :FlightRecorder in command cheatsheet rows"
         );
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1036,6 +1036,8 @@ pub struct Editor {
     pub theme_picker: Option<ThemePicker>,
     /// Floating rendered Markdown preview state.
     pub markdown_preview: Option<crate::markdown_preview::MarkdownPreviewState>,
+    /// Recent in-memory performance timing events.
+    pub flight_recorder: crate::perf::FlightRecorder,
     /// Last project-wide replace preview, pending explicit apply.
     project_replace_preview: Option<crate::project_replace::ProjectReplacePreview>,
     /// Marks for navigation (m{a-z}, '{a-z}, `{a-z})
@@ -1533,6 +1535,7 @@ impl Editor {
             theme_manager,
             theme_picker: None,
             markdown_preview: None,
+            flight_recorder: crate::perf::FlightRecorder::default(),
             project_replace_preview: None,
             marks: Marks::new(),
             last_visual_selection: None,
@@ -1733,6 +1736,16 @@ impl Editor {
     pub fn open_health_report(&mut self) {
         let report = crate::health::collect_health_report(&self.settings, &self.languages_config);
         self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
+    }
+
+    /// Open recent performance timings in a read-only virtual buffer.
+    pub fn open_flight_recorder_report(&mut self) {
+        let report = self.flight_recorder.render_report();
+        self.open_virtual_read_only_buffer(
+            "[flight-recorder]",
+            &report,
+            Some("flight-recorder.md"),
+        );
     }
 
     /// Build a project-wide replace preview and open it as a read-only buffer.
@@ -10543,6 +10556,26 @@ mod tests {
         assert!(content.contains("## Keymaps"));
         assert!(content.contains("## Performance"));
         assert!(content.contains("## LSP"));
+    }
+
+    #[test]
+    fn flight_recorder_report_opens_as_read_only_virtual_buffer() {
+        let mut editor = Editor::default();
+        editor
+            .flight_recorder
+            .record("render", Duration::from_micros(18_000));
+
+        editor.open_flight_recorder_report();
+
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[flight-recorder]");
+        assert!(editor.buffer().is_read_only());
+        assert!(editor.buffer().path.is_none());
+        assert!(!editor.buffer().dirty);
+        let content = editor.buffer().content();
+        assert!(content.contains("# Nevi Flight Recorder"));
+        assert!(content.contains("render"));
+        assert!(content.contains("slow"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,9 +181,10 @@ fn main() -> anyhow::Result<()> {
             }
         };
     }
-    macro_rules! profile_metric {
-        ($stats:expr, $file:expr, $name:literal, $duration:expr) => {{
+    macro_rules! record_metric {
+        ($editor:expr, $stats:expr, $file:expr, $name:literal, $duration:expr) => {{
             let elapsed = $duration;
+            $editor.flight_recorder.record($name, elapsed);
             if profile_enabled {
                 if let Some(ref mut stats) = $stats {
                     stats.record($name, elapsed);
@@ -392,7 +393,13 @@ fn main() -> anyhow::Result<()> {
         // Track loop cycle time
         let cycle_time = loop_start.elapsed();
         if cycle_time.as_millis() > 100 {
-            profile_metric!(profile_stats, profile_file, "slow_cycle", cycle_time);
+            record_metric!(
+                editor,
+                profile_stats,
+                profile_file,
+                "slow_cycle",
+                cycle_time
+            );
         }
         loop_start = Instant::now();
 
@@ -555,7 +562,7 @@ fn main() -> anyhow::Result<()> {
                         key_went_to_terminal =
                             terminal_visible_before_key && editor.floating_terminal.is_visible();
                         let elapsed = t_handle_key.elapsed();
-                        profile_metric!(profile_stats, profile_file, "handle_key", elapsed);
+                        record_metric!(editor, profile_stats, profile_file, "handle_key", elapsed);
                         // Only log slow handle_key operations (>1ms) with details
                         if elapsed.as_micros() > 1000 {
                             profile!(
@@ -1031,7 +1038,8 @@ fn main() -> anyhow::Result<()> {
             let t_syntax = Instant::now();
             let syntax_updated = editor.maybe_update_syntax_debounced(debounce);
             if syntax_updated {
-                profile_metric!(
+                record_metric!(
+                    editor,
                     profile_stats,
                     profile_file,
                     "syntax_update",
@@ -1520,6 +1528,9 @@ fn main() -> anyhow::Result<()> {
                 }
                 // Log if LSP processing was slow
                 let lsp_elapsed = t_lsp_poll.elapsed();
+                if lsp_notification_count > 0 {
+                    record_metric!(editor, profile_stats, profile_file, "lsp_poll", lsp_elapsed);
+                }
                 if lsp_elapsed.as_millis() > 50 || lsp_notification_count > 10 {
                     profile!(
                         profile_file,
@@ -1600,6 +1611,15 @@ fn main() -> anyhow::Result<()> {
                 }
                 // Log if Copilot processing was slow
                 let copilot_elapsed = t_copilot_poll.elapsed();
+                if copilot_count > 0 {
+                    record_metric!(
+                        editor,
+                        profile_stats,
+                        profile_file,
+                        "copilot_poll",
+                        copilot_elapsed
+                    );
+                }
                 if copilot_elapsed.as_millis() > 50 || copilot_count > 5 {
                     profile!(
                         profile_file,
@@ -1710,6 +1730,13 @@ fn main() -> anyhow::Result<()> {
                     editor.finder.preview_update_pending = false;
                     preview_pending_since = None;
                     needs_redraw = true;
+                    record_metric!(
+                        editor,
+                        profile_stats,
+                        profile_file,
+                        "finder_preview",
+                        t_preview.elapsed()
+                    );
                     profile!(
                         profile_file,
                         "preview_update (debounced): {:?}",
@@ -1737,6 +1764,13 @@ fn main() -> anyhow::Result<()> {
                     editor.finder.execute_grep_search();
                     grep_pending_since = None;
                     needs_redraw = true;
+                    record_metric!(
+                        editor,
+                        profile_stats,
+                        profile_file,
+                        "finder_grep",
+                        t_grep.elapsed()
+                    );
                     profile!(
                         profile_file,
                         "grep_search (debounced): {:?}",
@@ -1791,7 +1825,13 @@ fn main() -> anyhow::Result<()> {
                 }
                 let t_render = Instant::now();
                 terminal.render(&editor)?;
-                profile_metric!(profile_stats, profile_file, "render", t_render.elapsed());
+                record_metric!(
+                    editor,
+                    profile_stats,
+                    profile_file,
+                    "render",
+                    t_render.elapsed()
+                );
                 needs_redraw = false;
                 terminal_redraw_pending = false;
                 last_render = now;
@@ -1803,7 +1843,8 @@ fn main() -> anyhow::Result<()> {
                 editor.sync_floating_terminal_size();
                 let t_render = Instant::now();
                 terminal.render_terminal_only(&editor)?;
-                profile_metric!(
+                record_metric!(
+                    editor,
                     profile_stats,
                     profile_file,
                     "terminal_render",

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -1,8 +1,9 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::io::{self, Write};
 use std::time::Duration;
 
 const MAX_SAMPLES_PER_METRIC: usize = 10_000;
+const DEFAULT_FLIGHT_RECORDER_CAPACITY: usize = 2_048;
 
 #[derive(Debug, Default)]
 pub struct PerfStats {
@@ -77,9 +78,168 @@ fn percentile(sorted_samples: &[u128], percentile: u32) -> u128 {
     sorted_samples[index]
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FlightEvent {
+    pub sequence: u64,
+    pub name: &'static str,
+    pub duration_us: u128,
+    pub slow: bool,
+}
+
+#[derive(Debug)]
+pub struct FlightRecorder {
+    capacity: usize,
+    next_sequence: u64,
+    events: VecDeque<FlightEvent>,
+}
+
+impl Default for FlightRecorder {
+    fn default() -> Self {
+        Self::with_capacity(DEFAULT_FLIGHT_RECORDER_CAPACITY)
+    }
+}
+
+impl FlightRecorder {
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            next_sequence: 0,
+            events: VecDeque::new(),
+        }
+    }
+
+    pub fn record(&mut self, name: &'static str, duration: Duration) {
+        let duration_us = duration.as_micros();
+        let slow = duration_us >= slow_threshold_us(name);
+        let event = FlightEvent {
+            sequence: self.next_sequence,
+            name,
+            duration_us,
+            slow,
+        };
+        self.next_sequence = self.next_sequence.wrapping_add(1);
+
+        if self.events.len() == self.capacity {
+            self.events.pop_front();
+        }
+        self.events.push_back(event);
+    }
+
+    pub fn render_report(&self) -> String {
+        let mut report = String::new();
+        report.push_str("# Nevi Flight Recorder\n\n");
+        report.push_str("## Overview\n");
+        report.push_str(&format!(
+            "- Events retained: {} / {}\n",
+            self.events.len(),
+            self.capacity
+        ));
+        report.push_str("- Storage: in-memory ring buffer only\n");
+        report.push_str("- Verbose file logging remains opt-in with `NEVI_PROFILE=1`\n\n");
+
+        if self.events.is_empty() {
+            report.push_str("No timing events recorded yet.\n");
+            return report;
+        }
+
+        report.push_str("## Summary\n");
+        for line in self.summary_lines() {
+            report.push_str(&format!("- {line}\n"));
+        }
+        report.push('\n');
+
+        let slow_events: Vec<&FlightEvent> =
+            self.events.iter().filter(|event| event.slow).collect();
+        report.push_str("## Slow Events\n");
+        if slow_events.is_empty() {
+            report.push_str("- none\n\n");
+        } else {
+            for event in slow_events.iter().rev().take(20).rev() {
+                report.push_str(&format!(
+                    "- #{} {} {} slow\n",
+                    event.sequence,
+                    event.name,
+                    format_duration_us(event.duration_us)
+                ));
+            }
+            report.push('\n');
+        }
+
+        report.push_str("## Recent Events\n");
+        for event in self.events.iter().rev().take(40).rev() {
+            let marker = if event.slow { " slow" } else { "" };
+            report.push_str(&format!(
+                "- #{} {} {}{}\n",
+                event.sequence,
+                event.name,
+                format_duration_us(event.duration_us),
+                marker
+            ));
+        }
+
+        report
+    }
+
+    fn summary_lines(&self) -> Vec<String> {
+        let mut metrics: BTreeMap<&'static str, Vec<u128>> = BTreeMap::new();
+        for event in &self.events {
+            metrics
+                .entry(event.name)
+                .or_default()
+                .push(event.duration_us);
+        }
+
+        metrics
+            .into_iter()
+            .map(|(name, mut samples)| {
+                samples.sort_unstable();
+                let count = samples.len();
+                let total: u128 = samples.iter().sum();
+                let avg = total / count as u128;
+                let p50 = percentile(&samples, 50);
+                let p95 = percentile(&samples, 95);
+                let max = *samples.last().unwrap_or(&0);
+                let slow_count = self
+                    .events
+                    .iter()
+                    .filter(|event| event.name == name && event.slow)
+                    .count();
+                format!(
+                    "{name}: count={count} avg={} p50={} p95={} max={} slow={slow_count}",
+                    format_duration_us(avg),
+                    format_duration_us(p50),
+                    format_duration_us(p95),
+                    format_duration_us(max)
+                )
+            })
+            .collect()
+    }
+}
+
+fn slow_threshold_us(name: &str) -> u128 {
+    match name {
+        "handle_key" => 1_000,
+        "render" | "render_after_lsp" | "syntax_update" => 16_000,
+        "finder_preview" | "finder_grep" | "terminal_tick" | "terminal_render" => 5_000,
+        "lsp_poll" | "copilot_poll" => 10_000,
+        "slow_cycle" => 100_000,
+        _ => 10_000,
+    }
+}
+
+fn format_duration_us(us: u128) -> String {
+    if us >= 1_000 {
+        let millis = us / 1_000;
+        let frac = us % 1_000;
+        format!("{millis}.{frac:03}ms")
+    } else {
+        format!("{us}us")
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::PerfStats;
+    use super::{FlightRecorder, PerfStats};
     use std::time::Duration;
 
     #[test]
@@ -131,5 +291,35 @@ mod tests {
                 "render count=10005 samples=10000 total_us=10005 avg_us=1 p50_us=1 p95_us=1 max_us=1",
             ]
         );
+    }
+
+    #[test]
+    fn flight_recorder_keeps_recent_events_and_summaries() {
+        let mut recorder = FlightRecorder::with_capacity(3);
+
+        recorder.record("render", Duration::from_micros(900));
+        recorder.record("handle_key", Duration::from_micros(1_500));
+        recorder.record("render", Duration::from_micros(2_100));
+        recorder.record("syntax_update", Duration::from_micros(30_000));
+
+        let report = recorder.render_report();
+
+        assert!(report.contains("# Nevi Flight Recorder"));
+        assert!(report.contains("Events retained: 3 / 3"));
+        assert!(report.contains("handle_key"));
+        assert!(report.contains("render"));
+        assert!(report.contains("syntax_update"));
+        assert!(report.contains("slow"));
+        assert!(!report.contains("900us"));
+    }
+
+    #[test]
+    fn flight_recorder_empty_report_explains_no_events() {
+        let recorder = FlightRecorder::with_capacity(8);
+
+        let report = recorder.render_report();
+
+        assert!(report.contains("# Nevi Flight Recorder"));
+        assert!(report.contains("No timing events recorded yet."));
     }
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9875,6 +9875,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_health_report();
             CommandResult::Ok
         }
+        Command::FlightRecorder => {
+            editor.open_flight_recorder_report();
+            CommandResult::Ok
+        }
         Command::ConfigOpen => match editor.open_user_config_file() {
             Ok(path) => CommandResult::Message(format!("Opened config: {}", path.display())),
             Err(message) => CommandResult::Error(message),
@@ -10943,6 +10947,25 @@ mod tests {
         assert!(text.contains("Keymaps"));
         assert!(text.contains("Performance"));
         assert!(text.contains("LSP"));
+    }
+
+    #[test]
+    fn flight_recorder_command_opens_flight_report_buffer() {
+        let mut editor = Editor::default();
+        editor
+            .flight_recorder
+            .record("handle_key", Duration::from_micros(1_500));
+
+        execute_command(&mut editor, Command::FlightRecorder);
+
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[flight-recorder]");
+        assert!(editor.buffer().is_read_only());
+        assert!(!editor.buffer().dirty);
+        let text = editor.buffer().content();
+        assert!(text.contains("Nevi Flight Recorder"));
+        assert!(text.contains("handle_key"));
+        assert!(text.contains("slow"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a bounded in-memory Flight Recorder for recent hot-path timings
- expose `:FlightRecorder`, `:WhySlow`, and `:flight` as read-only timing reports
- keep verbose file profiling opt-in behind `NEVI_PROFILE=1`
- document the new command in README and keybindings docs

## Verification
- `cargo test --quiet`
- `git diff --check`
- `cargo build --release --quiet`
- release binary size checked with `du -sh target/release/nevi`: `12M`
- manual `:FlightRecorder` test confirmed
