### PR TITLE
feat: add macOS CI workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,46 @@
+name: Rust CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: Test on macOS
+    runs-on: macos-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup default stable
+          rustup component add rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run Rust tests
+        run: cargo test --quiet
+
+      - name: Install Neovim for parity smoke test
+        run: brew install neovim
+
+      - name: Run Vim oracle smoke test
+        run: NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture
+
+      - name: Build release binary
+        run: cargo build --release --quiet
+
+      - name: Report release binary size
+        run: du -sh target/release/nevi


### PR DESCRIPTION
## Summary
- add a macOS GitHub Actions workflow for pushes and pull requests to `master`
- run formatting, the full Rust test suite, the opt-in Vim oracle smoke test, and release build
- install Neovim in CI so parity checks run automatically

## Verification
- `cargo fmt --all -- --check`
- `cargo test --quiet`
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `git diff --check`
- `cargo build --release --quiet`
- release binary size checked with `du -sh target/release/nevi`: `12M`
