### PR TITLE
feat: add labeled jump navigation

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -106,6 +106,26 @@ action = ":Terminals"
 desc = "Terminal picker"
 ```
 
+Labeled jump is mapped to `<Space>j` by default. To move it to `<Space>s`:
+
+```toml
+[[keymap.leader_mappings]]
+key = "s"
+action = ":Jump"
+desc = "Labeled jump"
+```
+
+To use plain `s` for labeled jump instead:
+
+```toml
+[[keymap.normal]]
+from = "s"
+to = ":Jump<CR>"
+```
+
+This overrides Vim's default `s` behavior, which substitutes the character under
+the cursor and enters insert mode.
+
 ### Key Notation
 
 When specifying keys, use these formats:
@@ -677,6 +697,7 @@ the popup, or press `Esc` to cancel.
 | `<leader>fg` | Live grep (search in files) |
 | `<leader>fl` | Find lines in current buffer |
 | `<leader>sw` | Search word under cursor |
+| `<leader>j` | Labeled jump to visible text |
 | `<leader>fb` | Find buffers |
 | `<leader>ft` | Theme picker |
 | `<leader>tt` | Terminal picker |
@@ -886,6 +907,7 @@ While typing an Ex command after `:`.
 | `:LiveGrep` / `:grep` / `:rg` | Search in files |
 | `:BufferSearch` / `:FindLines` / `:Lines` / `:bl` | Find lines in current buffer |
 | `:SearchWord` / `:sw` | Search word under cursor |
+| `:Jump` / `:jump` | Start labeled jump mode: type 2 chars, then press a visible label |
 | `:FindBuffers` / `:fb` / `:buffers` | Open buffer finder |
 | `:FindDiagnostics` / `:diag` / `:fd` | Open diagnostics finder |
 | `:DiagnosticFloat` / `:df` | Show diagnostics for cursor line |

--- a/README.md
+++ b/README.md
@@ -152,9 +152,11 @@ nevi file1.rs file2.rs
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)
 - `:ProjectReplace/{pattern}/{replacement}/g` - Preview project-wide literal replace
 - `:ProjectReplaceApply` - Apply the last project replace preview
+- `:Jump` - Labeled jump to visible text
 - `<Space>ff` - Find files
 - `<Space>fg` - Live grep
 - `<Space>fl` - Find lines in current buffer
+- `<Space>j` - Labeled jump to visible text
 - `<Space>gc` - Git changes picker
 - `<Space>e` - File explorer
 - `<Space>tt` - Terminal picker
@@ -286,6 +288,7 @@ Press `<Space>` by itself to show available leader continuations. Set `[keymap] 
 | `fg` | Live grep |
 | `fl` | Find lines in current buffer |
 | `sw` | Search word under cursor |
+| `j` | Labeled jump to visible text |
 | `fb` | Find buffers |
 | `ft` | Theme picker |
 | `fk` | Search keymaps |

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -159,6 +159,8 @@ pub enum Command {
     CheckHealth,
     /// :FlightRecorder - Open recent performance timing report
     FlightRecorder,
+    /// :Jump - Start labeled jump navigation for visible text
+    Jump,
     /// :ConfigOpen - Open the user config file
     ConfigOpen,
     /// :ConfigDefaults - Open the latest default config template
@@ -648,6 +650,12 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "Jump",
+        aliases: &["jump"],
+        description: "Jump to visible text with labels",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "ConfigOpen",
         aliases: &["configopen", "config", "ConfigEdit", "configedit"],
         description: "Open user config file",
@@ -1096,6 +1104,7 @@ pub fn parse_command(input: &str) -> Command {
         "FlightRecorder" | "flightrecorder" | "flight" | "WhySlow" | "whyslow" => {
             Command::FlightRecorder
         }
+        "Jump" | "jump" => Command::Jump,
         "ConfigOpen" | "configopen" | "config" | "ConfigEdit" | "configedit" => Command::ConfigOpen,
         "ConfigDefaults" | "configdefaults" | "defaults" => Command::ConfigDefaults,
 
@@ -1986,6 +1995,24 @@ mod tests {
         assert!(
             rows.iter().any(|(name, _)| name == ":FlightRecorder"),
             "expected :FlightRecorder in command cheatsheet rows"
+        );
+    }
+
+    #[test]
+    fn jump_command_is_parseable_and_listed() {
+        assert_eq!(format!("{:?}", parse_command("Jump")), "Jump");
+        assert_eq!(format!("{:?}", parse_command("jump")), "Jump");
+
+        let suggestions = command_suggestions("jump", 8);
+        assert!(
+            suggestions.iter().any(|item| item.command == "Jump"),
+            "expected Jump to match jump query"
+        );
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":Jump"),
+            "expected :Jump in command cheatsheet rows"
         );
     }
 

--- a/src/config/keymap.rs
+++ b/src/config/keymap.rs
@@ -923,6 +923,7 @@ mod tests {
             ("ff", "FindFiles"),
             ("fg", "LiveGrep"),
             ("sw", "SearchWord"),
+            ("j", "Jump"),
             ("fb", "FindBuffers"),
             ("ft", "Themes"),
             ("tt", "Terminals"),
@@ -1034,6 +1035,19 @@ mod tests {
                 .iter()
                 .any(|m| m.key == "fk" && m.action.contains("Keymaps")),
             "default leader mappings should bind fk -> :Keymaps"
+        );
+    }
+
+    #[test]
+    fn default_leader_includes_labeled_jump() {
+        use super::super::KeymapSettings;
+        let settings = KeymapSettings::default();
+        assert!(
+            settings
+                .leader_mappings
+                .iter()
+                .any(|m| m.key == "j" && m.action.contains("Jump")),
+            "default leader mappings should bind j -> :Jump"
         );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -370,6 +370,11 @@ impl Default for KeymapSettings {
                     desc: Some("Search word under cursor".to_string()),
                 },
                 LeaderMapping {
+                    key: "j".to_string(),
+                    action: ":Jump".to_string(),
+                    desc: Some("Labeled jump".to_string()),
+                },
+                LeaderMapping {
                     key: "fb".to_string(),
                     action: ":FindBuffers".to_string(),
                     desc: Some("Find buffers".to_string()),
@@ -1253,6 +1258,7 @@ fn default_config_template() -> &'static str {
 # <leader>fg       - Live grep
 # <leader>fl       - Find lines in current buffer
 # <leader>sw       - Search word under cursor (grep)
+# <leader>j        - Labeled jump to visible text
 # <leader>fb       - Find buffers
 # <leader>ft       - Theme picker
 # <leader>tt       - Terminal picker
@@ -1347,6 +1353,18 @@ fn default_config_template() -> &'static str {
 # key = "md"
 # action = ":MarkdownPreview"
 # desc = "Open Markdown preview"
+#
+# Example: move labeled jump from <leader>j to <leader>s
+# [[keymap.leader_mappings]]
+# key = "s"
+# action = ":Jump"
+# desc = "Labeled jump"
+#
+# Example: use plain `s` for labeled jump.
+# This overrides Vim's default `s` substitute behavior.
+# [[keymap.normal]]
+# from = "s"
+# to = ":Jump<CR>"
 #
 # To override command-mode command-line UX bindings:
 # [[keymap.command_mappings]]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1040,6 +1040,8 @@ pub struct Editor {
     pub flight_recorder: crate::perf::FlightRecorder,
     /// Last project-wide replace preview, pending explicit apply.
     project_replace_preview: Option<crate::project_replace::ProjectReplacePreview>,
+    /// Active labeled jump state, if the user is choosing a visible target.
+    pub labeled_jump: Option<crate::labeled_jump::LabeledJumpState>,
     /// Marks for navigation (m{a-z}, '{a-z}, `{a-z})
     pub marks: Marks,
     /// Last visual selection for gv command
@@ -1537,6 +1539,7 @@ impl Editor {
             markdown_preview: None,
             flight_recorder: crate::perf::FlightRecorder::default(),
             project_replace_preview: None,
+            labeled_jump: None,
             marks: Marks::new(),
             last_visual_selection: None,
             pending_visual_block_edit: None,
@@ -1920,6 +1923,147 @@ impl Editor {
             crate::config::default_config_template_text(),
             Some("config.toml"),
         );
+    }
+
+    /// Start labeled jump navigation over the currently visible editor text.
+    pub fn start_labeled_jump(&mut self) {
+        self.labeled_jump = Some(crate::labeled_jump::LabeledJumpState::new());
+        self.set_status("Jump: type 2 chars, label to jump, Esc cancels");
+    }
+
+    /// Cancel the active labeled jump prompt.
+    pub fn cancel_labeled_jump(&mut self) {
+        self.labeled_jump = None;
+        self.set_status("Jump cancelled");
+    }
+
+    /// Add one character to the labeled jump query and refresh visible targets.
+    pub fn push_labeled_jump_query_char(&mut self, ch: char) {
+        let Some(state) = self.labeled_jump.as_mut() else {
+            return;
+        };
+
+        if state.query.chars().count() >= 2 {
+            self.set_status("Jump: press a label or Esc");
+            return;
+        }
+
+        state.query.push(ch);
+        let query = state.query.clone();
+        let targets = self.collect_labeled_jump_targets(&query);
+
+        if let Some(state) = self.labeled_jump.as_mut() {
+            state.targets = targets;
+        }
+
+        self.set_labeled_jump_status();
+    }
+
+    /// Remove one character from the labeled jump query.
+    pub fn pop_labeled_jump_query_char(&mut self) {
+        let Some(state) = self.labeled_jump.as_mut() else {
+            return;
+        };
+
+        state.query.pop();
+        let query = state.query.clone();
+        let targets = self.collect_labeled_jump_targets(&query);
+
+        if let Some(state) = self.labeled_jump.as_mut() {
+            state.targets = targets;
+        }
+
+        self.set_labeled_jump_status();
+    }
+
+    /// Jump to the target assigned to a label, if one exists.
+    pub fn select_labeled_jump_label(&mut self, label: char) -> bool {
+        let target = self
+            .labeled_jump
+            .as_ref()
+            .and_then(|state| state.target_for_label(label).cloned());
+        let Some(target) = target else {
+            self.set_status(format!("Jump: no target for label '{}'", label));
+            return false;
+        };
+
+        self.record_jump();
+        self.cursor.line = target.line;
+        self.cursor.col = target.col;
+        self.clamp_cursor();
+        self.scroll_to_cursor();
+        self.labeled_jump = None;
+        self.set_status("Jumped");
+        true
+    }
+
+    /// Labels that should be drawn over one visible line.
+    pub fn labeled_jump_labels_for_line(&self, line: usize) -> Vec<(usize, char)> {
+        self.labeled_jump
+            .as_ref()
+            .map(|state| {
+                state
+                    .targets
+                    .iter()
+                    .filter_map(|target| {
+                        (target.line == line).then_some((target.col, target.label))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    fn collect_labeled_jump_targets(
+        &self,
+        query: &str,
+    ) -> Vec<crate::labeled_jump::LabeledJumpTarget> {
+        let lines: Vec<String> = (0..self.buffer().len_lines())
+            .filter_map(|idx| {
+                self.buffer()
+                    .line(idx)
+                    .map(|line| line.to_string().trim_end_matches('\n').to_string())
+            })
+            .collect();
+        let (viewport_offset, visible_rows) = self.labeled_jump_visible_region();
+        crate::labeled_jump::collect_visible_targets(&lines, viewport_offset, visible_rows, query)
+    }
+
+    fn labeled_jump_visible_region(&self) -> (usize, usize) {
+        let Some(pane) = self.panes.get(self.active_pane) else {
+            return (self.viewport_offset, self.text_rows());
+        };
+
+        let rows = if pane.rect.height == 0 {
+            self.text_rows()
+        } else {
+            pane.rect.height as usize
+        };
+
+        (pane.viewport_offset, rows)
+    }
+
+    fn set_labeled_jump_status(&mut self) {
+        let Some(state) = self.labeled_jump.as_ref() else {
+            return;
+        };
+
+        if state.query.is_empty() {
+            self.set_status("Jump: type 2 chars, label to jump, Esc cancels");
+        } else if state.targets.is_empty() {
+            self.set_status(format!("Jump: no matches for `{}`", state.query));
+        } else if state.query.chars().count() < 2 {
+            self.set_status(format!(
+                "Jump: `{}` {} target(s), type next char",
+                state.query,
+                state.targets.len()
+            ));
+        } else {
+            self.set_status(format!(
+                "Jump: `{}` {} target(s), press label",
+                state.query,
+                state.targets.len()
+            ));
+        }
     }
 
     /// Close the floating Markdown preview.

--- a/src/labeled_jump.rs
+++ b/src/labeled_jump.rs
@@ -1,0 +1,112 @@
+pub const LABEL_ALPHABET: &str = "asdfghjklqwertyuiopzxcvbnm";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LabeledJumpTarget {
+    pub label: char,
+    pub line: usize,
+    pub col: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LabeledJumpState {
+    pub query: String,
+    pub targets: Vec<LabeledJumpTarget>,
+}
+
+impl LabeledJumpState {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn target_for_label(&self, label: char) -> Option<&LabeledJumpTarget> {
+        self.targets.iter().find(|target| target.label == label)
+    }
+}
+
+pub fn collect_visible_targets(
+    lines: &[String],
+    viewport_offset: usize,
+    visible_rows: usize,
+    query: &str,
+) -> Vec<LabeledJumpTarget> {
+    if query.is_empty() || visible_rows == 0 {
+        return Vec::new();
+    }
+
+    let mut labels = LABEL_ALPHABET.chars();
+    let mut targets = Vec::new();
+    let end_line = viewport_offset
+        .saturating_add(visible_rows)
+        .min(lines.len());
+
+    for line_idx in viewport_offset..end_line {
+        let Some(line) = lines.get(line_idx) else {
+            continue;
+        };
+
+        for (byte_idx, _) in line.match_indices(query) {
+            let Some(label) = labels.next() else {
+                return targets;
+            };
+            let col = line[..byte_idx].chars().count();
+            targets.push(LabeledJumpTarget {
+                label,
+                line: line_idx,
+                col,
+            });
+        }
+    }
+
+    targets
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_query_has_no_targets() {
+        let lines = vec!["alpha beta".to_string()];
+
+        assert!(collect_visible_targets(&lines, 0, 1, "").is_empty());
+    }
+
+    #[test]
+    fn collects_visible_targets_with_home_row_labels() {
+        let lines = vec![
+            "hidden old".to_string(),
+            "visible old here".to_string(),
+            "old visible too".to_string(),
+            "below old".to_string(),
+        ];
+
+        let targets = collect_visible_targets(&lines, 1, 2, "old");
+
+        assert_eq!(
+            targets,
+            vec![
+                LabeledJumpTarget {
+                    label: 'a',
+                    line: 1,
+                    col: 8
+                },
+                LabeledJumpTarget {
+                    label: 's',
+                    line: 2,
+                    col: 0
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn caps_targets_to_label_alphabet() {
+        let lines = vec!["aa ".repeat(LABEL_ALPHABET.len() + 4)];
+
+        let targets = collect_visible_targets(&lines, 0, 1, "aa");
+
+        assert_eq!(targets.len(), LABEL_ALPHABET.len());
+        assert_eq!(targets.first().map(|target| target.label), Some('a'));
+        assert_eq!(targets.last().map(|target| target.label), Some('m'));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod harpoon;
 pub mod health;
 pub mod indent;
 pub mod input;
+pub mod labeled_jump;
 pub mod lsp;
 pub mod markdown_preview;
 pub mod perf;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -268,6 +268,26 @@ fn apply_diagnostic_underline<W: Write>(
     }
 }
 
+fn apply_labeled_jump_style<W: Write>(writer: &mut W, bg: Color, fg: Color) -> io::Result<()> {
+    execute!(
+        writer,
+        SetAttribute(Attribute::Reset),
+        SetBackgroundColor(bg),
+        SetForegroundColor(fg),
+        SetAttribute(Attribute::Bold)
+    )
+}
+
+fn restore_after_labeled_jump<W: Write>(writer: &mut W, bg: Color, fg: Color) -> io::Result<()> {
+    execute!(
+        writer,
+        SetAttribute(Attribute::Reset),
+        SetAttribute(Attribute::NoUnderline)
+    )?;
+    write_ansi_underline_color(writer, Color::Reset)?;
+    execute!(writer, SetBackgroundColor(bg), SetForegroundColor(fg))
+}
+
 fn editor_char_display_width(ch: char, tab_width: usize) -> usize {
     if ch == '\t' {
         tab_width.max(1)
@@ -1202,6 +1222,11 @@ impl Terminal {
 
                 // Render segment content with syntax highlighting
                 let segment_text = segment.text.trim_end_matches('\n');
+                let jump_labels = if is_active {
+                    editor.labeled_jump_labels_for_line(file_line)
+                } else {
+                    Vec::new()
+                };
 
                 let rendered_cols = self.render_line_segment_with_highlights(
                     segment_text,
@@ -1213,6 +1238,7 @@ impl Terminal {
                     &editor.mode,
                     highlight_cursor_line && is_cursor_line,
                     &editor.search_matches,
+                    &jump_labels,
                     &line_diagnostics,
                     editor_bg,
                     editor_fg,
@@ -1220,6 +1246,8 @@ impl Terminal {
                     selection_bg,
                     search_bg,
                     search_fg,
+                    theme.ui.finder_match,
+                    Color::Black,
                     theme.diagnostic.error,
                     theme.ui.line_number, // Use grey color for unused code (hint diagnostics)
                     tab_width,
@@ -1538,6 +1566,11 @@ impl Terminal {
                     let selection_bg = theme.ui.selection;
                     let search_bg = theme.ui.search_match_bg;
                     let search_fg = theme.ui.search_match_fg;
+                    let jump_labels = if is_active {
+                        editor.labeled_jump_labels_for_line(file_line)
+                    } else {
+                        Vec::new()
+                    };
 
                     let rendered_cols = self.render_line_with_highlights(
                         &line_str,
@@ -1548,6 +1581,7 @@ impl Terminal {
                         &editor.mode,
                         highlight_cursor_line && is_cursor_line,
                         &editor.search_matches,
+                        &jump_labels,
                         &line_diagnostics,
                         editor_bg,
                         editor_fg,
@@ -1555,6 +1589,8 @@ impl Terminal {
                         selection_bg,
                         search_bg,
                         search_fg,
+                        theme.ui.finder_match,
+                        Color::Black,
                         theme.diagnostic.error,
                         theme.ui.line_number, // Use grey color for unused code (hint diagnostics)
                         tab_width,
@@ -1762,6 +1798,7 @@ impl Terminal {
         mode: &Mode,
         is_cursor_line: bool,
         search_matches: &[(usize, usize, usize)],
+        jump_labels: &[(usize, char)],
         diagnostics: &[&Diagnostic],
         editor_bg: Color,
         editor_fg: Color,
@@ -1769,6 +1806,8 @@ impl Terminal {
         selection_bg: Color,
         search_match_bg: Color,
         search_match_fg: Color,
+        jump_label_bg: Color,
+        jump_label_fg: Color,
         diagnostic_error_color: Color,
         diagnostic_hint_color: Color,
         tab_width: usize,
@@ -1837,6 +1876,24 @@ impl Terminal {
             // Check if in search match
             let is_search = source_col.map_or(false, in_search_match);
 
+            let jump_label = source_col.and_then(|actual_col| {
+                jump_labels
+                    .iter()
+                    .find_map(|(col, label)| (*col == actual_col).then_some(*label))
+            });
+
+            if let Some(label) = jump_label {
+                apply_labeled_jump_style(&mut self.stdout, jump_label_bg, jump_label_fg)?;
+                rendered_cols += print_editor_char(label, tab_width);
+                restore_after_labeled_jump(&mut self.stdout, base_bg, editor_fg)?;
+                current_fg = Some(editor_fg);
+                current_bg = Some(base_bg);
+                current_bold = false;
+                current_italic = false;
+                current_underline_color = None;
+                continue;
+            }
+
             let diag_at_col = source_col
                 .and_then(|actual_col| diagnostic_at_col(diagnostics, line_num, actual_col));
 
@@ -1854,7 +1911,9 @@ impl Terminal {
                 diag_at_col.map_or(false, |d| d.severity == DiagnosticSeverity::Hint);
 
             // Priority: visual selection > search match > hint (grey out) > base
-            let (desired_bg, desired_fg) = if in_visual {
+            let (desired_bg, desired_fg) = if jump_label.is_some() {
+                (jump_label_bg, jump_label_fg)
+            } else if in_visual {
                 (selection_bg, syntax_color.unwrap_or(editor_fg))
             } else if is_search {
                 (search_match_bg, search_match_fg)
@@ -1864,14 +1923,16 @@ impl Terminal {
             } else {
                 (base_bg, syntax_color.unwrap_or(editor_fg))
             };
-            let desired_style = if in_visual || (!is_search && !is_hint_diagnostic) {
-                syntax_style
-            } else {
-                None
-            };
-            let desired_bold = desired_style.map_or(false, |style| style.bold);
+            let desired_style =
+                if jump_label.is_none() && (in_visual || (!is_search && !is_hint_diagnostic)) {
+                    syntax_style
+                } else {
+                    None
+                };
+            let desired_bold =
+                jump_label.is_some() || desired_style.map_or(false, |style| style.bold);
             let desired_italic = desired_style.map_or(false, |style| style.italic);
-            let desired_underline_color = if in_visual || is_search {
+            let desired_underline_color = if jump_label.is_some() || in_visual || is_search {
                 None
             } else {
                 diag_at_col
@@ -1914,7 +1975,7 @@ impl Terminal {
                 current_underline_color = desired_underline_color;
             }
 
-            rendered_cols += print_editor_char(*ch, tab_width);
+            rendered_cols += print_editor_char(jump_label.unwrap_or(*ch), tab_width);
         }
 
         // Restore to base background/foreground and clear text attributes.
@@ -5773,6 +5834,7 @@ impl Terminal {
         mode: &Mode,
         is_cursor_line: bool,
         search_matches: &[(usize, usize, usize)],
+        jump_labels: &[(usize, char)],
         diagnostics: &[&Diagnostic],
         editor_bg: Color,
         editor_fg: Color,
@@ -5780,6 +5842,8 @@ impl Terminal {
         selection_bg: Color,
         search_match_bg: Color,
         search_match_fg: Color,
+        jump_label_bg: Color,
+        jump_label_fg: Color,
         diagnostic_error_color: Color,
         diagnostic_hint_color: Color,
         tab_width: usize,
@@ -5863,6 +5927,22 @@ impl Terminal {
             // Check if in search match
             let is_search_match = in_search_match(actual_col);
 
+            let jump_label = jump_labels
+                .iter()
+                .find_map(|(col, label)| (*col == actual_col).then_some(*label));
+
+            if let Some(label) = jump_label {
+                apply_labeled_jump_style(&mut self.stdout, jump_label_bg, jump_label_fg)?;
+                rendered_cols += print_editor_char(label, tab_width);
+                restore_after_labeled_jump(&mut self.stdout, base_bg, editor_fg)?;
+                current_fg = Some(editor_fg);
+                current_bg = Some(base_bg);
+                current_bold = false;
+                current_italic = false;
+                current_underline_color = None;
+                continue;
+            }
+
             let diag_at_col = diagnostic_at_col(diagnostics, line_idx, actual_col);
 
             // Check if within a hint diagnostic (unused variable/import) - grey out the text
@@ -5870,7 +5950,9 @@ impl Terminal {
                 diag_at_col.map_or(false, |d| d.severity == DiagnosticSeverity::Hint);
 
             // Priority: visual selection > search match > hint (grey out) > base
-            let (desired_bg, desired_fg) = if is_selected {
+            let (desired_bg, desired_fg) = if jump_label.is_some() {
+                (jump_label_bg, jump_label_fg)
+            } else if is_selected {
                 (selection_bg, syntax_color.unwrap_or(editor_fg))
             } else if is_search_match {
                 (search_match_bg, search_match_fg)
@@ -5880,14 +5962,18 @@ impl Terminal {
             } else {
                 (base_bg, syntax_color.unwrap_or(editor_fg))
             };
-            let desired_style = if is_selected || (!is_search_match && !is_hint_diagnostic) {
+            let desired_style = if jump_label.is_none()
+                && (is_selected || (!is_search_match && !is_hint_diagnostic))
+            {
                 syntax_style
             } else {
                 None
             };
-            let desired_bold = desired_style.map_or(false, |style| style.bold);
+            let desired_bold =
+                jump_label.is_some() || desired_style.map_or(false, |style| style.bold);
             let desired_italic = desired_style.map_or(false, |style| style.italic);
-            let desired_underline_color = if is_selected || is_search_match {
+            let desired_underline_color = if jump_label.is_some() || is_selected || is_search_match
+            {
                 None
             } else {
                 diag_at_col
@@ -5930,7 +6016,7 @@ impl Terminal {
                 current_underline_color = desired_underline_color;
             }
 
-            rendered_cols += print_editor_char(*ch, tab_width);
+            rendered_cols += print_editor_char(jump_label.unwrap_or(*ch), tab_width);
         }
 
         // Handle selection extending past line end
@@ -6330,6 +6416,11 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
         return;
     }
 
+    if editor.labeled_jump.is_some() {
+        handle_labeled_jump_key(editor, key);
+        return;
+    }
+
     // Clear status message on any key (except for pending operations, command mode, search mode)
     if editor.mode != Mode::Command
         && editor.mode != Mode::Search
@@ -6377,6 +6468,34 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
         Mode::Finder => handle_finder_mode(editor, key),
         Mode::Explorer => handle_explorer_mode(editor, key),
         Mode::RenamePrompt => handle_rename_prompt_mode(editor, key),
+    }
+}
+
+fn handle_labeled_jump_key(editor: &mut Editor, key: KeyEvent) {
+    match (key.modifiers, key.code) {
+        (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('[')) => {
+            editor.cancel_labeled_jump();
+        }
+        (KeyModifiers::NONE, KeyCode::Backspace) => {
+            editor.pop_labeled_jump_query_char();
+        }
+        (modifiers, KeyCode::Char(ch))
+            if !modifiers.contains(KeyModifiers::CONTROL)
+                && !modifiers.contains(KeyModifiers::ALT)
+                && !ch.is_control() =>
+        {
+            let query_len = editor
+                .labeled_jump
+                .as_ref()
+                .map(|state| state.query.chars().count())
+                .unwrap_or(0);
+            if query_len >= 2 {
+                editor.select_labeled_jump_label(ch);
+            } else {
+                editor.push_labeled_jump_query_char(ch);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -9879,6 +9998,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_flight_recorder_report();
             CommandResult::Ok
         }
+        Command::Jump => {
+            editor.start_labeled_jump();
+            CommandResult::Ok
+        }
         Command::ConfigOpen => match editor.open_user_config_file() {
             Ok(path) => CommandResult::Message(format!("Opened config: {}", path.display())),
             Err(message) => CommandResult::Error(message),
@@ -10001,9 +10124,10 @@ pub fn execute_leader_action(editor: &mut Editor, action: &LeaderAction) {
 #[cfg(test)]
 mod tests {
     use super::{
-        apply_diagnostic_underline, diagnostic_at_col, diagnostic_underline_color, execute_command,
-        execute_leader_action, finder_preview_match_ranges, handle_insert_mode, handle_key,
-        replace_completion_text, Terminal,
+        apply_diagnostic_underline, apply_labeled_jump_style, diagnostic_at_col,
+        diagnostic_underline_color, execute_command, execute_leader_action,
+        finder_preview_match_ranges, handle_insert_mode, handle_key, replace_completion_text,
+        restore_after_labeled_jump, Terminal,
     };
     use crate::commands::{Command, CommandPopupMode};
     use crate::config::{KeymapEntry, Settings};
@@ -10906,6 +11030,46 @@ mod tests {
     }
 
     #[test]
+    fn labeled_jump_style_resets_existing_text_attributes() {
+        crossterm::style::force_color_output(true);
+        let mut output = Vec::new();
+
+        apply_labeled_jump_style(&mut output, Color::Yellow, Color::Black)
+            .expect("apply jump label style");
+
+        let rendered = String::from_utf8(output).expect("utf8");
+        assert!(
+            rendered.contains("\x1b[0m"),
+            "jump label style should reset inherited underline and text attributes"
+        );
+    }
+
+    #[test]
+    fn labeled_jump_restore_resets_label_attributes_after_label() {
+        crossterm::style::force_color_output(true);
+        let mut output = Vec::new();
+
+        restore_after_labeled_jump(&mut output, Color::Rgb { r: 1, g: 2, b: 3 }, Color::White)
+            .expect("restore after jump label");
+
+        let rendered = String::from_utf8(output).expect("utf8");
+        assert!(
+            rendered.starts_with("\x1b[0m"),
+            "restoring after a jump label should reset label-only attributes first"
+        );
+        assert!(
+            rendered.contains("\x1b[24m"),
+            "restoring after a jump label should explicitly clear underline"
+        );
+        assert!(
+            rendered.contains("\x1b[59m"),
+            "restoring after a jump label should reset underline color"
+        );
+        assert!(rendered.contains("\x1b[48;2;1;2;3m"));
+        assert!(rendered.ends_with("\x1b[38;5;15m"));
+    }
+
+    #[test]
     fn markdown_preview_command_opens_only_for_markdown_buffers() {
         let tmp = unique_temp_dir("nevi_markdown_preview_command");
         std::fs::create_dir_all(&tmp).expect("create temp dir");
@@ -10987,6 +11151,58 @@ mod tests {
         assert!(text.contains("show_leader_popup"));
         assert!(text.contains("explorer"));
         assert!(!text.starts_with("```toml"));
+    }
+
+    #[test]
+    fn jump_command_starts_labeled_jump_state() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha old\nbeta old\n");
+
+        execute_command(&mut editor, Command::Jump);
+
+        let state = editor.labeled_jump.as_ref().expect("jump state");
+        assert_eq!(state.query, "");
+        assert!(state.targets.is_empty());
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Jump: type 2 chars, label to jump, Esc cancels")
+        );
+    }
+
+    #[test]
+    fn labeled_jump_jumps_to_selected_visible_match() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("first old\nsecond old\nthird\n");
+        editor.term_height = 8;
+        editor.update_pane_rects();
+
+        execute_command(&mut editor, Command::Jump);
+        handle_key(&mut editor, key('o'));
+        handle_key(&mut editor, key('l'));
+
+        let state = editor.labeled_jump.as_ref().expect("jump state");
+        assert_eq!(state.query, "ol");
+        assert_eq!(state.targets.len(), 2);
+        assert_eq!(state.targets[0].label, 'a');
+        assert_eq!((state.targets[0].line, state.targets[0].col), (0, 6));
+        assert_eq!(state.targets[1].label, 's');
+        assert_eq!((state.targets[1].line, state.targets[1].col), (1, 7));
+
+        handle_key(&mut editor, key('s'));
+
+        assert!(editor.labeled_jump.is_none());
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 7));
+    }
+
+    #[test]
+    fn escape_cancels_labeled_jump() {
+        let mut editor = Editor::default();
+
+        execute_command(&mut editor, Command::Jump);
+        handle_key(&mut editor, esc_key());
+
+        assert!(editor.labeled_jump.is_none());
+        assert_eq!(editor.status_message.as_deref(), Some("Jump cancelled"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add :Jump / :jump labeled jump mode for visible text targets
- Add default <leader>j mapping, command parsing, :Keymaps/default config docs, and user remap examples
- Render jump labels without leaking underline/style attributes into matched text

## Test Plan
- cargo fmt --all -- --check
- cargo test --quiet
- Manual: open /private/tmp/nevi_labeled_jump_demo.txt, run :Jump, type ol, press a visible label, and verify jump/cancel behavior