### PR TITLE
feat: add tool install report

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -956,6 +956,7 @@ for example `:ProjectReplace#/api/v1#/api/v2#g`.
 | `:Format` / `:format` | Format current document |
 | `:rn [name]` / `:lsprename [name]` | Rename symbol |
 | `:codeaction` / `:ca` | Show code actions |
+| `:ToolInstall` / `:LspInstall` | Open read-only `[tool-installer]` report with missing LSP/tool install commands |
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ If an optional tool is missing, the rest of Nevi still works. Run
 `:checkhealth` or `:Health` inside Nevi to inspect config paths, keymap
 overrides, optional tool availability, LSP settings, formatter commands,
 profiling status, and common setup issues.
+Run `:ToolInstall` or `:LspInstall` to open a read-only install plan for missing
+configured LSP servers and formatters.
 
 ### From Source
 
@@ -188,6 +190,7 @@ nevi file1.rs file2.rs
 - `:q` - Quit
 - `:wq` - Save and quit
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
+- `:ToolInstall` / `:LspInstall` - Open missing LSP/tool install guidance in a read-only `[tool-installer]` buffer
 - `:FlightRecorder` / `:WhySlow` - Open recent in-memory timing report in a read-only `[flight-recorder]` buffer
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
@@ -374,7 +377,8 @@ Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-o
 LSP servers are auto-detected when installed. See [`~/.config/nevi/config.toml`](#configuration) for LSP configuration options.
 
 If a server is missing, Nevi shows an install hint in the LSP status/error
-message. You can also run `:checkhealth` to review the active LSP configuration.
+message. You can also run `:checkhealth` to review the active LSP configuration,
+or `:ToolInstall` / `:LspInstall` to open a missing-tool install plan.
 
 > **Missing a language?** Open a [GitHub issue](https://github.com/anthonyamaro15/nevi/issues) and we'll work on adding support!
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -157,6 +157,8 @@ pub enum Command {
     Keymaps,
     /// :checkhealth - Open the editor health report
     CheckHealth,
+    /// :ToolInstall - Open missing tool install plan
+    ToolInstall,
     /// :FlightRecorder - Open recent performance timing report
     FlightRecorder,
     /// :Jump - Start labeled jump navigation for visible text
@@ -644,6 +646,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "ToolInstall",
+        aliases: &[
+            "toolinstall",
+            "toolsinstall",
+            "ToolsInstall",
+            "LspInstall",
+            "lspinstall",
+        ],
+        description: "Open missing LSP/tool install plan",
+        takes_args: false,
+    },
+    CommandSpec {
         command: "FlightRecorder",
         aliases: &["flightrecorder", "flight", "WhySlow", "whyslow"],
         description: "Open recent performance timing report",
@@ -1101,6 +1115,8 @@ pub fn parse_command(input: &str) -> Command {
         "Themes" | "themes" => Command::Themes,
         "Keymaps" | "keymaps" | "keys" => Command::Keymaps,
         "checkhealth" | "CheckHealth" | "Health" | "health" => Command::CheckHealth,
+        "ToolInstall" | "toolinstall" | "ToolsInstall" | "toolsinstall" | "LspInstall"
+        | "lspinstall" => Command::ToolInstall,
         "FlightRecorder" | "flightrecorder" | "flight" | "WhySlow" | "whyslow" => {
             Command::FlightRecorder
         }
@@ -1978,6 +1994,26 @@ mod tests {
         assert!(
             rows.iter().any(|(name, _)| name == ":checkhealth"),
             "expected :checkhealth in command cheatsheet rows"
+        );
+    }
+
+    #[test]
+    fn tool_install_commands_are_parseable_and_listed() {
+        assert!(matches!(parse_command("ToolInstall"), Command::ToolInstall));
+        assert!(matches!(parse_command("toolinstall"), Command::ToolInstall));
+        assert!(matches!(parse_command("LspInstall"), Command::ToolInstall));
+        assert!(matches!(parse_command("lspinstall"), Command::ToolInstall));
+
+        let suggestions = command_suggestions("install", 12);
+        assert!(
+            suggestions.iter().any(|item| item.command == "ToolInstall"),
+            "expected ToolInstall to match install query"
+        );
+
+        let rows = command_cheatsheet_rows();
+        assert!(
+            rows.iter().any(|(name, _)| name == ":ToolInstall"),
+            "expected :ToolInstall in command cheatsheet rows"
         );
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1741,6 +1741,17 @@ impl Editor {
         self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
     }
 
+    /// Open missing LSP/tool install guidance in a read-only virtual buffer.
+    pub fn open_tool_install_report(&mut self) {
+        let report = crate::tool_installer::collect_tool_install_report(
+            &self.settings,
+            &self.languages_config,
+            crate::health::command_exists_on_path,
+        )
+        .render_markdown();
+        self.open_virtual_read_only_buffer("[tool-installer]", &report, Some("tool-installer.md"));
+    }
+
     /// Open recent performance timings in a read-only virtual buffer.
     pub fn open_flight_recorder_report(&mut self) {
         let report = self.flight_recorder.render_report();
@@ -10700,6 +10711,22 @@ mod tests {
         assert!(content.contains("## Keymaps"));
         assert!(content.contains("## Performance"));
         assert!(content.contains("## LSP"));
+    }
+
+    #[test]
+    fn tool_install_report_opens_as_read_only_virtual_buffer() {
+        let mut editor = Editor::default();
+
+        editor.open_tool_install_report();
+
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[tool-installer]");
+        assert!(editor.buffer().is_read_only());
+        assert!(editor.buffer().path.is_none());
+        assert!(!editor.buffer().dirty);
+        let content = editor.buffer().content();
+        assert!(content.contains("# Nevi Tool Installer"));
+        assert!(content.contains(":checkhealth"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod project_replace;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;
+pub mod tool_installer;
 #[cfg(test)]
 mod vim_oracle;
 

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -181,23 +181,7 @@ impl MultiLspManager {
     }
 
     fn install_hint_for_command(command: &str) -> Option<&'static str> {
-        match Self::command_name(command) {
-            "typescript-language-server" | "typescript-language-server.cmd" => {
-                Some("npm install -g typescript typescript-language-server")
-            }
-            "rust-analyzer" | "rust-analyzer.exe" => Some("rustup component add rust-analyzer"),
-            "vscode-css-language-server"
-            | "vscode-json-language-server"
-            | "vscode-html-language-server"
-            | "vscode-eslint-language-server" => {
-                Some("npm install -g vscode-langservers-extracted")
-            }
-            "taplo" | "taplo.exe" => Some("cargo install taplo-cli --locked"),
-            "pyright-langserver" | "pyright-langserver.cmd" => Some("npm install -g pyright"),
-            "pylsp" => Some("pipx install python-lsp-server"),
-            "biome" | "biome.cmd" => Some("npm install -g @biomejs/biome"),
-            _ => None,
-        }
+        crate::tool_installer::install_command_for(command)
     }
 
     fn is_missing_command_error(message: &str) -> bool {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9994,6 +9994,10 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_health_report();
             CommandResult::Ok
         }
+        Command::ToolInstall => {
+            editor.open_tool_install_report();
+            CommandResult::Ok
+        }
         Command::FlightRecorder => {
             editor.open_flight_recorder_report();
             CommandResult::Ok
@@ -11111,6 +11115,21 @@ mod tests {
         assert!(text.contains("Keymaps"));
         assert!(text.contains("Performance"));
         assert!(text.contains("LSP"));
+    }
+
+    #[test]
+    fn tool_install_command_opens_tool_installer_report_buffer() {
+        let mut editor = Editor::default();
+
+        execute_command(&mut editor, Command::ToolInstall);
+
+        assert!(editor.markdown_preview.is_none());
+        assert_eq!(editor.buffer().display_name(), "[tool-installer]");
+        assert!(editor.buffer().is_read_only());
+        assert!(!editor.buffer().dirty);
+        let text = editor.buffer().content();
+        assert!(text.contains("Nevi Tool Installer"));
+        assert!(text.contains(":checkhealth"));
     }
 
     #[test]

--- a/src/tool_installer.rs
+++ b/src/tool_installer.rs
@@ -1,0 +1,334 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ToolCategory {
+    Lsp,
+    Formatter,
+    Optional,
+}
+
+impl ToolCategory {
+    fn heading(self) -> &'static str {
+        match self {
+            Self::Lsp => "LSP servers",
+            Self::Formatter => "Formatters",
+            Self::Optional => "Optional tools",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolInstallItem {
+    pub category: ToolCategory,
+    pub labels: Vec<String>,
+    pub command: String,
+    pub install_command: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ToolInstallReport {
+    pub items: Vec<ToolInstallItem>,
+}
+
+impl ToolInstallReport {
+    pub fn render_markdown(&self) -> String {
+        let mut output = String::from("# Nevi Tool Installer\n\n");
+        output.push_str(
+            "This report lists missing configured tools and the command Nevi knows how to install them with.\n",
+        );
+        output.push_str("Run install commands in your terminal, then restart Nevi or run `:checkhealth` again.\n\n");
+
+        if self.items.is_empty() {
+            output.push_str("No missing tools with known checks.\n");
+            return output;
+        }
+
+        for category in [
+            ToolCategory::Lsp,
+            ToolCategory::Formatter,
+            ToolCategory::Optional,
+        ] {
+            let items = self
+                .items
+                .iter()
+                .filter(|item| item.category == category)
+                .collect::<Vec<_>>();
+            if items.is_empty() {
+                continue;
+            }
+
+            output.push_str(&format!("## {}\n", category.heading()));
+            for item in items {
+                output.push_str(&format!(
+                    "- {} (`{}`)\n",
+                    item.labels.join(", "),
+                    item.command
+                ));
+                if let Some(command) = &item.install_command {
+                    output.push_str(&format!("  - Install: `{command}`\n"));
+                } else {
+                    output.push_str(
+                        "  - No known install command. Install it manually, add it to PATH, or update `config.toml`.\n",
+                    );
+                }
+            }
+            output.push('\n');
+        }
+
+        output
+    }
+}
+
+pub fn collect_tool_install_report<F>(
+    settings: &crate::config::Settings,
+    languages_config: &crate::config::LanguagesConfig,
+    is_command_available: F,
+) -> ToolInstallReport
+where
+    F: Fn(&str) -> bool,
+{
+    let mut grouped = BTreeMap::<(ToolCategory, String), ToolInstallItem>::new();
+
+    if settings.lsp.enabled {
+        let servers = &settings.lsp.servers;
+        add_lsp_tool(&mut grouped, "rust", &servers.rust, &is_command_available);
+        add_lsp_tool(
+            &mut grouped,
+            "typescript",
+            &servers.typescript,
+            &is_command_available,
+        );
+        add_lsp_tool(
+            &mut grouped,
+            "javascript",
+            &servers.javascript,
+            &is_command_available,
+        );
+        add_lsp_tool(&mut grouped, "css", &servers.css, &is_command_available);
+        add_lsp_tool(&mut grouped, "json", &servers.json, &is_command_available);
+        add_lsp_tool(&mut grouped, "toml", &servers.toml, &is_command_available);
+        add_lsp_tool(
+            &mut grouped,
+            "markdown",
+            &servers.markdown,
+            &is_command_available,
+        );
+        add_lsp_tool(&mut grouped, "html", &servers.html, &is_command_available);
+        add_lsp_tool(
+            &mut grouped,
+            "python",
+            &servers.python,
+            &is_command_available,
+        );
+    }
+
+    for (language, config) in &languages_config.languages {
+        let Some(formatter) = config.formatter.as_ref() else {
+            continue;
+        };
+        add_command_tool(
+            &mut grouped,
+            ToolCategory::Formatter,
+            language,
+            &formatter.command,
+            &is_command_available,
+        );
+    }
+
+    let mut items = grouped.into_values().collect::<Vec<_>>();
+    for item in &mut items {
+        item.labels.sort();
+        item.labels.dedup();
+    }
+    items.sort_by(|a, b| {
+        a.category
+            .cmp(&b.category)
+            .then(a.labels.join(", ").cmp(&b.labels.join(", ")))
+            .then(a.command.cmp(&b.command))
+    });
+
+    ToolInstallReport { items }
+}
+
+fn add_lsp_tool<F>(
+    grouped: &mut BTreeMap<(ToolCategory, String), ToolInstallItem>,
+    label: &str,
+    config: &crate::config::LspServerConfig,
+    is_command_available: &F,
+) where
+    F: Fn(&str) -> bool,
+{
+    if !config.enabled {
+        return;
+    }
+
+    add_command_tool(
+        grouped,
+        ToolCategory::Lsp,
+        label,
+        config.effective_command(),
+        is_command_available,
+    );
+}
+
+fn add_command_tool<F>(
+    grouped: &mut BTreeMap<(ToolCategory, String), ToolInstallItem>,
+    category: ToolCategory,
+    label: &str,
+    command: &str,
+    is_command_available: &F,
+) where
+    F: Fn(&str) -> bool,
+{
+    let command = command.trim();
+    if command.is_empty() || is_command_available(command) {
+        return;
+    }
+
+    let key = (category, command.to_string());
+    let install_command = install_command_for(command).map(str::to_string);
+    grouped
+        .entry(key)
+        .and_modify(|item| item.labels.push(label.to_string()))
+        .or_insert_with(|| ToolInstallItem {
+            category,
+            labels: vec![label.to_string()],
+            command: command.to_string(),
+            install_command,
+        });
+}
+
+pub fn install_command_for(command: &str) -> Option<&'static str> {
+    match command_name(command) {
+        "typescript-language-server" | "typescript-language-server.cmd" => {
+            Some("npm install -g typescript typescript-language-server")
+        }
+        "rust-analyzer" | "rust-analyzer.exe" => Some("rustup component add rust-analyzer"),
+        "ra-multiplex" | "ra-multiplex.exe" => Some("cargo install ra-multiplex"),
+        "vscode-css-language-server"
+        | "vscode-json-language-server"
+        | "vscode-html-language-server"
+        | "vscode-eslint-language-server" => Some("npm install -g vscode-langservers-extracted"),
+        "taplo" | "taplo.exe" => Some("cargo install taplo-cli --locked"),
+        "pyright-langserver" | "pyright-langserver.cmd" => Some("npm install -g pyright"),
+        "pylsp" => Some("pipx install python-lsp-server"),
+        "biome" | "biome.cmd" => Some("npm install -g @biomejs/biome"),
+        "oxfmt" | "oxfmt.cmd" => Some("npm install -g oxfmt"),
+        "prettier" | "prettier.cmd" => Some("npm install -g prettier"),
+        _ => None,
+    }
+}
+
+fn command_name(command: &str) -> &str {
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::config::{
+        FormatterConfig, LanguageConfig, LanguagesConfig, LspServerConfig, Settings,
+    };
+
+    fn disable_all_lsp(settings: &mut Settings) {
+        settings.lsp.servers.rust.enabled = false;
+        settings.lsp.servers.typescript.enabled = false;
+        settings.lsp.servers.javascript.enabled = false;
+        settings.lsp.servers.css.enabled = false;
+        settings.lsp.servers.json.enabled = false;
+        settings.lsp.servers.toml.enabled = false;
+        settings.lsp.servers.markdown.enabled = false;
+        settings.lsp.servers.html.enabled = false;
+        settings.lsp.servers.python.enabled = false;
+    }
+
+    #[test]
+    fn install_command_for_known_lsp_command_uses_basename() {
+        assert_eq!(
+            super::install_command_for("/usr/local/bin/typescript-language-server"),
+            Some("npm install -g typescript typescript-language-server")
+        );
+        assert_eq!(
+            super::install_command_for("rust-analyzer.exe"),
+            Some("rustup component add rust-analyzer")
+        );
+    }
+
+    #[test]
+    fn tool_install_report_deduplicates_missing_lsp_commands() {
+        let mut settings = Settings::default();
+        disable_all_lsp(&mut settings);
+        settings.lsp.servers.typescript.enabled = true;
+        settings.lsp.servers.javascript.enabled = true;
+
+        let report =
+            super::collect_tool_install_report(&settings, &LanguagesConfig::default(), |_| false);
+
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0].category, super::ToolCategory::Lsp);
+        assert_eq!(report.items[0].labels, vec!["javascript", "typescript"]);
+        assert_eq!(report.items[0].command, "typescript-language-server");
+        assert_eq!(
+            report.items[0].install_command.as_deref(),
+            Some("npm install -g typescript typescript-language-server")
+        );
+
+        let rendered = report.render_markdown();
+        assert!(rendered.contains("# Nevi Tool Installer"));
+        assert!(rendered.contains("javascript, typescript"));
+        assert!(rendered.contains("npm install -g typescript typescript-language-server"));
+    }
+
+    #[test]
+    fn tool_install_report_includes_missing_formatters() {
+        let mut settings = Settings::default();
+        settings.lsp.enabled = false;
+        let languages = LanguagesConfig {
+            languages: HashMap::from([(
+                "python".to_string(),
+                LanguageConfig {
+                    formatter: Some(FormatterConfig {
+                        command: "black".to_string(),
+                        args: vec!["-".to_string()],
+                        timeout: 5,
+                    }),
+                    tab_width: None,
+                },
+            )]),
+        };
+
+        let report = super::collect_tool_install_report(&settings, &languages, |_| false);
+
+        assert_eq!(report.items.len(), 1);
+        assert_eq!(report.items[0].category, super::ToolCategory::Formatter);
+        assert_eq!(report.items[0].labels, vec!["python"]);
+        assert_eq!(report.items[0].command, "black");
+        assert!(report.items[0].install_command.is_none());
+        assert!(report
+            .render_markdown()
+            .contains("No known install command"));
+    }
+
+    #[test]
+    fn tool_install_report_says_when_known_tools_are_installed() {
+        let mut settings = Settings::default();
+        disable_all_lsp(&mut settings);
+        settings.lsp.servers.rust = LspServerConfig {
+            enabled: true,
+            ..settings.lsp.servers.rust
+        };
+
+        let report =
+            super::collect_tool_install_report(&settings, &LanguagesConfig::default(), |_| true);
+
+        assert!(report.items.is_empty());
+        assert!(report
+            .render_markdown()
+            .contains("No missing tools with known checks."));
+    }
+}


### PR DESCRIPTION
## Summary
- Add :ToolInstall / :LspInstall to open a read-only install report for missing configured LSP servers and formatters.
- Centralize known install commands and reuse them for missing LSP command hints.
- Document the new commands in README and KEYBINDINGS.

## Test Plan
- cargo fmt --all -- --check
- cargo test --quiet
- Manual: ran :ToolInstall and verified the [tool-installer] buffer opens as expected.