### PR TITLE
feat: add read-only view subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ nevi .
 # Open a file
 nevi src/main.rs
 
+# Open a file as a read-only terminal viewer
+nevi view src/main.rs
+
 # Open multiple files
 nevi file1.rs file2.rs
 ```

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -24,7 +24,9 @@ pub struct Buffer {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum BufferKind {
-    File,
+    File {
+        read_only: bool,
+    },
     Untitled,
     Virtual {
         name: String,
@@ -48,6 +50,15 @@ impl Buffer {
 
     /// Create a buffer from a file
     pub fn from_file(path: PathBuf) -> anyhow::Result<Self> {
+        Self::from_file_with_read_only(path, false)
+    }
+
+    /// Create a read-only buffer from a file.
+    pub fn from_file_read_only(path: PathBuf) -> anyhow::Result<Self> {
+        Self::from_file_with_read_only(path, true)
+    }
+
+    fn from_file_with_read_only(path: PathBuf, read_only: bool) -> anyhow::Result<Self> {
         let (text, last_mtime) = if path.exists() {
             let mtime = std::fs::metadata(&path)?.modified().ok();
             let rope = Rope::from_reader(std::fs::File::open(&path)?)?;
@@ -63,7 +74,7 @@ impl Buffer {
             dirty: false,
             version: 0,
             last_mtime,
-            kind: BufferKind::File,
+            kind: BufferKind::File { read_only },
         })
     }
 
@@ -91,17 +102,33 @@ impl Buffer {
     pub fn is_read_only(&self) -> bool {
         matches!(
             self.kind,
-            BufferKind::Virtual {
-                read_only: true,
-                ..
-            }
+            BufferKind::File { read_only: true }
+                | BufferKind::Virtual {
+                    read_only: true,
+                    ..
+                }
         )
+    }
+
+    /// Update read-only state for file-backed buffers.
+    pub fn set_read_only(&mut self, read_only: bool) {
+        if let BufferKind::File {
+            read_only: ref mut file_read_only,
+        } = self.kind
+        {
+            *file_read_only = read_only;
+        }
+    }
+
+    /// Whether this is a file-backed buffer.
+    pub fn is_file_backed(&self) -> bool {
+        matches!(self.kind, BufferKind::File { .. })
     }
 
     /// Mark this buffer as file-backed.
     pub fn set_file_path(&mut self, path: PathBuf) {
         self.path = Some(path);
-        self.kind = BufferKind::File;
+        self.kind = BufferKind::File { read_only: false };
     }
 
     /// Path used for syntax detection. Virtual buffers may provide a synthetic hint.
@@ -110,7 +137,7 @@ impl Buffer {
             BufferKind::Virtual {
                 syntax_hint_path, ..
             } => syntax_hint_path.as_ref(),
-            BufferKind::File | BufferKind::Untitled => self.path.as_ref(),
+            BufferKind::File { .. } | BufferKind::Untitled => self.path.as_ref(),
         }
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3293,6 +3293,19 @@ impl Editor {
 
     /// Open a file in the editor (replaces current buffer or adds new one)
     pub fn open_file(&mut self, path: std::path::PathBuf) -> anyhow::Result<()> {
+        self.open_file_with_read_only(path, false)
+    }
+
+    /// Open a file as read-only.
+    pub fn open_file_read_only(&mut self, path: std::path::PathBuf) -> anyhow::Result<()> {
+        self.open_file_with_read_only(path, true)
+    }
+
+    fn open_file_with_read_only(
+        &mut self,
+        path: std::path::PathBuf,
+        read_only: bool,
+    ) -> anyhow::Result<()> {
         // Check if file is already open in an existing buffer
         let canonical_path = path.canonicalize().ok();
         if let Some(existing_idx) = self
@@ -3310,6 +3323,9 @@ impl Editor {
             self.cursor = Cursor::default();
             self.viewport_offset = 0;
             self.h_offset = 0;
+            if read_only && self.buffers[existing_idx].is_file_backed() {
+                self.buffers[existing_idx].set_read_only(true);
+            }
             // Sync active pane state
             if self.active_pane < self.panes.len() {
                 self.panes[self.active_pane].buffer_idx = existing_idx;
@@ -3328,7 +3344,11 @@ impl Editor {
         // Set up syntax highlighting based on file extension
         self.syntax.set_language_from_path(&path);
 
-        let new_buffer = Buffer::from_file(path)?;
+        let new_buffer = if read_only {
+            Buffer::from_file_read_only(path)?
+        } else {
+            Buffer::from_file(path)?
+        };
 
         // If current buffer is empty and unnamed, replace it; otherwise add new buffer
         if self.buffers[self.current_buffer_idx].is_empty()
@@ -10779,6 +10799,36 @@ mod tests {
             Some("Buffer is read-only")
         );
         assert!(!editor.buffer().dirty);
+    }
+
+    #[test]
+    fn read_only_file_buffer_rejects_insert_and_save() {
+        let tmp = unique_temp_dir("nevi_read_only_file_buffer");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("main.rs");
+        std::fs::write(&path, "fn main() {}\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.open_file_read_only(path.clone()).expect("open file");
+
+        assert_eq!(editor.buffer().path.as_ref(), Some(&path));
+        assert!(editor.buffer().is_read_only());
+        assert!(!editor.buffer().dirty);
+
+        editor.insert_char('x');
+        assert_eq!(editor.buffer().content(), "fn main() {}\n");
+        assert_eq!(
+            editor.status_message.as_deref(),
+            Some("Buffer is read-only")
+        );
+
+        let err = editor
+            .save()
+            .expect_err("read-only file should reject save");
+        assert!(err.to_string().contains("Buffer is read-only"));
+        assert!(!editor.buffer().dirty);
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,7 +129,9 @@ fn request_selected_completion_resolve(
 #[derive(Debug, Clone, PartialEq, Eq)]
 enum CliStartupAction {
     PrintVersion,
+    PrintUsageError(String),
     LaunchEditor(Option<PathBuf>),
+    ViewFile(PathBuf),
 }
 
 fn version_output() -> String {
@@ -144,18 +146,27 @@ where
     let mut args = args.into_iter();
     match args.next() {
         Some(arg) if matches!(arg.as_ref(), "--version" | "-V") => CliStartupAction::PrintVersion,
+        Some(arg) if arg.as_ref() == "view" => match args.next() {
+            Some(path) => CliStartupAction::ViewFile(PathBuf::from(path.as_ref())),
+            None => CliStartupAction::PrintUsageError("usage: nevi view <file>".to_string()),
+        },
         Some(arg) => CliStartupAction::LaunchEditor(Some(PathBuf::from(arg.as_ref()))),
         None => CliStartupAction::LaunchEditor(None),
     }
 }
 
 fn main() -> anyhow::Result<()> {
-    let arg_path = match startup_action_from_args(env::args().skip(1)) {
+    let (arg_path, read_only_view) = match startup_action_from_args(env::args().skip(1)) {
         CliStartupAction::PrintVersion => {
             println!("{}", version_output());
             return Ok(());
         }
-        CliStartupAction::LaunchEditor(path) => path,
+        CliStartupAction::PrintUsageError(message) => {
+            eprintln!("{}", message);
+            std::process::exit(2);
+        }
+        CliStartupAction::LaunchEditor(path) => (path, false),
+        CliStartupAction::ViewFile(path) => (Some(path), true),
     };
 
     // Profiling is opt-in with NEVI_PROFILE=1/true/yes/on.
@@ -197,7 +208,11 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Load configuration
-    let settings = load_config();
+    let mut settings = load_config();
+    if read_only_view {
+        settings.lsp.enabled = false;
+        settings.copilot.enabled = false;
+    }
     // Store LSP settings before moving settings into editor
     let lsp_enabled = settings.lsp.enabled;
     let lsp_servers = settings.lsp.servers.clone();
@@ -233,7 +248,17 @@ fn main() -> anyhow::Result<()> {
         // Canonicalize the path to get absolute path
         let abs_path = path.canonicalize().unwrap_or_else(|_| path.clone());
 
-        if abs_path.is_dir() {
+        if read_only_view {
+            if !abs_path.is_file() {
+                anyhow::bail!("view expects an existing file: {}", path.display());
+            }
+            initial_file = Some(abs_path.clone());
+            if let Some(parent) = abs_path.parent() {
+                editor.set_project_root(parent.to_path_buf());
+            }
+            editor.open_file_read_only(abs_path.clone())?;
+            editor.set_status(format!("Read-only view: {}", abs_path.display()));
+        } else if abs_path.is_dir() {
             // Directory: set as project root and open file picker
             editor.set_project_root(abs_path);
             open_file_picker = true;
@@ -2347,6 +2372,22 @@ mod tests {
         assert_eq!(
             startup_action_from_args(["README.md"]),
             CliStartupAction::LaunchEditor(Some(PathBuf::from("README.md")))
+        );
+    }
+
+    #[test]
+    fn cli_view_subcommand_opens_read_only_file_path() {
+        assert_eq!(
+            startup_action_from_args(["view", "README.md"]),
+            CliStartupAction::ViewFile(PathBuf::from("README.md"))
+        );
+    }
+
+    #[test]
+    fn cli_view_subcommand_requires_file_path() {
+        assert_eq!(
+            startup_action_from_args(["view"]),
+            CliStartupAction::PrintUsageError("usage: nevi view <file>".to_string())
         );
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2663,6 +2663,11 @@ impl Terminal {
         };
 
         let filename = editor.buffer().display_name();
+        let read_only = if editor.buffer().is_read_only() {
+            " [RO]"
+        } else {
+            ""
+        };
         let modified = if editor.buffer().dirty { " [+]" } else { "" };
 
         // Show macro recording indicator
@@ -2683,8 +2688,8 @@ impl Terminal {
 
         let mode_display = format!(" {} ", mode_str);
         let rest_left = format!(
-            "{}{} | {}{}{} ",
-            pending, recording, project_name, filename, modified
+            "{}{} | {}{}{}{} ",
+            pending, recording, project_name, filename, read_only, modified
         );
 
         // Right side: LSP status, language and position


### PR DESCRIPTION
## Summary
- Add `nevi view <file>` as a read-only terminal viewer mode.
- Add file-backed read-only buffers and a `[RO]` statusline marker.
- Skip LSP and Copilot startup in view mode to keep the path lightweight.
- Document the new CLI usage in README.

## Test Plan
- `cargo fmt --all -- --check`
- `cargo test --quiet`
- `git diff --check`
- Manual: `cargo run -- view /private/tmp/nevi_view_mode_demo.rs`; verified read-only behavior works as expected.