### PR TITLE
fix: keep pick output scriptable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -143,8 +143,22 @@ enum PickModeAction {
     Select(PathBuf),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TerminalOutputTarget {
+    Stdout,
+    Tty,
+}
+
 fn version_output() -> String {
     format!("nevi {}", env!("CARGO_PKG_VERSION"))
+}
+
+fn terminal_output_target_for_pick_mode(pick_mode: bool) -> TerminalOutputTarget {
+    if pick_mode {
+        TerminalOutputTarget::Tty
+    } else {
+        TerminalOutputTarget::Stdout
+    }
 }
 
 fn startup_action_from_args<I, S>(args: I) -> CliStartupAction
@@ -190,7 +204,9 @@ fn pick_mode_action_for_key(editor: &Editor, key: KeyEvent) -> PickModeAction {
         (KeyModifiers::NONE, KeyCode::Esc)
         | (KeyModifiers::CONTROL, KeyCode::Char('c'))
         | (KeyModifiers::CONTROL, KeyCode::Char('[')) => PickModeAction::Cancel,
-        (KeyModifiers::NONE, KeyCode::Char('q')) if editor.finder.query.is_empty() => {
+        (KeyModifiers::NONE, KeyCode::Char('q'))
+            if editor.finder.is_normal_mode() && editor.finder.query.is_empty() =>
+        {
             PickModeAction::Cancel
         }
         _ => PickModeAction::Continue,
@@ -364,7 +380,10 @@ fn main() -> anyhow::Result<()> {
     }
 
     // Initialize terminal
-    let mut terminal = Terminal::new()?;
+    let mut terminal = match terminal_output_target_for_pick_mode(pick_mode) {
+        TerminalOutputTarget::Stdout => Terminal::new()?,
+        TerminalOutputTarget::Tty => Terminal::new_tty()?,
+    };
 
     // Get initial size
     let (width, height) = Terminal::size()?;
@@ -2397,7 +2416,8 @@ mod tests {
         apply_edits_to_file, diagnostic_to_lsp_offsets, editor_lsp_cursor_col, editor_lsp_line_len,
         lsp_completion_response_matches_current_cursor, lsp_response_matches_current_buffer,
         pick_mode_action_for_key, profile_enabled_from_value, startup_action_from_args,
-        CliStartupAction, PickModeAction,
+        terminal_output_target_for_pick_mode, CliStartupAction, PickModeAction,
+        TerminalOutputTarget,
     };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use nevi::lsp::types::{Diagnostic, DiagnosticSeverity, TextEdit};
@@ -2549,6 +2569,7 @@ mod tests {
         let mut editor = Editor::default();
         editor.mode = Mode::Finder;
         editor.finder.mode = nevi::finder::FinderMode::Files;
+        editor.finder.input_mode = nevi::finder::FinderInputMode::Normal;
 
         assert_eq!(
             pick_mode_action_for_key(&editor, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
@@ -2569,6 +2590,43 @@ mod tests {
                 KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)
             ),
             PickModeAction::Continue
+        );
+    }
+
+    #[test]
+    fn pick_mode_q_only_cancels_in_finder_normal_mode() {
+        let mut editor = Editor::default();
+        editor.mode = Mode::Finder;
+        editor.finder.mode = nevi::finder::FinderMode::Files;
+        editor.finder.input_mode = nevi::finder::FinderInputMode::Insert;
+
+        assert_eq!(
+            pick_mode_action_for_key(
+                &editor,
+                KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)
+            ),
+            PickModeAction::Continue
+        );
+
+        editor.finder.input_mode = nevi::finder::FinderInputMode::Normal;
+        assert_eq!(
+            pick_mode_action_for_key(
+                &editor,
+                KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE)
+            ),
+            PickModeAction::Cancel
+        );
+    }
+
+    #[test]
+    fn pick_mode_uses_tty_for_terminal_output() {
+        assert_eq!(
+            terminal_output_target_for_pick_mode(true),
+            TerminalOutputTarget::Tty
+        );
+        assert_eq!(
+            terminal_output_target_for_pick_mode(false),
+            TerminalOutputTarget::Stdout
         );
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9,7 +9,7 @@ use crossterm::{
     style::{Attribute, Color, ResetColor, SetAttribute, SetBackgroundColor, SetForegroundColor},
     terminal::{self, ClearType},
 };
-use std::io::{self, Stdout, Write};
+use std::io::{self, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Instant;
 use unicode_width::UnicodeWidthChar;
@@ -552,15 +552,25 @@ fn source_col_for_wrap_segment_char(segment: &WrapSegment, visual_idx: usize) ->
 
 /// Terminal handler responsible for rendering and input
 pub struct Terminal {
-    stdout: Stdout,
+    stdout: Box<dyn Write>,
     mouse_capture_enabled: bool,
     leader_popup_rect: Option<(u16, u16)>,
 }
 
 impl Terminal {
     pub fn new() -> anyhow::Result<Self> {
-        let mut stdout = io::stdout();
+        Self::new_with_writer(Box::new(io::stdout()))
+    }
 
+    pub fn new_tty() -> anyhow::Result<Self> {
+        let tty = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/tty")?;
+        Self::new_with_writer(Box::new(tty))
+    }
+
+    fn new_with_writer(mut stdout: Box<dyn Write>) -> anyhow::Result<Self> {
         // Enter raw mode and alternate screen
         terminal::enable_raw_mode()?;
         execute!(


### PR DESCRIPTION
## Summary
- render `nevi pick` TUI through `/dev/tty` so stdout only contains the selected path
- keep `q` searchable in finder Insert mode; only cancel on `q` from finder Normal mode
- add tests for pick-mode output routing and q-cancel behavior

## Verification
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test pick --quiet`
- `cargo test --quiet`

## Manual test
- `selected=$(cargo run --quiet -- pick /private/tmp/nevi_pick_test)` captured only the selected path
- selected path verified as `/private/tmp/nevi_pick_test/query.rs`