### PR TITLE
feat: add Go language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,7 @@ dependencies = [
  "toml_edit",
  "tree-sitter",
  "tree-sitter-css",
+ "tree-sitter-go",
  "tree-sitter-html",
  "tree-sitter-javascript",
  "tree-sitter-json",
@@ -1759,6 +1760,16 @@ name = "tree-sitter-css"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad6489794d41350d12a7fbe520e5199f688618f43aace5443980d1ddcf1b29e"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tree-sitter-md = "0.3"
 tree-sitter-toml-ng = "0.7"
 tree-sitter-html = "0.23"
 tree-sitter-python = "0.23"
+tree-sitter-go = "0.25.0"
 streaming-iterator = "0.1"
 
 # System clipboard

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A fast, native terminal editor where your existing vim/neovim muscle memory just
 
 - **Vim/neovim keybindings** - Most common keybinds implemented, more being added regularly
 - **Built-in LSP** - rust-analyzer, typescript-language-server, pyright, and more
-- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
+- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, Go, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
 - **Theme selection** - Multiple built-in colorschemes with easy switching
 - **Fuzzy file finder** - Telescope-style file and content search
 - **Previewed project replace** - Project-wide literal replace with a read-only preview and explicit apply step
@@ -142,6 +142,7 @@ Optional tools unlock optional features:
 | CSS / JSON / HTML LSP | `vscode-langservers-extracted` | `npm install -g vscode-langservers-extracted` |
 | TOML LSP | `taplo` | `cargo install taplo-cli --locked` |
 | Python LSP | `pyright` | `npm install -g pyright` |
+| Go LSP | `gopls` | `go install golang.org/x/tools/gopls@latest` |
 | Markdown LSP | `marksman` | Optional and disabled by default |
 | External formatters | Whatever formatter you configure | Examples: `biome`, `prettier`, `black`, `gofmt` |
 | Git signs / `:GitChanges` | A Git repository | No external `git` CLI required |

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -647,6 +647,7 @@ pub struct LspServers {
     pub markdown: LspServerConfig,
     pub html: LspServerConfig,
     pub python: LspServerConfig,
+    pub go: LspServerConfig,
 }
 
 impl Default for LspServers {
@@ -744,6 +745,14 @@ impl Default for LspServers {
                     "pyrightconfig.json".to_string(),
                 ],
                 file_extensions: vec!["py".to_string(), "pyi".to_string(), "pyw".to_string()],
+            },
+            go: LspServerConfig {
+                enabled: true,
+                preset: None,
+                command: "gopls".to_string(),
+                args: Vec::new(),
+                root_patterns: vec!["go.work".to_string(), "go.mod".to_string()],
+                file_extensions: vec!["go".to_string()],
             },
         }
     }
@@ -1410,7 +1419,7 @@ fn default_config_template() -> &'static str {
 # ============================================================================
 # LSP servers are auto-detected and enabled by default.
 # Supported: rust-analyzer, typescript-language-server, vscode-css-language-server,
-# vscode-json-language-server, taplo, vscode-html-language-server, pyright-langserver
+# vscode-json-language-server, taplo, vscode-html-language-server, pyright-langserver, gopls
 # Optional: marksman for Markdown (disabled by default)
 #
 # To disable LSP entirely:
@@ -1553,6 +1562,7 @@ fn merge_lsp_servers_with_defaults(user: LspServers) -> LspServers {
         markdown: merge_lsp_server_config(defaults.markdown, user.markdown),
         html: merge_lsp_server_config(defaults.html, user.html),
         python: merge_lsp_server_config(defaults.python, user.python),
+        go: merge_lsp_server_config(defaults.go, user.go),
     }
 }
 
@@ -1695,6 +1705,25 @@ mod tests {
         assert_eq!(
             settings.lsp.servers.rust.preset,
             Some(LspPreset::RustAnalyzer)
+        );
+    }
+
+    #[test]
+    fn go_lsp_defaults_use_gopls() {
+        let settings = Settings::default();
+
+        assert_eq!(settings.lsp.servers.go.effective_command(), "gopls");
+        assert_eq!(
+            settings.lsp.servers.go.effective_args(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            settings.lsp.servers.go.root_patterns,
+            vec!["go.work".to_string(), "go.mod".to_string()]
+        );
+        assert_eq!(
+            settings.lsp.servers.go.file_extensions,
+            vec!["go".to_string()]
         );
     }
 

--- a/src/health.rs
+++ b/src/health.rs
@@ -453,6 +453,7 @@ where
         command_tool_health_if_enabled("markdown", &servers.markdown, is_command_available),
         command_tool_health_if_enabled("html", &servers.html, is_command_available),
         command_tool_health_if_enabled("python", &servers.python, is_command_available),
+        command_tool_health_if_enabled("go", &servers.go, is_command_available),
     ]
     .into_iter()
     .flatten()
@@ -653,6 +654,7 @@ fn lsp_server_health(settings: &crate::config::Settings) -> Vec<LspServerHealth>
         server_health("markdown", &servers.markdown),
         server_health("html", &servers.html),
         server_health("python", &servers.python),
+        server_health("go", &servers.go),
     ]
 }
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -680,6 +680,7 @@ mod tests {
             ("file.less", "less"),
             ("file.pyi", "python"),
             ("file.pyw", "python"),
+            ("file.go", "go"),
         ];
 
         for (path, language) in cases {

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -24,6 +24,7 @@ pub enum LanguageId {
     Markdown,
     Html,
     Python,
+    Go,
 }
 
 impl LanguageId {
@@ -39,6 +40,7 @@ impl LanguageId {
             "md" | "markdown" => Some(Self::Markdown),
             "html" | "htm" => Some(Self::Html),
             "py" | "pyi" | "pyw" => Some(Self::Python),
+            "go" => Some(Self::Go),
             _ => None,
         }
     }
@@ -62,6 +64,7 @@ impl LanguageId {
             Self::Markdown => "markdown",
             Self::Html => "html",
             Self::Python => "python",
+            Self::Go => "go",
         }
     }
 }
@@ -113,6 +116,7 @@ impl MultiLspManager {
             LanguageId::Markdown,
             LanguageId::Html,
             LanguageId::Python,
+            LanguageId::Go,
         ]
         .into_iter()
         .find(|lang| {
@@ -289,6 +293,7 @@ impl MultiLspManager {
         markdown_config: LspServerConfig,
         html_config: LspServerConfig,
         python_config: LspServerConfig,
+        go_config: LspServerConfig,
     ) -> Self {
         let mut configs = HashMap::new();
         configs.insert(LanguageId::Rust, rust_config);
@@ -300,6 +305,7 @@ impl MultiLspManager {
         configs.insert(LanguageId::Markdown, markdown_config);
         configs.insert(LanguageId::Html, html_config);
         configs.insert(LanguageId::Python, python_config);
+        configs.insert(LanguageId::Go, go_config);
 
         Self {
             instances: HashMap::new(),
@@ -855,6 +861,7 @@ mod tests {
             servers.markdown,
             servers.html,
             servers.python,
+            servers.go,
         )
     }
 
@@ -925,6 +932,28 @@ mod tests {
         assert_eq!(
             manager.status(Some(Path::new("src/main.rs"))),
             "LSP: rust-analyzer not started (rust)"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn go_extension_routes_to_go_language_server() {
+        let tmp = unique_temp_dir("nevi_lsp_go_route");
+        let workspace_root = tmp.join("workspace");
+        fs::create_dir_all(&workspace_root).expect("create workspace");
+
+        let manager = make_manager(workspace_root);
+
+        assert_eq!(LanguageId::from_extension("go"), Some(LanguageId::Go));
+        assert_eq!(LanguageId::Go.as_lsp_id(), "go");
+        assert_eq!(
+            manager.language_for_path(Path::new("cmd/nevi/main.go")),
+            Some(LanguageId::Go)
+        );
+        assert_eq!(
+            manager.status(Some(Path::new("cmd/nevi/main.go"))),
+            "LSP: gopls not started (go)"
         );
 
         let _ = fs::remove_dir_all(&tmp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,6 +412,7 @@ fn main() -> anyhow::Result<()> {
             &lsp_servers.markdown,
             &lsp_servers.html,
             &lsp_servers.python,
+            &lsp_servers.go,
         ] {
             for marker in &cfg.root_patterns {
                 if marker.trim().is_empty() {
@@ -447,6 +448,7 @@ fn main() -> anyhow::Result<()> {
             lsp_servers.markdown,
             lsp_servers.html,
             lsp_servers.python,
+            lsp_servers.go,
         );
         multi_lsp = Some(mgr);
         editor.set_lsp_status("LSP: (no server)");

--- a/src/syntax/highlighter.rs
+++ b/src/syntax/highlighter.rs
@@ -1232,6 +1232,131 @@ pub fn python_highlight_query() -> &'static str {
 "##
 }
 
+/// Get the highlight query for Go
+pub fn go_highlight_query() -> &'static str {
+    r##"
+; Comments
+(comment) @comment
+
+; Strings and runes
+(interpreted_string_literal) @string
+(raw_string_literal) @string
+(rune_literal) @string
+
+; Numbers
+(int_literal) @number
+(float_literal) @number
+(imaginary_literal) @number
+
+; Constants
+(nil) @constant
+(true) @constant
+(false) @constant
+(iota) @constant
+
+; Keywords
+[
+  "break"
+  "case"
+  "chan"
+  "const"
+  "continue"
+  "default"
+  "defer"
+  "else"
+  "fallthrough"
+  "for"
+  "func"
+  "go"
+  "goto"
+  "if"
+  "import"
+  "interface"
+  "map"
+  "package"
+  "range"
+  "return"
+  "select"
+  "struct"
+  "switch"
+  "type"
+  "var"
+] @keyword
+
+; Declarations
+(function_declaration name: (identifier) @function)
+(method_declaration name: (field_identifier) @function)
+(type_declaration (type_spec name: (type_identifier) @type))
+
+; Types and namespaces
+(type_identifier) @type
+(package_identifier) @namespace
+
+; Calls and selectors
+(call_expression function: (identifier) @function)
+(selector_expression field: (field_identifier) @property)
+
+; Identifiers
+(field_identifier) @property
+(identifier) @variable
+
+; Operators
+[
+  "+"
+  "-"
+  "*"
+  "/"
+  "%"
+  "&"
+  "|"
+  "^"
+  "<<"
+  ">>"
+  "&^"
+  "+="
+  "-="
+  "*="
+  "/="
+  "%="
+  "&="
+  "|="
+  "^="
+  "<<="
+  ">>="
+  "&^="
+  "&&"
+  "||"
+  "<-"
+  "++"
+  "--"
+  "=="
+  "<"
+  ">"
+  "="
+  "!"
+  "!="
+  "<="
+  ">="
+  ":="
+  "..."
+] @operator
+
+; Punctuation
+[
+  "("
+  ")"
+  "["
+  "]"
+  "{"
+  "}"
+  "."
+  ","
+  ";"
+  ":"
+] @punctuation
+"##
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1372,6 +1497,11 @@ mod tests {
             python_highlight_query(),
             "Python",
         );
+    }
+
+    #[test]
+    fn go_highlight_query_compiles() {
+        assert_query_compiles(tree_sitter_go::LANGUAGE.into(), go_highlight_query(), "Go");
     }
 
     #[test]

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -69,6 +69,7 @@ impl SyntaxManager {
             Some("yaml") | Some("yml") => self.set_yaml_language(),
             Some("html") | Some("htm") => self.set_html_language(),
             Some("py") | Some("pyi") | Some("pyw") => self.set_python_language(),
+            Some("go") => self.set_go_language(),
             _ => {
                 self.language = None;
                 self.query = None;
@@ -372,6 +373,30 @@ impl SyntaxManager {
             }
             Err(e) => {
                 self.language = Some(format!("python (lang error: {:?})", e));
+            }
+        }
+    }
+
+    /// Set up Go language parser
+    fn set_go_language(&mut self) {
+        let language = tree_sitter_go::LANGUAGE;
+        match self.parser.set_language(&language.into()) {
+            Ok(()) => {
+                self.language = Some("go".to_string());
+
+                let query_source = highlighter::go_highlight_query();
+                match Query::new(&language.into(), query_source) {
+                    Ok(query) => {
+                        self.query = Some(query);
+                    }
+                    Err(e) => {
+                        self.language = Some(format!("go (query error: {:?})", e));
+                        self.query = None;
+                    }
+                }
+            }
+            Err(e) => {
+                self.language = Some(format!("go (lang error: {:?})", e));
             }
         }
     }
@@ -713,6 +738,23 @@ mod tests {
         assert!(
             !syntax.get_line_highlights(1).is_empty(),
             "scss should use the SCSS highlight path instead of plain text"
+        );
+    }
+
+    #[test]
+    fn go_extension_uses_go_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("main.go"));
+
+        let mut buffer = Buffer::new();
+        buffer.set_content("package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n");
+        syntax.parse(&buffer);
+
+        assert_eq!(syntax.language_name(), Some("go"));
+        assert!(syntax.has_highlighting());
+        assert!(
+            !syntax.get_line_highlights(0).is_empty(),
+            "go files should use Go syntax highlighting"
         );
     }
 }

--- a/src/tool_installer.rs
+++ b/src/tool_installer.rs
@@ -121,6 +121,7 @@ where
             &servers.python,
             &is_command_available,
         );
+        add_lsp_tool(&mut grouped, "go", &servers.go, &is_command_available);
     }
 
     for (language, config) in &languages_config.languages {
@@ -212,6 +213,7 @@ pub fn install_command_for(command: &str) -> Option<&'static str> {
         | "vscode-eslint-language-server" => Some("npm install -g vscode-langservers-extracted"),
         "taplo" | "taplo.exe" => Some("cargo install taplo-cli --locked"),
         "pyright-langserver" | "pyright-langserver.cmd" => Some("npm install -g pyright"),
+        "gopls" | "gopls.exe" => Some("go install golang.org/x/tools/gopls@latest"),
         "pylsp" => Some("pipx install python-lsp-server"),
         "biome" | "biome.cmd" => Some("npm install -g @biomejs/biome"),
         "oxfmt" | "oxfmt.cmd" => Some("npm install -g oxfmt"),
@@ -245,6 +247,7 @@ mod tests {
         settings.lsp.servers.markdown.enabled = false;
         settings.lsp.servers.html.enabled = false;
         settings.lsp.servers.python.enabled = false;
+        settings.lsp.servers.go.enabled = false;
     }
 
     #[test]
@@ -256,6 +259,10 @@ mod tests {
         assert_eq!(
             super::install_command_for("rust-analyzer.exe"),
             Some("rustup component add rust-analyzer")
+        );
+        assert_eq!(
+            super::install_command_for("gopls"),
+            Some("go install golang.org/x/tools/gopls@latest")
         );
     }
 


### PR DESCRIPTION
## Summary
- Add tree-sitter Go syntax highlighting and .go file detection.
- Route Go files through the multi-LSP manager with a default gopls configuration.
- Surface gopls in health/tool-install guidance and document Go support in the README.

## Test Plan
- cargo fmt -- --check
- cargo build
- cargo test

## Manual Verification
- Opened a sample main.go file and confirmed syntax highlighting.
- Installed gopls and confirmed hover documentation works.
- Introduced an undefined symbol and confirmed diagnostics are shown.