### PR TITLE
feat: show large file mode visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,9 +450,12 @@ terminal-only renders.
 Run `:checkhealth` (or `:Health`) inside Nevi to open a read-only `[health]`
 buffer with config paths, config discoverability commands, keymap overrides and
 warnings, LSP settings, optional external tool checks, formatter command checks,
-profiling status, and any profile summary from `/tmp/nevi_profile.log`. Because
-it is a regular buffer, normal motions, search, and yank commands work there.
-Profile summaries are written when a profiled Nevi session exits.
+profiling status, large-file thresholds, the active buffer's large-file mode,
+and any profile summary from `/tmp/nevi_profile.log`. When syntax highlighting
+is degraded for a very large buffer, the statusline shows `[large]` and
+`:checkhealth` reports the active threshold. Because it is a regular buffer,
+normal motions, search, and yank commands work there. Profile summaries are
+written when a profiled Nevi session exits.
 
 ## License
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1739,7 +1739,11 @@ impl Editor {
 
     /// Open a health report in a read-only virtual buffer.
     pub fn open_health_report(&mut self) {
-        let report = crate::health::collect_health_report(&self.settings, &self.languages_config);
+        let report = crate::health::collect_health_report(
+            &self.settings,
+            &self.languages_config,
+            Some(self.current_large_file_health()),
+        );
         self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
     }
 
@@ -2666,6 +2670,24 @@ impl Editor {
     /// Get a mutable reference to the current buffer
     pub fn buffer_mut(&mut self) -> &mut Buffer {
         &mut self.buffers[self.current_buffer_idx]
+    }
+
+    pub fn current_large_file_health(&self) -> crate::health::LargeFileHealth {
+        let buffer = self.buffer();
+        let line_count = buffer.len_lines();
+        let char_count = buffer.len_chars();
+
+        crate::health::LargeFileHealth {
+            buffer_name: buffer.display_name(),
+            line_count,
+            char_count,
+            syntax_degraded: crate::syntax::exceeds_highlight_limits(line_count, char_count),
+        }
+    }
+
+    pub fn current_buffer_large_file_mode_active(&self) -> bool {
+        let buffer = self.buffer();
+        crate::syntax::exceeds_highlight_limits(buffer.len_lines(), buffer.len_chars())
     }
 
     fn reject_read_only_edit(&mut self) -> bool {
@@ -11064,7 +11086,21 @@ mod tests {
         assert!(content.contains("## Configuration"));
         assert!(content.contains("## Keymaps"));
         assert!(content.contains("## Performance"));
+        assert!(content.contains("Current buffer large-file mode: inactive"));
         assert!(content.contains("## LSP"));
+    }
+
+    #[test]
+    fn health_report_shows_current_large_file_mode() {
+        let mut editor = Editor::default();
+        let content = "x".repeat(crate::syntax::MAX_HIGHLIGHT_CHARS + 1);
+        editor.buffer_mut().set_content(&content);
+
+        editor.open_health_report();
+
+        let report = editor.buffer().content();
+        assert!(report.contains("Current buffer large-file mode: active"));
+        assert!(report.contains("Syntax highlighting: degraded"));
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -38,11 +38,20 @@ pub struct HealthReportInput {
     pub languages_status: FileCheckStatus,
     pub keymap: KeymapHealth,
     pub external_tools: ExternalToolsHealth,
+    pub large_file: Option<LargeFileHealth>,
     pub profile_enabled: bool,
     pub profile_log_path: PathBuf,
     pub profile_log_status: ProfileLogStatus,
     pub lsp_enabled: bool,
     pub lsp_servers: Vec<LspServerHealth>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LargeFileHealth {
+    pub buffer_name: String,
+    pub line_count: usize,
+    pub char_count: usize,
+    pub syntax_degraded: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -249,6 +258,41 @@ pub fn build_health_report(input: &HealthReportInput) -> String {
             report.push_str(&format!("- Profile summary: error ({error})\n"));
         }
     }
+    report.push_str(&format!(
+        "- Large file thresholds: syntax highlighting is disabled above {} lines or {} chars\n",
+        crate::syntax::MAX_HIGHLIGHT_LINES,
+        crate::syntax::MAX_HIGHLIGHT_CHARS
+    ));
+    match &input.large_file {
+        Some(large_file) => {
+            report.push_str(&format!(
+                "- Current buffer: {} ({} lines, {} chars)\n",
+                large_file.buffer_name, large_file.line_count, large_file.char_count
+            ));
+            report.push_str(&format!(
+                "- Current buffer large-file mode: {}\n",
+                if large_file.syntax_degraded {
+                    "active"
+                } else {
+                    "inactive"
+                }
+            ));
+            report.push_str(&format!(
+                "- Syntax highlighting: {}\n",
+                if large_file.syntax_degraded {
+                    "degraded to keep input/rendering responsive"
+                } else {
+                    "full"
+                }
+            ));
+        }
+        None => {
+            report.push_str("- Current buffer large-file mode: unavailable\n");
+        }
+    }
+    report.push_str(
+        "- Live grep large-file cutoff: none; it respects ignore patterns and binary extensions\n",
+    );
     report.push('\n');
 
     report.push_str("## LSP\n");
@@ -312,6 +356,7 @@ pub fn build_health_report(input: &HealthReportInput) -> String {
 pub fn collect_health_report(
     settings: &crate::config::Settings,
     languages_config: &crate::config::LanguagesConfig,
+    large_file: Option<LargeFileHealth>,
 ) -> String {
     let config_path = crate::config::config_path();
     let languages_path = crate::config::languages::languages_config_path();
@@ -330,6 +375,7 @@ pub fn collect_health_report(
             languages_config,
             command_exists_on_path,
         ),
+        large_file,
         profile_enabled: profile_enabled_from_env(),
         profile_log_status: inspect_profile_log(&profile_log_path),
         profile_log_path,
@@ -742,6 +788,7 @@ mod tests {
             languages_status: FileCheckStatus::Missing,
             keymap: default_keymap_health(),
             external_tools: default_external_tools_health(),
+            large_file: None,
             profile_enabled: false,
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
@@ -774,6 +821,7 @@ mod tests {
             languages_status: FileCheckStatus::Unavailable,
             keymap: default_keymap_health(),
             external_tools: default_external_tools_health(),
+            large_file: None,
             profile_enabled: true,
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Summary(vec![ProfileMetricSummary {
@@ -804,6 +852,7 @@ mod tests {
             languages_status: FileCheckStatus::Unavailable,
             keymap: default_keymap_health(),
             external_tools: default_external_tools_health(),
+            large_file: None,
             profile_enabled: false,
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Summary(vec![ProfileMetricSummary {
@@ -822,6 +871,29 @@ mod tests {
 
         assert!(report.contains("Profiling: disabled for this session"));
         assert!(report.contains("Profile summary: found from saved log"));
+    }
+
+    #[test]
+    fn health_report_lists_large_file_limits() {
+        let report = build_health_report(&HealthReportInput {
+            config_path: None,
+            config_status: FileCheckStatus::Unavailable,
+            languages_path: None,
+            languages_status: FileCheckStatus::Unavailable,
+            keymap: default_keymap_health(),
+            external_tools: default_external_tools_health(),
+            large_file: None,
+            profile_enabled: false,
+            profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
+            profile_log_status: ProfileLogStatus::Missing,
+            lsp_enabled: true,
+            lsp_servers: Vec::new(),
+        });
+
+        assert!(report.contains("Large file thresholds"));
+        assert!(report.contains("200000 lines"));
+        assert!(report.contains("2000000 chars"));
+        assert!(report.contains("Live grep large-file cutoff: none"));
     }
 
     #[test]
@@ -847,6 +919,7 @@ mod tests {
             languages_status: FileCheckStatus::Unavailable,
             keymap: keymap_health_from_settings(&settings.keymap),
             external_tools: default_external_tools_health(),
+            large_file: None,
             profile_enabled: false,
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
@@ -875,6 +948,7 @@ mod tests {
             languages_path: None,
             languages_status: FileCheckStatus::Unavailable,
             keymap: default_keymap_health(),
+            large_file: None,
             profile_enabled: false,
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -10,6 +10,13 @@ use tree_sitter::{Parser, Query, Tree};
 
 use crate::editor::Buffer;
 
+pub const MAX_HIGHLIGHT_LINES: usize = 200_000;
+pub const MAX_HIGHLIGHT_CHARS: usize = 2_000_000;
+
+pub fn exceeds_highlight_limits(line_count: usize, char_count: usize) -> bool {
+    line_count > MAX_HIGHLIGHT_LINES || char_count > MAX_HIGHLIGHT_CHARS
+}
+
 /// Manages syntax highlighting for a buffer
 pub struct SyntaxManager {
     /// Tree-sitter parser
@@ -425,10 +432,7 @@ impl SyntaxManager {
             return;
         }
 
-        const MAX_HIGHLIGHT_LINES: usize = 200_000;
-        const MAX_HIGHLIGHT_CHARS: usize = 2_000_000;
-
-        if buffer.len_lines() > MAX_HIGHLIGHT_LINES || buffer.len_chars() > MAX_HIGHLIGHT_CHARS {
+        if exceeds_highlight_limits(buffer.len_lines(), buffer.len_chars()) {
             self.tree = None;
             self.source_cache.clear();
             self.line_start_bytes.clear();

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2843,6 +2843,11 @@ impl Terminal {
         } else {
             ""
         };
+        let large_file = if editor.current_buffer_large_file_mode_active() {
+            " [large]"
+        } else {
+            ""
+        };
         let modified = if editor.buffer().dirty { " [+]" } else { "" };
 
         // Show macro recording indicator
@@ -2863,8 +2868,8 @@ impl Terminal {
 
         let mode_display = format!(" {} ", mode_str);
         let rest_left = format!(
-            "{}{} | {}{}{}{} ",
-            pending, recording, project_name, filename, read_only, modified
+            "{}{} | {}{}{}{}{} ",
+            pending, recording, project_name, filename, large_file, read_only, modified
         );
 
         // Right side: LSP status, language and position


### PR DESCRIPTION
## Summary
- expose syntax large-file thresholds from one shared helper
- show a [large] statusline marker when the active buffer exceeds syntax highlight limits
- add :checkhealth large-file threshold/current-buffer reporting and document it in README

## Verification
- cargo test --quiet