### PR TITLE
feat: add Ruby language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,7 @@ dependencies = [
  "tree-sitter-json",
  "tree-sitter-md",
  "tree-sitter-python",
+ "tree-sitter-ruby",
  "tree-sitter-rust",
  "tree-sitter-toml-ng",
  "tree-sitter-typescript",
@@ -1826,6 +1827,16 @@ name = "tree-sitter-python"
 version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d065aaa27f3aaceaf60c1f0e0ac09e1cb9eb8ed28e7bcdaa52129cffc7f4b04"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tree-sitter-toml-ng = "0.7"
 tree-sitter-html = "0.23"
 tree-sitter-python = "0.23"
 tree-sitter-go = "0.25.0"
+tree-sitter-ruby = "0.23.1"
 streaming-iterator = "0.1"
 
 # System clipboard

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A fast, native terminal editor where your existing vim/neovim muscle memory just
 
 - **Vim/neovim keybindings** - Most common keybinds implemented, more being added regularly
 - **Built-in LSP** - rust-analyzer, typescript-language-server, pyright, and more
-- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, Go, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
+- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, Go, Ruby, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
 - **Theme selection** - Multiple built-in colorschemes with easy switching
 - **Fuzzy file finder** - Telescope-style file and content search
 - **Previewed project replace** - Project-wide literal replace with a read-only preview and explicit apply step
@@ -143,6 +143,7 @@ Optional tools unlock optional features:
 | TOML LSP | `taplo` | `cargo install taplo-cli --locked` |
 | Python LSP | `pyright` | `npm install -g pyright` |
 | Go LSP | `gopls` | `go install golang.org/x/tools/gopls@latest` |
+| Ruby LSP | `ruby-lsp` | `gem install ruby-lsp` |
 | Markdown LSP | `marksman` | Optional and disabled by default |
 | External formatters | Whatever formatter you configure | Examples: `biome`, `prettier`, `black`, `gofmt` |
 | Git signs / `:GitChanges` | A Git repository | No external `git` CLI required |
@@ -379,10 +380,12 @@ Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-o
 | Rust | rust-analyzer | Supported |
 | TypeScript/JavaScript | typescript-language-server | Supported |
 | Python | pyright | Supported |
+| Ruby | ruby-lsp | Supported |
 | CSS/SCSS | vscode-css-language-server | Supported |
 | JSON | vscode-json-language-server | Supported |
 | TOML | taplo | Supported |
 | HTML | vscode-html-language-server | Supported |
+| Go | gopls | Supported |
 | Markdown | marksman | Optional, disabled by default |
 
 LSP servers are auto-detected when installed. See [`~/.config/nevi/config.toml`](#configuration) for LSP configuration options.

--- a/src/command_resolver.rs
+++ b/src/command_resolver.rs
@@ -1,0 +1,202 @@
+use std::collections::HashSet;
+use std::ffi::OsStr;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+pub(crate) fn resolve_command(command: &str) -> String {
+    let path_var = std::env::var_os("PATH");
+    resolve_command_with(command, path_var.as_deref())
+}
+
+fn resolve_command_with(command: &str, path_var: Option<&OsStr>) -> String {
+    let command = command.trim();
+    if command.is_empty() {
+        return String::new();
+    }
+
+    let command_path = Path::new(command);
+    if is_path_like_command(command) {
+        return command.to_string();
+    }
+    if find_command_on_path(command, path_var).is_some() {
+        return command.to_string();
+    }
+    if is_ruby_lsp_command(command) {
+        if let Some(command_path) = find_ruby_gem_command(command, path_var) {
+            return command_path.to_string_lossy().into_owned();
+        }
+    }
+
+    command_path.to_string_lossy().into_owned()
+}
+
+pub(crate) fn command_available(command: &str) -> bool {
+    resolve_command_path(command).map(|_| true).unwrap_or(false)
+}
+
+fn resolve_command_path(command: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os("PATH");
+    resolve_command_path_with(command, path_var.as_deref())
+}
+
+fn resolve_command_path_with(command: &str, path_var: Option<&OsStr>) -> Option<PathBuf> {
+    let command = command.trim();
+    if command.is_empty() {
+        return None;
+    }
+
+    let command_path = Path::new(command);
+    if is_path_like_command(command) {
+        return is_executable_file(command_path).then(|| command_path.to_path_buf());
+    }
+
+    if let Some(command_path) = find_command_on_path(command, path_var) {
+        return Some(command_path);
+    }
+
+    if is_ruby_lsp_command(command) {
+        return find_ruby_gem_command(command, path_var);
+    }
+
+    None
+}
+
+fn find_command_on_path(command: &str, path_var: Option<&OsStr>) -> Option<PathBuf> {
+    find_commands_on_path(command, path_var).into_iter().next()
+}
+
+fn find_commands_on_path(command: &str, path_var: Option<&OsStr>) -> Vec<PathBuf> {
+    let Some(path_var) = path_var else {
+        return Vec::new();
+    };
+
+    let mut seen = HashSet::new();
+    std::env::split_paths(path_var)
+        .map(|dir| dir.join(command))
+        .filter(|candidate| is_executable_file(candidate))
+        .filter(|candidate| seen.insert(candidate.clone()))
+        .collect()
+}
+
+fn is_ruby_lsp_command(command: &str) -> bool {
+    matches!(command_name(command), "ruby-lsp" | "ruby-lsp.cmd")
+}
+
+fn find_ruby_gem_command(command: &str, path_var: Option<&OsStr>) -> Option<PathBuf> {
+    find_commands_on_path("ruby", path_var)
+        .into_iter()
+        .filter_map(|ruby| ruby_gem_bindir(&ruby))
+        .map(|bindir| bindir.join(command))
+        .find(|candidate| is_executable_file(candidate))
+}
+
+fn ruby_gem_bindir(ruby: &Path) -> Option<PathBuf> {
+    let output = Command::new(ruby)
+        .args(["-e", "print Gem.bindir"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    stdout
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .map(PathBuf::from)
+}
+
+fn is_path_like_command(command: &str) -> bool {
+    Path::new(command).is_absolute() || command.contains('/') || command.contains('\\')
+}
+
+fn command_name(command: &str) -> &str {
+    Path::new(command)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(command)
+}
+
+fn is_executable_file(path: &Path) -> bool {
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return false;
+    };
+    if !metadata.is_file() {
+        return false;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        metadata.permissions().mode() & 0o111 != 0
+    }
+
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_root(test_name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos();
+        std::env::temp_dir().join(format!("nevi-{test_name}-{}-{nanos}", std::process::id()))
+    }
+
+    fn write_executable(path: &Path, contents: &str) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).expect("create parent");
+        }
+        fs::write(path, contents).expect("write executable");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut permissions = fs::metadata(path).expect("metadata").permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(path, permissions).expect("set executable bit");
+        }
+    }
+
+    #[test]
+    fn ruby_lsp_resolves_from_ruby_gem_bindir_when_not_on_path() {
+        let root = temp_root("ruby-lsp-gem-bindir");
+        let ruby_bin = root.join("ruby-bin");
+        let gem_bin = root.join("gem-bin");
+        let ruby = ruby_bin.join("ruby");
+        let ruby_lsp = gem_bin.join("ruby-lsp");
+        write_executable(
+            &ruby,
+            &format!("#!/bin/sh\nprintf '%s\\n' '{}'\n", gem_bin.display()),
+        );
+        write_executable(&ruby_lsp, "#!/bin/sh\n");
+
+        let path_var = std::env::join_paths([ruby_bin.as_path()]).expect("join path");
+        let resolved = resolve_command_path_with("ruby-lsp", Some(path_var.as_os_str()));
+
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(resolved.as_deref(), Some(ruby_lsp.as_path()));
+    }
+
+    #[test]
+    fn command_on_path_uses_configured_name_for_spawn() {
+        let root = temp_root("configured-command");
+        let bin = root.join("bin");
+        write_executable(&bin.join("ruby-lsp"), "#!/bin/sh\n");
+
+        let path_var = std::env::join_paths([bin.as_path()]).expect("join path");
+        let resolved = resolve_command_with("ruby-lsp", Some(path_var.as_os_str()));
+
+        let _ = fs::remove_dir_all(&root);
+        assert_eq!(resolved, "ruby-lsp");
+    }
+}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -648,6 +648,7 @@ pub struct LspServers {
     pub html: LspServerConfig,
     pub python: LspServerConfig,
     pub go: LspServerConfig,
+    pub ruby: LspServerConfig,
 }
 
 impl Default for LspServers {
@@ -753,6 +754,25 @@ impl Default for LspServers {
                 args: Vec::new(),
                 root_patterns: vec!["go.work".to_string(), "go.mod".to_string()],
                 file_extensions: vec!["go".to_string()],
+            },
+            ruby: LspServerConfig {
+                enabled: true,
+                preset: None,
+                command: "ruby-lsp".to_string(),
+                args: Vec::new(),
+                root_patterns: vec![
+                    "Gemfile".to_string(),
+                    ".ruby-version".to_string(),
+                    ".ruby-gemset".to_string(),
+                    ".rubocop.yml".to_string(),
+                ],
+                file_extensions: vec![
+                    "rb".to_string(),
+                    "rake".to_string(),
+                    "gemspec".to_string(),
+                    "ru".to_string(),
+                    "podspec".to_string(),
+                ],
             },
         }
     }
@@ -1419,7 +1439,7 @@ fn default_config_template() -> &'static str {
 # ============================================================================
 # LSP servers are auto-detected and enabled by default.
 # Supported: rust-analyzer, typescript-language-server, vscode-css-language-server,
-# vscode-json-language-server, taplo, vscode-html-language-server, pyright-langserver, gopls
+# vscode-json-language-server, taplo, vscode-html-language-server, pyright-langserver, gopls, ruby-lsp
 # Optional: marksman for Markdown (disabled by default)
 #
 # To disable LSP entirely:
@@ -1563,6 +1583,7 @@ fn merge_lsp_servers_with_defaults(user: LspServers) -> LspServers {
         html: merge_lsp_server_config(defaults.html, user.html),
         python: merge_lsp_server_config(defaults.python, user.python),
         go: merge_lsp_server_config(defaults.go, user.go),
+        ruby: merge_lsp_server_config(defaults.ruby, user.ruby),
     }
 }
 
@@ -1724,6 +1745,36 @@ mod tests {
         assert_eq!(
             settings.lsp.servers.go.file_extensions,
             vec!["go".to_string()]
+        );
+    }
+
+    #[test]
+    fn ruby_lsp_defaults_use_ruby_lsp() {
+        let settings = Settings::default();
+
+        assert_eq!(settings.lsp.servers.ruby.effective_command(), "ruby-lsp");
+        assert_eq!(
+            settings.lsp.servers.ruby.effective_args(),
+            Vec::<String>::new()
+        );
+        assert_eq!(
+            settings.lsp.servers.ruby.root_patterns,
+            vec![
+                "Gemfile".to_string(),
+                ".ruby-version".to_string(),
+                ".ruby-gemset".to_string(),
+                ".rubocop.yml".to_string()
+            ]
+        );
+        assert_eq!(
+            settings.lsp.servers.ruby.file_extensions,
+            vec![
+                "rb".to_string(),
+                "rake".to_string(),
+                "gemspec".to_string(),
+                "ru".to_string(),
+                "podspec".to_string()
+            ]
         );
     }
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3678,10 +3678,11 @@ impl Editor {
             self.cursor_wrapped_visual_row_from_viewport(cursor_segment_idx, wrap_width, tab_width);
 
         if cursor_visual_row < scroll_off {
-            if self.cursor.line != self.viewport_offset {
-                self.viewport_offset = self.cursor.line;
+            if self.cursor.line == self.viewport_offset {
+                self.h_offset = cursor_segment_idx.saturating_sub(scroll_off);
+            } else {
+                self.h_offset = 0;
             }
-            self.h_offset = cursor_segment_idx.saturating_sub(scroll_off);
             return;
         }
 
@@ -10778,6 +10779,26 @@ mod tests {
         editor.apply_motion(Motion::DisplayLineUp, 2);
 
         assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+    }
+
+    #[test]
+    fn wrapped_scroll_keeps_short_file_top_visible_when_cursor_moves_down() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 80;
+        editor.replace_buffer_content(
+            "class Greeter\n  def hello(name)\n    puts \"hello\n#{name}\"\n  end\nend\n",
+        );
+
+        editor.cursor.line = 1;
+        editor.scroll_to_cursor();
+
+        assert_eq!(
+            editor.viewport_offset, 0,
+            "moving down in a short wrapped buffer should keep earlier lines visible"
+        );
+        assert_eq!(editor.panes[editor.active_pane].viewport_offset, 0);
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 pub const PROFILE_LOG_PATH: &str = "/tmp/nevi_profile.log";
 
@@ -500,6 +500,7 @@ where
         command_tool_health_if_enabled("html", &servers.html, is_command_available),
         command_tool_health_if_enabled("python", &servers.python, is_command_available),
         command_tool_health_if_enabled("go", &servers.go, is_command_available),
+        command_tool_health_if_enabled("ruby", &servers.ruby, is_command_available),
     ]
     .into_iter()
     .flatten()
@@ -612,41 +613,7 @@ pub fn profile_enabled_from_value(value: Option<&str>) -> bool {
 }
 
 pub fn command_exists_on_path(command: &str) -> bool {
-    let command = command.trim();
-    if command.is_empty() {
-        return false;
-    }
-
-    let command_path = Path::new(command);
-    if command_path.is_absolute() || command.contains('/') {
-        return is_executable_file(command_path);
-    }
-
-    let Some(path_var) = std::env::var_os("PATH") else {
-        return false;
-    };
-
-    std::env::split_paths(&path_var).any(|dir| is_executable_file(&dir.join(command)))
-}
-
-fn is_executable_file(path: &Path) -> bool {
-    let Ok(metadata) = std::fs::metadata(path) else {
-        return false;
-    };
-    if !metadata.is_file() {
-        return false;
-    }
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        metadata.permissions().mode() & 0o111 != 0
-    }
-
-    #[cfg(not(unix))]
-    {
-        true
-    }
+    crate::command_resolver::command_available(command)
 }
 
 fn inspect_toml_file<T>(path: Option<&PathBuf>) -> FileCheckStatus
@@ -701,6 +668,7 @@ fn lsp_server_health(settings: &crate::config::Settings) -> Vec<LspServerHealth>
         server_health("html", &servers.html),
         server_health("python", &servers.python),
         server_health("go", &servers.go),
+        server_health("ruby", &servers.ruby),
     ]
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub(crate) mod command_resolver;
 pub mod commands;
 pub mod config;
 pub mod copilot;

--- a/src/lsp/client.rs
+++ b/src/lsp/client.rs
@@ -216,7 +216,8 @@ fn client_capabilities() -> ClientCapabilities {
 impl LspClient {
     /// Spawn a new LSP server process
     pub fn spawn(command: &str, args: &[String]) -> Result<(Self, PendingRequests, SharedStdin)> {
-        let mut process = Command::new(command)
+        let resolved_command = crate::command_resolver::resolve_command(command);
+        let mut process = Command::new(&resolved_command)
             .args(args)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -239,7 +240,7 @@ impl LspClient {
             Self {
                 process,
                 stdin,
-                command: command.to_string(),
+                command: resolved_command,
                 request_id: AtomicU64::new(1),
                 pending_requests,
             },

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -621,7 +621,9 @@ fn detect_language(path: &PathBuf) -> String {
         Some("cpp") | Some("cc") | Some("cxx") => "cpp".to_string(),
         Some("h") | Some("hpp") => "cpp".to_string(),
         Some("java") => "java".to_string(),
-        Some("rb") => "ruby".to_string(),
+        Some("rb") | Some("rake") | Some("gemspec") | Some("ru") | Some("podspec") => {
+            "ruby".to_string()
+        }
         Some("php") => "php".to_string(),
         Some("swift") => "swift".to_string(),
         Some("kt") | Some("kts") => "kotlin".to_string(),
@@ -681,6 +683,11 @@ mod tests {
             ("file.pyi", "python"),
             ("file.pyw", "python"),
             ("file.go", "go"),
+            ("file.rb", "ruby"),
+            ("file.rake", "ruby"),
+            ("file.gemspec", "ruby"),
+            ("config.ru", "ruby"),
+            ("file.podspec", "ruby"),
         ];
 
         for (path, language) in cases {

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -25,6 +25,7 @@ pub enum LanguageId {
     Html,
     Python,
     Go,
+    Ruby,
 }
 
 impl LanguageId {
@@ -41,15 +42,40 @@ impl LanguageId {
             "html" | "htm" => Some(Self::Html),
             "py" | "pyi" | "pyw" => Some(Self::Python),
             "go" => Some(Self::Go),
+            "rb" | "rake" | "gemspec" | "ru" | "podspec" => Some(Self::Ruby),
             _ => None,
         }
     }
 
     /// Detect language from file path
     pub fn from_path(path: &Path) -> Option<Self> {
+        if Self::is_ruby_path(path) {
+            return Some(Self::Ruby);
+        }
+
         path.extension()
             .and_then(|ext| ext.to_str())
             .and_then(Self::from_extension)
+    }
+
+    fn is_ruby_path(path: &Path) -> bool {
+        matches!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some(
+                "Appraisals"
+                    | "Berksfile"
+                    | "Brewfile"
+                    | "Capfile"
+                    | "Cheffile"
+                    | "Fastfile"
+                    | "Gemfile"
+                    | "Guardfile"
+                    | "Podfile"
+                    | "Rakefile"
+                    | "Thorfile"
+                    | "Vagrantfile"
+            )
+        )
     }
 
     /// Get the LSP language identifier string
@@ -65,6 +91,7 @@ impl LanguageId {
             Self::Html => "html",
             Self::Python => "python",
             Self::Go => "go",
+            Self::Ruby => "ruby",
         }
     }
 }
@@ -101,10 +128,11 @@ pub struct MultiLspManager {
 
 impl MultiLspManager {
     pub fn language_for_path(&self, path: &Path) -> Option<LanguageId> {
-        let ext = path.extension().and_then(|ext| ext.to_str())?;
-        if let Some(lang) = LanguageId::from_extension(ext) {
+        if let Some(lang) = LanguageId::from_path(path) {
             return Some(lang);
         }
+
+        let ext = path.extension().and_then(|ext| ext.to_str())?;
 
         [
             LanguageId::Rust,
@@ -117,6 +145,7 @@ impl MultiLspManager {
             LanguageId::Html,
             LanguageId::Python,
             LanguageId::Go,
+            LanguageId::Ruby,
         ]
         .into_iter()
         .find(|lang| {
@@ -294,6 +323,7 @@ impl MultiLspManager {
         html_config: LspServerConfig,
         python_config: LspServerConfig,
         go_config: LspServerConfig,
+        ruby_config: LspServerConfig,
     ) -> Self {
         let mut configs = HashMap::new();
         configs.insert(LanguageId::Rust, rust_config);
@@ -306,6 +336,7 @@ impl MultiLspManager {
         configs.insert(LanguageId::Html, html_config);
         configs.insert(LanguageId::Python, python_config);
         configs.insert(LanguageId::Go, go_config);
+        configs.insert(LanguageId::Ruby, ruby_config);
 
         Self {
             instances: HashMap::new(),
@@ -862,6 +893,7 @@ mod tests {
             servers.html,
             servers.python,
             servers.go,
+            servers.ruby,
         )
     }
 
@@ -955,6 +987,57 @@ mod tests {
             manager.status(Some(Path::new("cmd/nevi/main.go"))),
             "LSP: gopls not started (go)"
         );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn ruby_paths_route_to_ruby_language_server() {
+        let tmp = unique_temp_dir("nevi_lsp_ruby_route");
+        let workspace_root = tmp.join("workspace");
+        fs::create_dir_all(&workspace_root).expect("create workspace");
+
+        let manager = make_manager(workspace_root);
+
+        assert_eq!(LanguageId::from_extension("rb"), Some(LanguageId::Ruby));
+        assert_eq!(
+            LanguageId::from_path(Path::new("Gemfile")),
+            Some(LanguageId::Ruby)
+        );
+        assert_eq!(LanguageId::Ruby.as_lsp_id(), "ruby");
+        assert_eq!(
+            manager.language_for_path(Path::new("app/models/user.rb")),
+            Some(LanguageId::Ruby)
+        );
+        assert_eq!(
+            manager.language_for_path(Path::new("Gemfile")),
+            Some(LanguageId::Ruby)
+        );
+        assert_eq!(
+            manager.status(Some(Path::new("app/models/user.rb"))),
+            "LSP: ruby-lsp not started (ruby)"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn resolve_server_root_uses_ruby_root_markers() {
+        let tmp = unique_temp_dir("nevi_lsp_ruby_root");
+        let workspace_root = tmp.join("workspace");
+        let project_root = workspace_root.join("project");
+        let nested = project_root.join("app/models");
+        fs::create_dir_all(&nested).expect("create nested tree");
+        fs::write(
+            project_root.join("Gemfile"),
+            "source \"https://rubygems.org\"\n",
+        )
+        .expect("write Gemfile marker");
+
+        let manager = make_manager(workspace_root.clone());
+        let file_path = nested.join("user.rb");
+        let resolved = manager.resolve_server_root(LanguageId::Ruby, Some(file_path.as_path()));
+        assert_eq!(resolved, project_root);
 
         let _ = fs::remove_dir_all(&tmp);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -413,6 +413,7 @@ fn main() -> anyhow::Result<()> {
             &lsp_servers.html,
             &lsp_servers.python,
             &lsp_servers.go,
+            &lsp_servers.ruby,
         ] {
             for marker in &cfg.root_patterns {
                 if marker.trim().is_empty() {
@@ -449,6 +450,7 @@ fn main() -> anyhow::Result<()> {
             lsp_servers.html,
             lsp_servers.python,
             lsp_servers.go,
+            lsp_servers.ruby,
         );
         multi_lsp = Some(mgr);
         editor.set_lsp_status("LSP: (no server)");

--- a/src/syntax/highlighter.rs
+++ b/src/syntax/highlighter.rs
@@ -1357,6 +1357,11 @@ pub fn go_highlight_query() -> &'static str {
 "##
 }
 
+/// Get the highlight query for Ruby
+pub fn ruby_highlight_query() -> &'static str {
+    tree_sitter_ruby::HIGHLIGHTS_QUERY
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1502,6 +1507,15 @@ mod tests {
     #[test]
     fn go_highlight_query_compiles() {
         assert_query_compiles(tree_sitter_go::LANGUAGE.into(), go_highlight_query(), "Go");
+    }
+
+    #[test]
+    fn ruby_highlight_query_compiles() {
+        assert_query_compiles(
+            tree_sitter_ruby::LANGUAGE.into(),
+            ruby_highlight_query(),
+            "Ruby",
+        );
     }
 
     #[test]

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -62,6 +62,11 @@ impl SyntaxManager {
     pub fn set_language_from_path(&mut self, path: &Path) {
         let extension = path.extension().and_then(|e| e.to_str());
 
+        if is_ruby_path(path, extension) {
+            self.set_ruby_language();
+            return;
+        }
+
         match extension {
             Some("rs") => self.set_rust_language(),
             Some("js") | Some("mjs") | Some("cjs") => self.set_javascript_language(),
@@ -408,6 +413,30 @@ impl SyntaxManager {
         }
     }
 
+    /// Set up Ruby language parser
+    fn set_ruby_language(&mut self) {
+        let language = tree_sitter_ruby::LANGUAGE;
+        match self.parser.set_language(&language.into()) {
+            Ok(()) => {
+                self.language = Some("ruby".to_string());
+
+                let query_source = highlighter::ruby_highlight_query();
+                match Query::new(&language.into(), query_source) {
+                    Ok(query) => {
+                        self.query = Some(query);
+                    }
+                    Err(e) => {
+                        self.language = Some(format!("ruby (query error: {:?})", e));
+                        self.query = None;
+                    }
+                }
+            }
+            Err(e) => {
+                self.language = Some(format!("ruby (lang error: {:?})", e));
+            }
+        }
+    }
+
     /// Parse the entire buffer
     pub fn parse(&mut self, buffer: &Buffer) {
         if self.language.is_none() {
@@ -676,6 +705,33 @@ fn buffer_to_string(buffer: &Buffer) -> String {
     result
 }
 
+fn is_ruby_path(path: &Path, extension: Option<&str>) -> bool {
+    if matches!(
+        extension,
+        Some("rb" | "rake" | "gemspec" | "ru" | "podspec")
+    ) {
+        return true;
+    }
+
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(
+            "Appraisals"
+                | "Berksfile"
+                | "Brewfile"
+                | "Capfile"
+                | "Cheffile"
+                | "Fastfile"
+                | "Gemfile"
+                | "Guardfile"
+                | "Podfile"
+                | "Rakefile"
+                | "Thorfile"
+                | "Vagrantfile"
+        )
+    )
+}
+
 /// Get the line comment string for a language
 /// Returns the comment prefix (e.g., "// " for Rust/JS, "# " for Python)
 pub fn get_comment_string(language: Option<&str>) -> &'static str {
@@ -759,6 +815,42 @@ mod tests {
         assert!(
             !syntax.get_line_highlights(0).is_empty(),
             "go files should use Go syntax highlighting"
+        );
+    }
+
+    #[test]
+    fn ruby_extension_uses_ruby_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("example.rb"));
+
+        let mut buffer = Buffer::new();
+        buffer.set_content(
+            "class Greeter\n  def hello(name)\n    puts \"hello #{name}\"\n  end\nend\n",
+        );
+        syntax.parse(&buffer);
+
+        assert_eq!(syntax.language_name(), Some("ruby"));
+        assert!(syntax.has_highlighting());
+        assert!(
+            !syntax.get_line_highlights(0).is_empty(),
+            "ruby files should use Ruby syntax highlighting"
+        );
+    }
+
+    #[test]
+    fn ruby_known_filenames_use_ruby_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("Gemfile"));
+
+        let mut buffer = Buffer::new();
+        buffer.set_content("source \"https://rubygems.org\"\ngem \"rails\"\n");
+        syntax.parse(&buffer);
+
+        assert_eq!(syntax.language_name(), Some("ruby"));
+        assert!(syntax.has_highlighting());
+        assert!(
+            !syntax.get_line_highlights(1).is_empty(),
+            "common Ruby filenames should use Ruby syntax highlighting"
         );
     }
 }

--- a/src/tool_installer.rs
+++ b/src/tool_installer.rs
@@ -122,6 +122,7 @@ where
             &is_command_available,
         );
         add_lsp_tool(&mut grouped, "go", &servers.go, &is_command_available);
+        add_lsp_tool(&mut grouped, "ruby", &servers.ruby, &is_command_available);
     }
 
     for (language, config) in &languages_config.languages {
@@ -214,6 +215,7 @@ pub fn install_command_for(command: &str) -> Option<&'static str> {
         "taplo" | "taplo.exe" => Some("cargo install taplo-cli --locked"),
         "pyright-langserver" | "pyright-langserver.cmd" => Some("npm install -g pyright"),
         "gopls" | "gopls.exe" => Some("go install golang.org/x/tools/gopls@latest"),
+        "ruby-lsp" | "ruby-lsp.cmd" => Some("gem install ruby-lsp"),
         "pylsp" => Some("pipx install python-lsp-server"),
         "biome" | "biome.cmd" => Some("npm install -g @biomejs/biome"),
         "oxfmt" | "oxfmt.cmd" => Some("npm install -g oxfmt"),
@@ -248,6 +250,7 @@ mod tests {
         settings.lsp.servers.html.enabled = false;
         settings.lsp.servers.python.enabled = false;
         settings.lsp.servers.go.enabled = false;
+        settings.lsp.servers.ruby.enabled = false;
     }
 
     #[test]
@@ -263,6 +266,10 @@ mod tests {
         assert_eq!(
             super::install_command_for("gopls"),
             Some("go install golang.org/x/tools/gopls@latest")
+        );
+        assert_eq!(
+            super::install_command_for("ruby-lsp"),
+            Some("gem install ruby-lsp")
         );
     }
 


### PR DESCRIPTION
## Summary
- add Ruby syntax highlighting and Ruby file detection
- add Ruby LSP defaults, routing, health checks, and tool installer support
- resolve `ruby-lsp` from RubyGems bin directories when it is installed but not directly on PATH
- include the wrapped-scroll regression fix found during manual Ruby testing

## Tests
- `cargo fmt -- --check`
- `cargo test`

Updates #117