### PR TITLE
perf: add render damage bookkeeping

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1040,6 +1040,8 @@ pub struct Editor {
     pub markdown_preview: Option<crate::markdown_preview::MarkdownPreviewState>,
     /// Recent in-memory performance timing events.
     pub flight_recorder: crate::perf::FlightRecorder,
+    /// Dirty regions recorded for future partial-rendering passes.
+    pub render_damage: crate::render_damage::RenderDamage,
     /// Last project-wide replace preview, pending explicit apply.
     project_replace_preview: Option<crate::project_replace::ProjectReplacePreview>,
     /// Active labeled jump state, if the user is choosing a visible target.
@@ -1540,6 +1542,7 @@ impl Editor {
             theme_picker: None,
             markdown_preview: None,
             flight_recorder: crate::perf::FlightRecorder::default(),
+            render_damage: crate::render_damage::RenderDamage::full(),
             project_replace_preview: None,
             labeled_jump: None,
             marks: Marks::new(),
@@ -2182,6 +2185,7 @@ impl Editor {
     /// Set the LSP status (persistent, shown in status bar)
     pub fn set_lsp_status<S: Into<String>>(&mut self, msg: S) {
         self.lsp_status = Some(msg.into());
+        self.render_damage.mark_statusline();
     }
 
     /// Update diagnostics for a file URI
@@ -3485,8 +3489,12 @@ impl Editor {
 
     /// Set terminal size
     pub fn set_size(&mut self, width: u16, height: u16) {
+        let size_changed = self.term_width != width || self.term_height != height;
         self.term_width = width;
         self.term_height = height;
+        if size_changed {
+            self.render_damage.mark_full();
+        }
         if let Some(preview) = &mut self.markdown_preview {
             preview.reflow(crate::markdown_preview::preview_content_width(width));
         }
@@ -5464,29 +5472,34 @@ impl Editor {
     /// Set a status message
     pub fn set_status(&mut self, msg: impl Into<String>) {
         self.status_message = Some(msg.into());
+        self.render_damage.mark_command_line();
     }
 
     /// Clear status message
     pub fn clear_status(&mut self) {
         self.status_message = None;
+        self.render_damage.mark_command_line();
     }
 
     /// Enter command mode
     pub fn enter_command_mode(&mut self) {
         self.mode = Mode::Command;
         self.command_line.begin_prompt();
+        self.render_damage.mark_command_line();
     }
 
     /// Enter command mode with prefilled input.
     pub fn enter_command_mode_with_input(&mut self, input: impl Into<String>) {
         self.mode = Mode::Command;
         self.command_line.begin_prompt_with_input(input);
+        self.render_damage.mark_command_line();
     }
 
     /// Exit command mode back to normal
     pub fn exit_command_mode(&mut self) {
         self.mode = Mode::Normal;
         self.command_line.clear();
+        self.render_damage.mark_command_line();
     }
 
     /// Go to a specific line number (1-indexed)
@@ -11122,6 +11135,25 @@ mod tests {
         let report = editor.buffer().content();
         assert!(report.contains("Current buffer large-file mode: active"));
         assert!(report.contains("Syntax highlighting: degraded"));
+    }
+
+    #[test]
+    fn editor_marks_render_damage_for_status_lsp_and_resize_changes() {
+        let mut editor = Editor::default();
+        editor.render_damage.clear_after_full_render();
+
+        editor.set_status("saved");
+        assert!(editor.render_damage.command_line());
+        assert!(!editor.render_damage.requires_full_render());
+
+        editor.render_damage.clear_after_full_render();
+        editor.set_lsp_status("LSP: ready");
+        assert!(editor.render_damage.statusline());
+        assert!(!editor.render_damage.requires_full_render());
+
+        editor.render_damage.clear_after_full_render();
+        editor.set_size(120, 40);
+        assert!(editor.render_damage.requires_full_render());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod lsp;
 pub mod markdown_preview;
 pub mod perf;
 pub mod project_replace;
+pub mod render_damage;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;
@@ -45,5 +46,6 @@ pub use markdown_preview::{
     render_markdown, MarkdownPreview, MarkdownPreviewState, PreviewLine, PreviewLineKind,
     PreviewSpan, PreviewSpanStyle,
 };
+pub use render_damage::RenderDamage;
 pub use terminal::Terminal;
 pub use theme::{Theme, ThemeManager};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1968,6 +1968,7 @@ fn main() -> anyhow::Result<()> {
                     "render",
                     t_render.elapsed()
                 );
+                editor.render_damage.clear_after_full_render();
                 needs_redraw = false;
                 terminal_redraw_pending = false;
                 last_render = now;

--- a/src/render_damage.rs
+++ b/src/render_damage.rs
@@ -1,0 +1,125 @@
+use std::collections::BTreeSet;
+use std::ops::Range;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenderDamage {
+    full: bool,
+    statusline: bool,
+    command_line: bool,
+    editor_rows: BTreeSet<usize>,
+}
+
+impl RenderDamage {
+    pub fn full() -> Self {
+        Self {
+            full: true,
+            statusline: false,
+            command_line: false,
+            editor_rows: BTreeSet::new(),
+        }
+    }
+
+    pub fn clean() -> Self {
+        Self {
+            full: false,
+            statusline: false,
+            command_line: false,
+            editor_rows: BTreeSet::new(),
+        }
+    }
+
+    pub fn is_clean(&self) -> bool {
+        !self.full && !self.statusline && !self.command_line && self.editor_rows.is_empty()
+    }
+
+    pub fn requires_full_render(&self) -> bool {
+        self.full
+    }
+
+    pub fn statusline(&self) -> bool {
+        self.statusline
+    }
+
+    pub fn command_line(&self) -> bool {
+        self.command_line
+    }
+
+    pub fn dirty_editor_rows(&self) -> Vec<usize> {
+        self.editor_rows.iter().copied().collect()
+    }
+
+    pub fn mark_full(&mut self) {
+        self.full = true;
+        self.statusline = false;
+        self.command_line = false;
+        self.editor_rows.clear();
+    }
+
+    pub fn mark_statusline(&mut self) {
+        if !self.full {
+            self.statusline = true;
+        }
+    }
+
+    pub fn mark_command_line(&mut self) {
+        if !self.full {
+            self.command_line = true;
+        }
+    }
+
+    pub fn mark_editor_row(&mut self, row: usize) {
+        if !self.full {
+            self.editor_rows.insert(row);
+        }
+    }
+
+    pub fn mark_editor_rows(&mut self, rows: Range<usize>) {
+        if self.full {
+            return;
+        }
+        self.editor_rows.extend(rows);
+    }
+
+    pub fn clear_after_full_render(&mut self) {
+        *self = Self::clean();
+    }
+}
+
+impl Default for RenderDamage {
+    fn default() -> Self {
+        Self::full()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RenderDamage;
+
+    #[test]
+    fn damage_records_granular_regions_until_full_damage_takes_over() {
+        let mut damage = RenderDamage::clean();
+
+        assert!(damage.is_clean());
+
+        damage.mark_statusline();
+        damage.mark_command_line();
+        damage.mark_editor_row(3);
+        damage.mark_editor_rows(5..8);
+
+        assert!(!damage.requires_full_render());
+        assert!(damage.statusline());
+        assert!(damage.command_line());
+        assert_eq!(damage.dirty_editor_rows(), vec![3, 5, 6, 7]);
+
+        damage.mark_full();
+
+        assert!(damage.requires_full_render());
+        assert!(!damage.statusline());
+        assert!(!damage.command_line());
+        assert!(damage.dirty_editor_rows().is_empty());
+
+        damage.clear_after_full_render();
+
+        assert!(damage.is_clean());
+    }
+}


### PR DESCRIPTION
## Summary
- add a RenderDamage model for full, statusline, command-line, and editor-row dirty regions
- wire status/LSP status/command-mode transitions/resize into damage tracking
- clear damage after the current full-frame render completes, without changing render behavior yet

## Verification
- cargo test --quiet
- manual smoke test confirmed normal editing/search/command behavior still works
