### PR TITLE
feat: add ZZ write-quit keybind

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -888,7 +888,7 @@ While typing an Ex command after `:`.
 | `:qa!` / `:qall!` | Force quit all |
 | `:wq` | Save and quit |
 | `:wqa` / `:wqall` / `:xall` | Save all and quit |
-| `:x` / `:exit` | Save if modified and quit |
+| `:x` / `:exit` / `ZZ` | Save if modified and quit |
 | `:xa` | Save all modified files and quit all |
 | `:e {file}` / `:edit {file}` | Edit/open a file |
 | `:e!` / `:edit!` | Reload current file and discard changes |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 315 keybinds implemented, 52 planned Vim/Neovim parity defaults.**
+**Status: 316 keybinds implemented, 52 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ nevi file1.rs file2.rs
 - `:w!` - Force save and overwrite external disk changes
 - `:q` - Quit
 - `:wq` - Save and quit
+- `ZZ` / `:x` - Save if modified and quit
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
 - `:ToolInstall` / `:LspInstall` - Open missing LSP/tool install guidance in a read-only `[tool-installer]` buffer
 - `:FlightRecorder` / `:WhySlow` - Open recent in-memory timing report in a read-only `[flight-recorder]` buffer

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -47,6 +47,17 @@ status = "implemented"
 vim_default = false
 
 # ----------------------------------------------------------------------------
+# File operations
+# ----------------------------------------------------------------------------
+
+[[normal.file]]
+key = "ZZ"
+action = "write_quit_if_modified"
+desc = "Write if modified and quit"
+status = "implemented"
+vim_default = true
+
+# ----------------------------------------------------------------------------
 # Movement - Basic cursor movement
 # ----------------------------------------------------------------------------
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -202,6 +202,8 @@ pub enum KeyAction {
     Quit,
     /// Save
     Save,
+    /// Write if modified and quit
+    WriteQuitIfModified,
     /// Window/pane operations
     WindowSplitVertical,
     WindowSplitHorizontal,
@@ -1121,6 +1123,10 @@ impl InputState {
                 self.partial_key = Some('z');
                 KeyAction::Pending
             }
+            (KeyModifiers::SHIFT, KeyCode::Char('Z')) => {
+                self.partial_key = Some('Z');
+                KeyAction::Pending
+            }
             (KeyModifiers::NONE, KeyCode::Char(']')) => {
                 // ] prefix for forward navigation (]d = next diagnostic)
                 self.partial_key = Some(']');
@@ -1444,6 +1450,11 @@ impl InputState {
             ('z', KeyModifiers::NONE, KeyCode::Char('b')) => {
                 self.reset();
                 KeyAction::ScrollBottom
+            }
+            // ZZ - write if modified and quit
+            ('Z', KeyModifiers::SHIFT, KeyCode::Char('Z')) => {
+                self.reset();
+                KeyAction::WriteQuitIfModified
             }
             // ]d - go to next diagnostic
             (']', KeyModifiers::NONE, KeyCode::Char('d')) => {
@@ -2021,6 +2032,13 @@ mod tests {
         }
     }
 
+    fn assert_write_quit_if_modified(keys: &[KeyEvent]) {
+        match run(keys) {
+            KeyAction::WriteQuitIfModified => {}
+            other => panic!("expected write quit action, got {:?}", other),
+        }
+    }
+
     fn assert_text_object(
         keys: &[KeyEvent],
         expected_operator: Operator,
@@ -2107,6 +2125,11 @@ mod tests {
         assert_motion(&[shift('H')], Motion::ScreenTop, 1);
         assert_motion(&[shift('M')], Motion::ScreenMiddle, 1);
         assert_motion(&[shift('L')], Motion::ScreenBottom, 1);
+    }
+
+    #[test]
+    fn normal_zz_maps_to_write_quit_if_modified() {
+        assert_write_quit_if_modified(&[shift('Z'), shift('Z')]);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7126,6 +7126,10 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             }
         }
 
+        KeyAction::WriteQuitIfModified => {
+            execute_command(editor, Command::WriteQuitIfModified);
+        }
+
         // Window/pane operations
         KeyAction::WindowSplitVertical => {
             if let Err(e) = editor.vsplit(None) {
@@ -12029,6 +12033,68 @@ mod tests {
             "local edit\n"
         );
         assert!(!editor.buffer().dirty);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_zz_writes_modified_file_and_quits() {
+        let tmp = unique_temp_dir("nevi_normal_zz_write_quit");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+
+        handle_key(&mut editor, shift_key('Z'));
+        handle_key(&mut editor, shift_key('Z'));
+
+        assert!(editor.should_quit);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read saved file"),
+            "local edit\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_zz_refuses_dirty_unnamed_buffer_without_quitting() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("scratch edit\n");
+
+        handle_key(&mut editor, shift_key('Z'));
+        handle_key(&mut editor, shift_key('Z'));
+
+        assert!(!editor.should_quit);
+        assert_eq!(editor.status_message.as_deref(), Some("E: No filename"));
+    }
+
+    #[test]
+    fn normal_keymap_can_bind_custom_key_to_write_quit_if_modified() {
+        let tmp = unique_temp_dir("nevi_normal_keymap_write_quit");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut settings = Settings::default();
+        settings.keymap.normal.push(KeymapEntry {
+            from: "Q".to_string(),
+            to: ":x<CR>".to_string(),
+        });
+        let mut editor = Editor::new(settings);
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+
+        handle_key(&mut editor, shift_key('Q'));
+
+        assert!(editor.should_quit);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read saved file"),
+            "local edit\n"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }


### PR DESCRIPTION
## Summary
- Add normal-mode `ZZ` as write-if-modified-and-quit.
- Wire it to the existing `:x` behavior, including configurable mappings through `:x<CR>`.
- Update keybinding docs, roadmap count, and keybind picker data.

## Test Plan
- `cargo fmt -- --check`
- `git diff --check`
- `cargo test`
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle::tests::vim_oracle_smoke_matches_neovim_for_basic_normal_edit -- --ignored --nocapture`

Closes #187