### PR TITLE
fix: normal Enter line motion parity

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -209,7 +209,7 @@ When specifying keys, use these formats:
 | `0` | Move to start of line (column 0) |
 | `^` | Move to first non-blank character |
 | `$` | Move to end of line |
-| `+` | Move to first non-blank of next line |
+| `+` / `Enter` | Move to first non-blank of next line |
 | `-` | Move to first non-blank of previous line |
 | `gj` | Move down by display line when wrap is enabled |
 | `gk` | Move up by display line when wrap is enabled |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4112,6 +4112,8 @@ impl Editor {
     /// Delete from cursor to motion target
     pub fn delete_motion(&mut self, motion: Motion, count: usize, register: Option<char>) {
         if let Some((start_line, start_col, end_line, end_col)) = self.motion_range(motion, count) {
+            let linewise = Self::motion_is_linewise(motion);
+            let original_col = self.cursor.col;
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
 
             // Record for undo
@@ -4124,9 +4126,17 @@ impl Editor {
             self.undo_stack
                 .end_undo_group(self.cursor.line, self.cursor.col);
 
-            let is_small = !deleted.contains('\n');
-            self.registers
-                .delete(register, RegisterContent::Chars(deleted), is_small);
+            if linewise {
+                self.cursor.col = original_col;
+                self.clamp_cursor();
+                self.scroll_to_cursor();
+                self.registers
+                    .delete(register, RegisterContent::Lines(deleted), false);
+            } else {
+                let is_small = !deleted.contains('\n');
+                self.registers
+                    .delete(register, RegisterContent::Chars(deleted), is_small);
+            }
         }
     }
 
@@ -4158,7 +4168,12 @@ impl Editor {
     pub fn yank_motion(&mut self, motion: Motion, count: usize, register: Option<char>) {
         if let Some((start_line, start_col, end_line, end_col)) = self.motion_range(motion, count) {
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
-            self.registers.yank(register, RegisterContent::Chars(text));
+            let content = if Self::motion_is_linewise(motion) {
+                RegisterContent::Lines(text)
+            } else {
+                RegisterContent::Chars(text)
+            };
+            self.registers.yank(register, content);
             self.set_status("Yanked");
         }
     }
@@ -4184,6 +4199,7 @@ impl Editor {
     /// Change from cursor to motion target (delete + insert mode)
     pub fn change_motion(&mut self, motion: Motion, count: usize, register: Option<char>) {
         if let Some((start_line, start_col, end_line, end_col)) = self.motion_range(motion, count) {
+            let linewise = Self::motion_is_linewise(motion);
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
 
             // Begin undo group (will include the delete and subsequent inserts)
@@ -4193,9 +4209,14 @@ impl Editor {
 
             let deleted = self.delete_range(start_line, start_col, end_line, end_col);
 
-            let is_small = !deleted.contains('\n');
-            self.registers
-                .delete(register, RegisterContent::Chars(deleted), is_small);
+            if linewise {
+                self.registers
+                    .delete(register, RegisterContent::Lines(deleted), false);
+            } else {
+                let is_small = !deleted.contains('\n');
+                self.registers
+                    .delete(register, RegisterContent::Chars(deleted), is_small);
+            }
 
             // Enter insert mode (don't start new undo group, reuse the one from change)
             self.enter_insert_mode_at_change(start_line, start_col);
@@ -10387,6 +10408,13 @@ impl Editor {
         )
     }
 
+    fn motion_is_linewise(motion: Motion) -> bool {
+        matches!(
+            motion,
+            Motion::NextLineFirstNonBlank | Motion::PrevLineFirstNonBlank
+        )
+    }
+
     fn motion_range(&self, motion: Motion, count: usize) -> Option<(usize, usize, usize, usize)> {
         let (target_line, target_col) = apply_motion(
             &self.buffers[self.current_buffer_idx],
@@ -10396,6 +10424,19 @@ impl Editor {
             count,
             self.text_rows(),
         )?;
+
+        if Self::motion_is_linewise(motion) {
+            if target_line == self.cursor.line {
+                return None;
+            }
+
+            let start_line = self.cursor.line.min(target_line);
+            let end_line = self.cursor.line.max(target_line);
+            let end_col = self.buffers[self.current_buffer_idx]
+                .line_len_including_newline(end_line)
+                .saturating_sub(1);
+            return Some((start_line, 0, end_line, end_col));
+        }
 
         let forward = (target_line, target_col) >= (self.cursor.line, self.cursor.col);
         let inclusive = forward && Self::motion_is_inclusive(motion);

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -931,7 +931,7 @@ impl InputState {
             }
             (_, KeyCode::Char('^')) => self.motion_or_operator(Motion::FirstNonBlank, count),
             (_, KeyCode::Char('$')) => self.motion_or_operator(Motion::LineEnd, count),
-            (_, KeyCode::Char('+')) => {
+            (_, KeyCode::Char('+')) | (KeyModifiers::NONE, KeyCode::Enter) => {
                 self.motion_or_operator(Motion::NextLineFirstNonBlank, count)
             }
             (_, KeyCode::Char('-')) => {
@@ -1599,7 +1599,9 @@ impl InputState {
             (KeyModifiers::NONE, KeyCode::Char('0')) => Motion::LineStart,
             (_, KeyCode::Char('^')) => Motion::FirstNonBlank,
             (_, KeyCode::Char('$')) => Motion::LineEnd,
-            (_, KeyCode::Char('+')) => Motion::NextLineFirstNonBlank,
+            (_, KeyCode::Char('+')) | (KeyModifiers::NONE, KeyCode::Enter) => {
+                Motion::NextLineFirstNonBlank
+            }
             (_, KeyCode::Char('-')) => Motion::PrevLineFirstNonBlank,
             (_, KeyCode::Char('}')) => Motion::ParagraphForward,
             (_, KeyCode::Char('{')) => Motion::ParagraphBackward,
@@ -1756,7 +1758,7 @@ impl InputState {
                 self.reset();
                 KeyAction::ToggleCommentMotion(Motion::FirstNonBlank, count)
             }
-            (_, KeyCode::Char('+')) => {
+            (_, KeyCode::Char('+')) | (KeyModifiers::NONE, KeyCode::Enter) => {
                 self.reset();
                 KeyAction::ToggleCommentMotion(Motion::NextLineFirstNonBlank, count)
             }
@@ -1890,7 +1892,7 @@ impl InputState {
                 self.reset();
                 KeyAction::CaseMotion(case_op, Motion::FirstNonBlank, count)
             }
-            (_, KeyCode::Char('+')) => {
+            (_, KeyCode::Char('+')) | (KeyModifiers::NONE, KeyCode::Enter) => {
                 self.reset();
                 KeyAction::CaseMotion(case_op, Motion::NextLineFirstNonBlank, count)
             }
@@ -1963,6 +1965,10 @@ mod tests {
 
     fn ctrl(c: char) -> KeyEvent {
         KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL)
+    }
+
+    fn enter() -> KeyEvent {
+        KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)
     }
 
     fn run(keys: &[KeyEvent]) -> KeyAction {
@@ -2108,8 +2114,10 @@ mod tests {
         assert_motion(&[key('^')], Motion::FirstNonBlank, 1);
         assert_motion(&[key('$')], Motion::LineEnd, 1);
         assert_motion(&[key('+')], Motion::NextLineFirstNonBlank, 1);
+        assert_motion(&[enter()], Motion::NextLineFirstNonBlank, 1);
         assert_motion(&[key('-')], Motion::PrevLineFirstNonBlank, 1);
         assert_motion(&[key('3'), key('+')], Motion::NextLineFirstNonBlank, 3);
+        assert_motion(&[key('3'), enter()], Motion::NextLineFirstNonBlank, 3);
         assert_motion(&[key('3'), key('-')], Motion::PrevLineFirstNonBlank, 3);
         assert_motion(&[key('{')], Motion::ParagraphBackward, 1);
         assert_motion(&[key('}')], Motion::ParagraphForward, 1);
@@ -2194,9 +2202,21 @@ mod tests {
             1,
         );
         assert_operator_motion(
+            &[key('d'), enter()],
+            Operator::Delete,
+            Motion::NextLineFirstNonBlank,
+            1,
+        );
+        assert_operator_motion(
             &[key('2'), key('d'), key('3'), key('w')],
             Operator::Delete,
             Motion::WordForward,
+            6,
+        );
+        assert_operator_motion(
+            &[key('2'), key('d'), key('3'), enter()],
+            Operator::Delete,
+            Motion::NextLineFirstNonBlank,
             6,
         );
         assert_operator_line(&[key('d'), key('d')], Operator::Delete, 1);
@@ -2288,6 +2308,12 @@ mod tests {
             &[key('g'), shift('U'), key('w')],
             CaseOperator::Uppercase,
             Motion::WordForward,
+            1,
+        );
+        assert_case_motion(
+            &[key('g'), shift('U'), enter()],
+            CaseOperator::Uppercase,
+            Motion::NextLineFirstNonBlank,
             1,
         );
         assert_case_line(

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -14733,6 +14733,37 @@ mod tests {
     }
 
     #[test]
+    fn normal_enter_moves_to_first_non_blank_on_next_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("zero\n    one\n  two\nthree\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 2;
+
+        handle_key(&mut editor, enter_key());
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+
+        handle_key(&mut editor, key('2'));
+        handle_key(&mut editor, enter_key());
+
+        assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+    }
+
+    #[test]
+    fn normal_delete_enter_deletes_through_next_line() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("zero\n    one\n  two\nthree\n");
+        editor.cursor.line = 0;
+        editor.cursor.col = 2;
+
+        handle_key(&mut editor, key('d'));
+        handle_key(&mut editor, enter_key());
+
+        assert_eq!(editor.buffer().content(), "  two\nthree\n");
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+    }
+
+    #[test]
     fn normal_gj_gk_move_by_wrapped_display_lines() {
         let mut editor = Editor::default();
         editor.set_size(40, 12);

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -84,6 +84,16 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "$^",
     },
     OracleCase {
+        name: "enter next line first nonblank",
+        initial_text: "zero\n    one\n  two\nthree\n",
+        keys: "<CR>",
+    },
+    OracleCase {
+        name: "counted enter next line first nonblank",
+        initial_text: "zero\n    one\n  two\nthree\n",
+        keys: "2<CR>",
+    },
+    OracleCase {
         name: "file top",
         initial_text: "alpha\nbeta\ngamma\n",
         keys: "gg",
@@ -160,6 +170,11 @@ const EDITING_CASES: &[OracleCase] = &[
         name: "delete word",
         initial_text: "alpha beta\n",
         keys: "dw",
+    },
+    OracleCase {
+        name: "delete enter motion",
+        initial_text: "zero\n    one\n  two\nthree\n",
+        keys: "d<CR>",
     },
     OracleCase {
         name: "change inner word",


### PR DESCRIPTION
## Summary
- Map normal-mode Enter to the existing next-line-first-nonblank motion, matching Vim/Neovim behavior for plain and counted motions.
- Treat `+` / `-` line motions as linewise when used with operators so `d<CR>` and related operator motions match Neovim.
- Add parser, editor, and Vim-oracle regression coverage for `<CR>` motion parity.

Fixes #199.

## Test Plan
- [x] `cargo test --quiet`
- [x] `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
