### PR TITLE
chore: prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,61 @@
+# Changelog
+
+## 0.2.0 - 2026-07-07
+
+Nevi 0.2.0 is a feature and performance release focused on making the editor
+feel faster, safer, and easier to adopt.
+
+### Highlights
+
+- Added damage-aware partial rendering for common cursor movement and edit paths.
+- Improved long-line and large-file responsiveness, including clearer large-file mode visibility.
+- Added render regression coverage and a frame budget guard to catch future UI regressions earlier.
+- Added an in-memory `:FlightRecorder` / `:WhySlow` performance report for debugging latency.
+- Added Vim oracle parity coverage and macOS/Linux CI validation.
+- Added labeled jump navigation with `:Jump` and `<Space>j`.
+- Added Swiss-army CLI modes: `nevi view`, `nevi diff`, and `nevi pick`.
+- Added previewed project-wide replace with an explicit apply step.
+- Added `:ToolInstall`, `:ConfigDefaults`, and expanded `:checkhealth` reporting.
+- Added Go and Ruby language support.
+- Added more Vim/Neovim-compatible keybindings, including window movement/resizing, visual block insert/append, `ZZ`, and normal-mode Enter motion.
+- Improved Homebrew, Linux/source install, and update documentation.
+
+### Performance
+
+- Partially repaint only affected editor rows for many normal and insert-mode operations.
+- Limit search highlights and labeled-jump scans to visible rows.
+- Optimize long-line rendering for minified and very wide files.
+- Throttle LSP status redraws and hide benign LSP request errors.
+- Add input event coalescing coverage to guard responsiveness.
+
+### Safety And Diagnostics
+
+- Guard saves against overwriting files changed externally on disk.
+- Open health, config defaults, and generated reports in read-only buffers.
+- Add keymap health checks and external tool checks.
+- Add project replace safeguards for preview/apply workflows.
+
+### Install And Upgrade
+
+Homebrew users can upgrade after this release with:
+
+```bash
+brew update
+brew upgrade nevi
+```
+
+If installed with the fully qualified formula name:
+
+```bash
+brew upgrade anthonyamaro15/nevi/nevi
+```
+
+Verify the installed version:
+
+```bash
+nevi --version
+```
+
+## 0.1.0 - Initial Release
+
+- Initial public release of Nevi.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -925,7 +925,7 @@ dependencies = [
 
 [[package]]
 name = "nevi"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nevi"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A Neovim-like terminal editor in Rust"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A fast, Neovim-inspired terminal editor written in Rust.
 ![Nevi demo — fuzzy file finder with preview, vim motions, Harpoon quick-switch, live grep, and live theme switching](nevi-demo.gif)
 
 > **Tip:** To see every keybinding available in Nevi, run `:Keymaps` (or press `<Space>fk`) — a searchable list with a description for each one.
+> See [CHANGELOG.md](CHANGELOG.md) for release notes and upgrade highlights.
 
 ## Why Nevi?
 


### PR DESCRIPTION
## Summary
- bump Nevi from 0.1.0 to 0.2.0
- add CHANGELOG.md with v0.2.0 release notes and upgrade commands
- link the changelog from README.md

## Verification
- Latest master CI was successful before branching
- cargo test --quiet
- cargo run --quiet -- --version
- NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture
- git diff --cached --check