### PR TITLE
test: cover WORD motions in Vim oracle

### DIFF
--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -88,11 +88,15 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
             test_id: "default_leader_includes_keymaps_picker",
         },
     },
-    needs_oracle("W", "Move to start of next WORD"),
-    needs_oracle("B", "Move to start of previous WORD"),
-    needs_oracle("E", "Move to end of WORD"),
-    needs_oracle("ge", "Move to end of previous word"),
-    needs_oracle("gE", "Move to end of previous WORD"),
+    vim_oracle("W", "Move to start of next WORD", "big word forward"),
+    vim_oracle("B", "Move to start of previous WORD", "big word backward"),
+    vim_oracle("E", "Move to end of WORD", "big word end"),
+    vim_oracle("ge", "Move to end of previous word", "previous word end"),
+    vim_oracle(
+        "gE",
+        "Move to end of previous WORD",
+        "previous big word end",
+    ),
     needs_oracle("%", "Jump to matching bracket"),
     needs_oracle("H", "Move to top of visible screen"),
     needs_oracle("M", "Move to middle of visible screen"),
@@ -265,8 +269,33 @@ mod tests {
 
         assert!(
             gaps.iter()
-                .any(|entry| entry.mode == KeybindMode::Normal && entry.key == "W"),
-            "`W` should stay visible as a tracked Vim parity gap until oracle-covered"
+                .any(|entry| entry.mode == KeybindMode::Normal && entry.key == "%"),
+            "`%` should stay visible as a tracked Vim parity gap until oracle-covered"
         );
+    }
+
+    #[test]
+    fn word_motion_defaults_are_oracle_covered() {
+        let expected = [
+            ("W", "big word forward"),
+            ("B", "big word backward"),
+            ("E", "big word end"),
+            ("ge", "previous word end"),
+            ("gE", "previous big word end"),
+        ];
+
+        for (key, oracle_case) in expected {
+            let entry = coverage_for(KeybindMode::Normal, key)
+                .unwrap_or_else(|| panic!("missing coverage entry for `{key}`"));
+
+            assert_eq!(entry.kind, CoverageKind::VimOracle);
+            assert_eq!(
+                entry.state,
+                CoverageState::Protected {
+                    test_id: oracle_case,
+                },
+                "`{key}` should be protected by oracle case `{oracle_case}`"
+            );
+        }
     }
 }

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -59,14 +59,39 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "w",
     },
     OracleCase {
+        name: "big word forward",
+        initial_text: "alpha.beta gamma\n",
+        keys: "W",
+    },
+    OracleCase {
         name: "word backward",
         initial_text: "alpha beta gamma\n",
         keys: "wwb",
     },
     OracleCase {
+        name: "big word backward",
+        initial_text: "alpha.beta gamma.delta omega\n",
+        keys: "WWB",
+    },
+    OracleCase {
         name: "word end",
         initial_text: "alpha beta\n",
         keys: "e",
+    },
+    OracleCase {
+        name: "big word end",
+        initial_text: "alpha.beta gamma\n",
+        keys: "E",
+    },
+    OracleCase {
+        name: "previous word end",
+        initial_text: "alpha beta gamma\n",
+        keys: "wwge",
+    },
+    OracleCase {
+        name: "previous big word end",
+        initial_text: "alpha.beta gamma.delta omega\n",
+        keys: "WWgE",
     },
     OracleCase {
         name: "line start",


### PR DESCRIPTION
## Summary
- add Vim oracle cases for WORD motion defaults: W, B, E, ge, and gE
- promote those keybind coverage entries from explicit gaps to protected oracle coverage
- keep the explicit-gap sentinel active by moving it to the still-uncovered % motion

## Verification
- cargo test word_motion_defaults_are_oracle_covered --quiet
- cargo test vim_oracle --quiet
- NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture
- cargo test keybind_coverage --quiet
- cargo test --quiet
- git diff --check