### PR TITLE
test: cover matching bracket in Vim oracle

### DIFF
--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -97,7 +97,7 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Move to end of previous WORD",
         "previous big word end",
     ),
-    needs_oracle("%", "Jump to matching bracket"),
+    vim_oracle("%", "Jump to matching bracket", "matching bracket"),
     needs_oracle("H", "Move to top of visible screen"),
     needs_oracle("M", "Move to middle of visible screen"),
     needs_oracle("L", "Move to bottom of visible screen"),
@@ -293,8 +293,8 @@ mod tests {
 
         assert!(
             gaps.iter()
-                .any(|entry| entry.mode == KeybindMode::Normal && entry.key == "%"),
-            "`%` should stay visible as a tracked Vim parity gap until oracle-covered"
+                .any(|entry| entry.mode == KeybindMode::Normal && entry.key == "H"),
+            "`H` should stay visible as a tracked Vim parity gap until oracle-covered"
         );
     }
 
@@ -347,5 +347,20 @@ mod tests {
                 "`{key}` should be protected by oracle case `{oracle_case}`"
             );
         }
+    }
+
+    #[test]
+    fn matching_bracket_default_is_oracle_covered() {
+        let entry = coverage_for(KeybindMode::Normal, "%")
+            .expect("missing coverage entry for matching-bracket motion");
+
+        assert_eq!(entry.kind, CoverageKind::VimOracle);
+        assert_eq!(
+            entry.state,
+            CoverageState::Protected {
+                test_id: "matching bracket",
+            },
+            "`%` should be protected by the matching-bracket oracle case"
+        );
     }
 }

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -139,6 +139,11 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "fa;,",
     },
     OracleCase {
+        name: "matching bracket",
+        initial_text: "(alpha)\n",
+        keys: "%",
+    },
+    OracleCase {
         name: "enter next line first nonblank",
         initial_text: "zero\n    one\n  two\nthree\n",
         keys: "<CR>",


### PR DESCRIPTION
## Summary
- add a Vim oracle case for `%` matching-bracket motion
- promote `%` in keybind coverage from explicit gap to protected oracle coverage
- keep the explicit-gap sentinel active by moving it to `H`
- test-only coverage; no runtime behavior changes

## Verification
- `cargo test matching_bracket_default_is_oracle_covered --quiet`
- `cargo test vim_oracle --quiet`
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo test keybind_coverage --quiet`
- `cargo test --quiet`
- `git diff --check`