### PR TITLE
test: make vim oracle viewport aware

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -9708,23 +9708,31 @@ impl Editor {
         }
     }
 
-    /// Scroll viewport so cursor is at top of screen (zt command)
+    /// Scroll viewport so cursor is near the top, respecting scrolloff (zt command)
     pub fn scroll_cursor_top(&mut self) {
-        self.viewport_offset = self.cursor.line;
+        let text_rows = self.active_pane_text_rows();
+        let scroll_off = self
+            .settings
+            .editor
+            .scroll_off
+            .min(text_rows.saturating_sub(1) / 2);
+        self.viewport_offset = self.cursor.line.saturating_sub(scroll_off);
         // Sync to active pane for rendering
         if self.active_pane < self.panes.len() {
             self.panes[self.active_pane].viewport_offset = self.viewport_offset;
         }
     }
 
-    /// Scroll viewport so cursor is at bottom of screen (zb command)
+    /// Scroll viewport so cursor is near the bottom, respecting scrolloff (zb command)
     pub fn scroll_cursor_bottom(&mut self) {
         let text_rows = self.active_pane_text_rows();
-        if self.cursor.line >= text_rows.saturating_sub(1) {
-            self.viewport_offset = self.cursor.line - text_rows + 1;
-        } else {
-            self.viewport_offset = 0;
-        }
+        let scroll_off = self
+            .settings
+            .editor
+            .scroll_off
+            .min(text_rows.saturating_sub(1) / 2);
+        let target_row = text_rows.saturating_sub(1).saturating_sub(scroll_off);
+        self.viewport_offset = self.cursor.line.saturating_sub(target_row);
         // Sync to active pane for rendering
         if self.active_pane < self.panes.len() {
             self.panes[self.active_pane].viewport_offset = self.viewport_offset;

--- a/src/editor/tests/screen_position.rs
+++ b/src/editor/tests/screen_position.rs
@@ -21,6 +21,76 @@ fn right_after_zt_near_eof_preserves_neovim_top_line() {
 }
 
 #[test]
+fn scroll_cursor_top_respects_scrolloff() {
+    let mut editor = Editor::default();
+    editor.set_size(80, 24);
+    editor.settings.editor.scroll_off = 8;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03}\n"))
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.cursor.line = 49;
+
+    editor.scroll_cursor_top();
+
+    assert_eq!(editor.viewport_offset, 41);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 41);
+}
+
+#[test]
+fn scroll_cursor_bottom_respects_scrolloff() {
+    let mut editor = Editor::default();
+    editor.set_size(80, 24);
+    editor.settings.editor.scroll_off = 8;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03}\n"))
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.cursor.line = 49;
+
+    editor.scroll_cursor_bottom();
+
+    assert_eq!(editor.viewport_offset, 36);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 36);
+}
+
+#[test]
+fn scroll_cursor_top_caps_scrolloff_for_even_height() {
+    let mut editor = Editor::default();
+    editor.set_size(80, 12);
+    editor.settings.editor.scroll_off = 8;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03}\n"))
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.cursor.line = 49;
+
+    editor.scroll_cursor_top();
+
+    assert_eq!(editor.text_rows(), 10);
+    assert_eq!(editor.viewport_offset, 45);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 45);
+}
+
+#[test]
+fn scroll_cursor_bottom_caps_scrolloff_for_even_height() {
+    let mut editor = Editor::default();
+    editor.set_size(80, 12);
+    editor.settings.editor.scroll_off = 8;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03}\n"))
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.cursor.line = 49;
+
+    editor.scroll_cursor_bottom();
+
+    assert_eq!(editor.text_rows(), 10);
+    assert_eq!(editor.viewport_offset, 44);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 44);
+}
+
+#[test]
 fn screen_bottom_motion_ignores_trailing_newline_line_near_eof() {
     let mut editor = Editor::default();
     let content = (1..=30)

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -135,9 +135,9 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     needs_oracle("<C-b>", "Scroll page up"),
     needs_oracle("<C-d>", "Scroll half page down"),
     needs_oracle("<C-u>", "Scroll half page up"),
-    needs_oracle("zz", "Center cursor line"),
-    needs_oracle("zt", "Move cursor line to top"),
-    needs_oracle("zb", "Move cursor line to bottom"),
+    vim_oracle("zz", "Center cursor line", "center cursor line"),
+    vim_oracle("zt", "Move cursor line to top", "cursor line to top"),
+    vim_oracle("zb", "Move cursor line to bottom", "cursor line to bottom"),
 ];
 
 const fn vim_oracle(
@@ -370,6 +370,29 @@ mod tests {
             ("H", "screen top"),
             ("M", "screen middle"),
             ("L", "screen bottom"),
+        ];
+
+        for (key, oracle_case) in expected {
+            let entry = coverage_for(KeybindMode::Normal, key)
+                .unwrap_or_else(|| panic!("missing coverage entry for `{key}`"));
+
+            assert_eq!(entry.kind, CoverageKind::VimOracle);
+            assert_eq!(
+                entry.state,
+                CoverageState::Protected {
+                    test_id: oracle_case,
+                },
+                "`{key}` should be protected by oracle case `{oracle_case}`"
+            );
+        }
+    }
+
+    #[test]
+    fn viewport_position_defaults_are_oracle_covered() {
+        let expected = [
+            ("zz", "center cursor line"),
+            ("zt", "cursor line to top"),
+            ("zb", "cursor line to bottom"),
         ];
 
         for (key, oracle_case) in expected {

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -23,6 +23,7 @@ struct EditorSnapshot {
     lines: Vec<String>,
     cursor_line: usize,
     cursor_col: usize,
+    viewport_top: usize,
     mode: String,
 }
 
@@ -31,6 +32,11 @@ struct OracleComparison {
     passed: bool,
     report: String,
 }
+
+const ORACLE_TERM_WIDTH: u16 = 80;
+const ORACLE_TERM_HEIGHT: u16 = 24;
+const ORACLE_SHORT_TERM_HEIGHT: u16 = 12;
+const ORACLE_SCROLL_OFF: usize = 8;
 
 const SCREEN_POSITION_TEXT: &str = concat!(
     "line 001\n",
@@ -272,6 +278,21 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "50Gzz30L",
     },
     OracleCase {
+        name: "center cursor line",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz",
+    },
+    OracleCase {
+        name: "cursor line to top",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzt",
+    },
+    OracleCase {
+        name: "cursor line to bottom",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzb",
+    },
+    OracleCase {
         name: "enter next line first nonblank",
         initial_text: "zero\n    one\n  two\nthree\n",
         keys: "<CR>",
@@ -305,6 +326,19 @@ const MOTION_CASES: &[OracleCase] = &[
         name: "counted word forward",
         initial_text: "alpha beta gamma\n",
         keys: "2w",
+    },
+];
+
+const SHORT_VIEWPORT_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "short viewport cursor line to top",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzt",
+    },
+    OracleCase {
+        name: "short viewport cursor line to bottom",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzb",
     },
 ];
 
@@ -477,7 +511,13 @@ fn char_key(ch: char) -> KeyEvent {
 }
 
 fn run_nevi_case(case: &OracleCase) -> Result<EditorSnapshot, String> {
+    run_nevi_case_at_height(case, ORACLE_TERM_HEIGHT)
+}
+
+fn run_nevi_case_at_height(case: &OracleCase, term_height: u16) -> Result<EditorSnapshot, String> {
     let mut editor = Editor::default();
+    editor.set_size(ORACLE_TERM_WIDTH, term_height);
+    editor.settings.editor.scroll_off = ORACLE_SCROLL_OFF;
     editor.replace_buffer_content(case.initial_text);
 
     for key in parse_key_sequence(case.keys)? {
@@ -492,6 +532,7 @@ fn snapshot_nevi(editor: &Editor) -> EditorSnapshot {
         lines: normalized_lines(&editor.buffer().content()),
         cursor_line: editor.cursor.line,
         cursor_col: editor.cursor.col,
+        viewport_top: editor.viewport_offset,
         mode: nevi_mode_name(editor.mode).to_string(),
     }
 }
@@ -542,6 +583,12 @@ fn compare_snapshots(
         mismatches.push(format!(
             "cursor_col: nevi={} nvim={}",
             nevi.cursor_col, nvim.cursor_col
+        ));
+    }
+    if nevi.viewport_top != nvim.viewport_top {
+        mismatches.push(format!(
+            "viewport_top: nevi={} nvim={}",
+            nevi.viewport_top, nvim.viewport_top
         ));
     }
     if nevi.mode != nvim.mode {
@@ -606,25 +653,38 @@ fn format_snapshot(snapshot: &EditorSnapshot) -> String {
         .collect::<Vec<_>>()
         .join("\n");
     format!(
-        "  mode={} cursor=({}, {})\n{}",
-        snapshot.mode, snapshot.cursor_line, snapshot.cursor_col, lines
+        "  mode={} cursor=({}, {}) viewport_top={}\n{}",
+        snapshot.mode, snapshot.cursor_line, snapshot.cursor_col, snapshot.viewport_top, lines
     )
 }
 
 fn compare_with_neovim(case: &OracleCase) -> Result<OracleComparison, String> {
-    let nevi = run_nevi_case(case)?;
-    let nvim = run_neovim_case(case)?;
+    compare_with_neovim_at_height(case, ORACLE_TERM_HEIGHT)
+}
+
+fn compare_with_neovim_at_height(
+    case: &OracleCase,
+    term_height: u16,
+) -> Result<OracleComparison, String> {
+    let nevi = run_nevi_case_at_height(case, term_height)?;
+    let nvim = run_neovim_case_at_height(case, term_height)?;
     Ok(compare_snapshots(case, nevi, nvim))
 }
 
-fn run_neovim_case(case: &OracleCase) -> Result<EditorSnapshot, String> {
+fn run_neovim_case_at_height(
+    case: &OracleCase,
+    term_height: u16,
+) -> Result<EditorSnapshot, String> {
     let tmp = unique_temp_dir("nevi_vim_oracle");
     std::fs::create_dir_all(&tmp).map_err(|err| format!("create temp dir: {err}"))?;
     let file_path = tmp.join("case.txt");
     let script_path = tmp.join("snapshot.lua");
     std::fs::write(&file_path, case.initial_text).map_err(|err| format!("write case: {err}"))?;
-    std::fs::write(&script_path, neovim_snapshot_lua(case.keys))
-        .map_err(|err| format!("write lua script: {err}"))?;
+    std::fs::write(
+        &script_path,
+        neovim_snapshot_lua(case.keys, term_height.saturating_sub(2)),
+    )
+    .map_err(|err| format!("write lua script: {err}"))?;
 
     let output = Command::new("nvim")
         .args(["--headless", "-u", "NONE", "-i", "NONE", "-n"])
@@ -651,22 +711,29 @@ fn run_neovim_case(case: &OracleCase) -> Result<EditorSnapshot, String> {
     snapshot_from_neovim_json(json_line)
 }
 
-fn neovim_snapshot_lua(keys: &str) -> String {
+fn neovim_snapshot_lua(keys: &str, text_rows: u16) -> String {
     format!(
         r#"
 local keys = vim.api.nvim_replace_termcodes("{}", true, false, true)
-vim.o.scrolloff = 8
+vim.o.scrolloff = {}
+vim.o.wrap = false
+vim.api.nvim_win_set_width(0, {})
+vim.api.nvim_win_set_height(0, {})
 vim.api.nvim_feedkeys(keys, "xt", false)
 local pos = vim.api.nvim_win_get_cursor(0)
 local snapshot = {{
   lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
   cursor_line = pos[1] - 1,
   cursor_col = pos[2],
+  viewport_top = vim.fn.line("w0") - 1,
   mode = vim.api.nvim_get_mode().mode,
 }}
 io.stdout:write(vim.fn.json_encode(snapshot) .. "\n")
 "#,
-        lua_escape(keys)
+        lua_escape(keys),
+        ORACLE_SCROLL_OFF,
+        ORACLE_TERM_WIDTH,
+        text_rows
     )
 }
 
@@ -688,6 +755,7 @@ fn snapshot_from_neovim_json(line: &str) -> Result<EditorSnapshot, String> {
 
     let cursor_line = json_usize(&value, "cursor_line", line)?;
     let cursor_col = json_usize(&value, "cursor_col", line)?;
+    let viewport_top = json_usize(&value, "viewport_top", line)?;
     let raw_mode = value
         .get("mode")
         .and_then(|mode| mode.as_str())
@@ -697,6 +765,7 @@ fn snapshot_from_neovim_json(line: &str) -> Result<EditorSnapshot, String> {
         lines,
         cursor_line,
         cursor_col,
+        viewport_top,
         mode: normalize_neovim_mode(raw_mode).to_string(),
     })
 }
@@ -781,6 +850,7 @@ mod tests {
                 lines: vec!["alpha".to_string(), "eta".to_string()],
                 cursor_line: 1,
                 cursor_col: 0,
+                viewport_top: 0,
                 mode: "normal".to_string(),
             }
         );
@@ -797,12 +867,14 @@ mod tests {
             lines: vec!["abc".to_string()],
             cursor_line: 0,
             cursor_col: 1,
+            viewport_top: 0,
             mode: "normal".to_string(),
         };
         let nvim = EditorSnapshot {
             lines: vec!["abc".to_string()],
             cursor_line: 0,
             cursor_col: 2,
+            viewport_top: 0,
             mode: "normal".to_string(),
         };
 
@@ -813,6 +885,45 @@ mod tests {
         assert!(comparison.report.contains("cursor_col"));
         assert!(comparison.report.contains("nevi=1"));
         assert!(comparison.report.contains("nvim=2"));
+    }
+
+    #[test]
+    fn comparison_detects_viewport_top_mismatch() {
+        let case = OracleCase {
+            name: "viewport mismatch",
+            initial_text: SCREEN_POSITION_TEXT,
+            keys: "50Gzz",
+        };
+        let mut nevi_editor = Editor::default();
+        nevi_editor.replace_buffer_content(SCREEN_POSITION_TEXT);
+        nevi_editor.cursor.line = 49;
+        nevi_editor.viewport_offset = 39;
+
+        let mut nvim_editor = Editor::default();
+        nvim_editor.replace_buffer_content(SCREEN_POSITION_TEXT);
+        nvim_editor.cursor.line = 49;
+        nvim_editor.viewport_offset = 40;
+
+        let comparison = compare_snapshots(
+            &case,
+            snapshot_nevi(&nevi_editor),
+            snapshot_nevi(&nvim_editor),
+        );
+
+        assert!(!comparison.passed);
+        assert!(comparison.report.contains("viewport_top"));
+        assert!(comparison.report.contains("nevi=39"));
+        assert!(comparison.report.contains("nvim=40"));
+    }
+
+    #[test]
+    fn neovim_snapshot_parses_viewport_top() {
+        let snapshot = snapshot_from_neovim_json(
+            r#"{"lines":["alpha"],"cursor_line":0,"cursor_col":0,"viewport_top":4,"mode":"n"}"#,
+        )
+        .expect("parse snapshot");
+
+        assert_eq!(snapshot.viewport_top, 4);
     }
 
     #[test]
@@ -870,12 +981,14 @@ mod tests {
             lines: vec!["before!".to_string()],
             cursor_line: 0,
             cursor_col: 6,
+            viewport_top: 0,
             mode: "normal".to_string(),
         };
         let nvim = EditorSnapshot {
             lines: vec!["before".to_string()],
             cursor_line: 0,
             cursor_col: 5,
+            viewport_top: 0,
             mode: "normal".to_string(),
         };
 
@@ -906,6 +1019,13 @@ mod tests {
                 if !comparison.passed {
                     reports.push(format!("[{}] {}", category.name, comparison.report));
                 }
+            }
+        }
+        for case in SHORT_VIEWPORT_CASES {
+            let comparison = compare_with_neovim_at_height(case, ORACLE_SHORT_TERM_HEIGHT)
+                .expect("run short viewport oracle comparison");
+            if !comparison.passed {
+                reports.push(format!("[short-viewport] {}", comparison.report));
             }
         }
 


### PR DESCRIPTION
## Summary
- compare Nevi and Neovim top-visible-line state in the Vim oracle
- protect `zz`, `zt`, and `zb` with normal and short-viewport oracle cases
- align `zt` and `zb` with Neovim `scrolloff` behavior, including even-height panes
- mark all three keybinds as oracle-protected in the coverage inventory

## Verification
- `cargo fmt --check`
- `cargo test --quiet` (668 library tests passed, 3 ignored; 26 binary tests passed)
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `git diff --check`
- manual `zz`/`zt`/`zb` verification with `scroll_off = 5` in full and reduced viewports
- independent Rust review: no remaining blocking or important findings