### PR TITLE
fix: match Vim page scrolling behavior

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,15 +60,14 @@ jobs:
       - name: Run render frame-budget guard
         run: cargo test render_frame_budget -- --ignored --nocapture
 
-      - name: Install Neovim for parity smoke test on macOS
-        if: runner.os == 'macOS'
-        run: brew install neovim
+      - name: Install pinned Neovim for parity smoke test
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.11.3
 
-      - name: Install Neovim for parity smoke test on Linux
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y neovim
+      - name: Report Neovim oracle version
+        run: nvim --version
 
       - name: Run Vim oracle smoke test
         run: NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -159,6 +159,8 @@ pub struct Pane {
     pub viewport_offset: usize,
     /// Horizontal scroll offset for this pane
     pub h_offset: usize,
+    /// Explicit Vim half-page distance set by a counted Ctrl-d/Ctrl-u.
+    pub half_page_scroll_rows: Option<usize>,
     /// Screen region for this pane
     pub rect: Rect,
     /// Relative size in the active split axis.
@@ -172,6 +174,7 @@ impl Pane {
             cursor: Cursor::default(),
             viewport_offset: 0,
             h_offset: 0,
+            half_page_scroll_rows: None,
             rect: Rect::default(),
             size_weight: 1,
         }
@@ -3613,6 +3616,9 @@ impl Editor {
 
                 let mut x = explorer_offset;
                 for (pane, w) in self.panes.iter_mut().zip(widths) {
+                    if pane.rect.height != text_height {
+                        pane.half_page_scroll_rows = None;
+                    }
                     pane.rect = Rect::new(x, 0, w, text_height);
                     x += w;
                 }
@@ -3623,6 +3629,9 @@ impl Editor {
 
                 let mut y = 0u16;
                 for (pane, h) in self.panes.iter_mut().zip(heights) {
+                    if pane.rect.height != h {
+                        pane.half_page_scroll_rows = None;
+                    }
                     pane.rect = Rect::new(explorer_offset, y, available_width, h);
                     y += h;
                 }
@@ -9826,6 +9835,18 @@ impl Editor {
             Motion::DisplayLineFirstNonBlank => {
                 self.move_to_display_line_position(DisplayLineTarget::FirstNonBlank);
             }
+            Motion::PageDown if !self.settings.editor.wrap => {
+                self.scroll_full_page(true, count);
+            }
+            Motion::PageUp if !self.settings.editor.wrap => {
+                self.scroll_full_page(false, count);
+            }
+            Motion::HalfPageDown if !self.settings.editor.wrap => {
+                self.scroll_half_page(true, count);
+            }
+            Motion::HalfPageUp if !self.settings.editor.wrap => {
+                self.scroll_half_page(false, count);
+            }
             _ => {
                 // Use standard motion handling
                 if let Some((new_line, new_col)) = apply_motion(
@@ -9854,6 +9875,202 @@ impl Editor {
                     }
                 }
             }
+        }
+    }
+
+    pub fn apply_page_motion(&mut self, motion: Motion, explicit_count: Option<usize>) {
+        match motion {
+            Motion::PageDown | Motion::PageUp => {
+                let count = explicit_count.unwrap_or(1);
+                let travel_rows = self.active_pane_text_rows().saturating_mul(count);
+                if self.page_motion_range_has_no_wrapped_lines(motion, travel_rows) {
+                    self.scroll_full_page(matches!(motion, Motion::PageDown), count);
+                } else {
+                    self.apply_motion(motion, count);
+                }
+            }
+            Motion::HalfPageDown | Motion::HalfPageUp => {
+                let default_rows = (self.active_pane_text_rows() / 2).max(1);
+                let stored_rows = self
+                    .panes
+                    .get(self.active_pane)
+                    .and_then(|pane| pane.half_page_scroll_rows);
+                let distance = explicit_count
+                    .unwrap_or(stored_rows.unwrap_or(default_rows))
+                    .max(1);
+
+                if let Some(count) = explicit_count
+                    && let Some(pane) = self.panes.get_mut(self.active_pane)
+                {
+                    pane.half_page_scroll_rows = Some(count.max(1));
+                }
+
+                if self.page_motion_range_has_no_wrapped_lines(motion, distance) {
+                    self.scroll_half_page_by(matches!(motion, Motion::HalfPageDown), distance);
+                } else {
+                    self.apply_motion(motion, explicit_count.unwrap_or(1));
+                }
+            }
+            _ => self.apply_motion(motion, explicit_count.unwrap_or(1)),
+        }
+    }
+
+    fn page_motion_range_has_no_wrapped_lines(&self, motion: Motion, travel_rows: usize) -> bool {
+        if !self.settings.editor.wrap {
+            return true;
+        }
+
+        let wrap_width = self.effective_wrap_width();
+        if wrap_width == 0 {
+            return false;
+        }
+
+        let last_line = last_addressable_line(self.buffer());
+        let viewport_top = self.viewport_offset.min(last_line);
+        let span = travel_rows.saturating_add(self.active_pane_text_rows());
+        let moving_up = matches!(motion, Motion::PageUp | Motion::HalfPageUp);
+        let mut start = if moving_up {
+            viewport_top.saturating_sub(span)
+        } else {
+            viewport_top
+        };
+        let mut end = if moving_up {
+            viewport_top.saturating_add(self.active_pane_text_rows())
+        } else {
+            viewport_top.saturating_add(span)
+        }
+        .min(last_line);
+        start = start.min(self.cursor.line.min(last_line));
+        end = end.max(self.cursor.line.min(last_line));
+
+        let tab_width = self.get_effective_tab_width();
+        (start..=end).all(|line_idx| {
+            self.buffer()
+                .line(line_idx)
+                .map(|line| {
+                    let (rows, capped) =
+                        Self::capped_wrapped_segment_rows(line, wrap_width, tab_width, 2);
+                    rows == 1 && !capped
+                })
+                .unwrap_or(true)
+        })
+    }
+
+    fn scroll_full_page(&mut self, down: bool, count: usize) {
+        let text_rows = self.active_pane_text_rows();
+        let page_rows = match text_rows {
+            0 | 1 => 1,
+            2 => 2,
+            _ => text_rows.saturating_sub(2).max(3),
+        };
+        let last_line = last_addressable_line(self.buffer());
+        let scroll_off = self.settings.editor.scroll_off;
+
+        for _ in 0..count.max(1) {
+            let previous_top = self.viewport_offset;
+            if down {
+                let eof_visible =
+                    self.viewport_offset.saturating_add(text_rows) >= last_line.saturating_add(1);
+                self.viewport_offset = if eof_visible {
+                    last_line
+                } else {
+                    self.viewport_offset
+                        .saturating_add(page_rows)
+                        .min(last_line)
+                };
+                if self.viewport_offset == previous_top {
+                    break;
+                }
+
+                let top_margin = scroll_off.min(text_rows.saturating_sub(1) / 2);
+                self.cursor.line = self
+                    .viewport_offset
+                    .saturating_add(top_margin)
+                    .min(last_line);
+            } else {
+                if self.viewport_offset == 0 {
+                    let visible_bottom = text_rows.saturating_sub(1).min(last_line);
+                    let bottom_margin = if visible_bottom == last_line {
+                        0
+                    } else {
+                        scroll_off.min(text_rows / 2)
+                    };
+                    self.cursor.line = self
+                        .cursor
+                        .line
+                        .min(visible_bottom.saturating_sub(bottom_margin));
+                    break;
+                }
+
+                let distance = if self.viewport_offset == last_line {
+                    text_rows.max(1)
+                } else {
+                    page_rows
+                };
+                self.viewport_offset = self.viewport_offset.saturating_sub(distance);
+                let visible_bottom = self
+                    .viewport_offset
+                    .saturating_add(text_rows.saturating_sub(1))
+                    .min(last_line);
+                let bottom_margin = if visible_bottom == last_line {
+                    0
+                } else {
+                    scroll_off.min(text_rows / 2)
+                };
+                self.cursor.line = visible_bottom.saturating_sub(bottom_margin);
+            }
+        }
+
+        self.finish_page_scroll();
+    }
+
+    fn scroll_half_page(&mut self, down: bool, count: usize) {
+        let text_rows = self.active_pane_text_rows();
+        // Vim treats an explicit count as the new half-page distance. Nevi's
+        // input layer cannot distinguish an explicit count of one from the
+        // default command, so the default remains half a viewport.
+        let distance = if count > 1 { count } else { text_rows / 2 }.max(1);
+        self.scroll_half_page_by(down, distance);
+    }
+
+    fn scroll_half_page_by(&mut self, down: bool, distance: usize) {
+        let text_rows = self.active_pane_text_rows();
+        let last_line = last_addressable_line(self.buffer());
+        let last_packed_top = last_line.saturating_add(1).saturating_sub(text_rows);
+        if down {
+            self.cursor.line = self.cursor.line.saturating_add(distance).min(last_line);
+            let furthest_top = last_packed_top.max(self.viewport_offset);
+            self.viewport_offset = self
+                .viewport_offset
+                .saturating_add(distance)
+                .min(furthest_top);
+        } else {
+            self.cursor.line = self.cursor.line.saturating_sub(distance);
+            self.viewport_offset = self.viewport_offset.saturating_sub(distance);
+        }
+
+        self.finish_page_scroll();
+    }
+
+    fn finish_page_scroll(&mut self) {
+        self.clamp_cursor();
+        if !self.settings.editor.wrap {
+            let text_area_width = self.text_area_width();
+            if text_area_width > 0 {
+                if self.cursor.col >= self.h_offset.saturating_add(text_area_width) {
+                    self.h_offset = self.cursor.col - text_area_width + 1;
+                } else if self.cursor.col < self.h_offset {
+                    self.h_offset = self
+                        .cursor
+                        .col
+                        .saturating_sub(text_area_width.saturating_sub(1));
+                }
+            }
+        }
+        if self.active_pane < self.panes.len() {
+            self.panes[self.active_pane].viewport_offset = self.viewport_offset;
+            self.panes[self.active_pane].h_offset = self.h_offset;
+            self.panes[self.active_pane].cursor = self.cursor;
         }
     }
 

--- a/src/editor/tests/screen_position.rs
+++ b/src/editor/tests/screen_position.rs
@@ -1,6 +1,19 @@
 use crate::editor::Editor;
 use crate::input::Motion;
 
+fn centered_editor(term_height: u16) -> Editor {
+    let mut editor = Editor::default();
+    editor.set_size(80, term_height);
+    editor.settings.editor.scroll_off = 8;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03}\n"))
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.apply_motion(Motion::GotoLine(50), 1);
+    editor.scroll_cursor_center();
+    editor
+}
+
 #[test]
 fn right_after_zt_near_eof_preserves_neovim_top_line() {
     let mut editor = Editor::default();
@@ -252,5 +265,391 @@ fn capped_wrapped_segment_rows_stops_at_requested_viewport_cap() {
     assert_eq!(
         Editor::capped_wrapped_segment_rows(line, 10, 4, 3),
         (3, true)
+    );
+}
+
+#[test]
+fn page_scroll_down_matches_neovim_in_normal_and_short_viewports() {
+    for (term_height, expected_cursor, expected_top) in [(24, 67, 59), (12, 57, 53)] {
+        let mut editor = centered_editor(term_height);
+
+        editor.apply_motion(Motion::PageDown, 1);
+
+        assert_eq!(
+            (editor.cursor.line, editor.viewport_offset),
+            (expected_cursor, expected_top),
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].cursor, editor.cursor,
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].viewport_offset, expected_top,
+            "term_height={term_height}"
+        );
+    }
+}
+
+#[test]
+fn page_scroll_up_matches_neovim_in_normal_and_short_viewports() {
+    for (term_height, expected_cursor, expected_top) in [(24, 32, 19), (12, 41, 37)] {
+        let mut editor = centered_editor(term_height);
+
+        editor.apply_motion(Motion::PageUp, 1);
+
+        assert_eq!(
+            (editor.cursor.line, editor.viewport_offset),
+            (expected_cursor, expected_top),
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].cursor, editor.cursor,
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].viewport_offset, expected_top,
+            "term_height={term_height}"
+        );
+    }
+}
+
+#[test]
+fn half_page_scroll_down_matches_neovim_in_normal_and_short_viewports() {
+    for (term_height, expected_cursor, expected_top) in [(24, 60, 50), (12, 54, 50)] {
+        let mut editor = centered_editor(term_height);
+
+        editor.apply_motion(Motion::HalfPageDown, 1);
+
+        assert_eq!(
+            (editor.cursor.line, editor.viewport_offset),
+            (expected_cursor, expected_top),
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].cursor, editor.cursor,
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].viewport_offset, expected_top,
+            "term_height={term_height}"
+        );
+    }
+}
+
+#[test]
+fn half_page_scroll_up_matches_neovim_in_normal_and_short_viewports() {
+    for (term_height, expected_cursor, expected_top) in [(24, 38, 28), (12, 44, 40)] {
+        let mut editor = centered_editor(term_height);
+
+        editor.apply_motion(Motion::HalfPageUp, 1);
+
+        assert_eq!(
+            (editor.cursor.line, editor.viewport_offset),
+            (expected_cursor, expected_top),
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].cursor, editor.cursor,
+            "term_height={term_height}"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].viewport_offset, expected_top,
+            "term_height={term_height}"
+        );
+    }
+}
+
+#[test]
+fn page_scroll_matches_neovim_at_file_boundaries() {
+    let mut near_end = centered_editor(24);
+    near_end.apply_motion(Motion::GotoLine(95), 1);
+    near_end.scroll_cursor_center();
+    near_end.apply_motion(Motion::PageDown, 1);
+
+    assert_eq!((near_end.cursor.line, near_end.viewport_offset), (99, 99));
+
+    let mut near_start = centered_editor(24);
+    near_start.apply_motion(Motion::GotoLine(5), 1);
+    near_start.scroll_cursor_center();
+    near_start.apply_motion(Motion::PageUp, 1);
+
+    assert_eq!((near_start.cursor.line, near_start.viewport_offset), (4, 0));
+}
+
+#[test]
+fn half_page_scroll_matches_neovim_at_file_boundaries() {
+    let mut near_end = centered_editor(24);
+    near_end.apply_motion(Motion::GotoLine(95), 1);
+    near_end.scroll_cursor_center();
+    near_end.apply_motion(Motion::HalfPageDown, 1);
+
+    assert_eq!((near_end.cursor.line, near_end.viewport_offset), (99, 84));
+
+    let mut near_start = centered_editor(24);
+    near_start.apply_motion(Motion::GotoLine(5), 1);
+    near_start.scroll_cursor_center();
+    near_start.apply_motion(Motion::HalfPageUp, 1);
+
+    assert_eq!((near_start.cursor.line, near_start.viewport_offset), (0, 0));
+}
+
+#[test]
+fn counted_page_scroll_matches_neovim() {
+    let mut page_down = centered_editor(24);
+    page_down.apply_motion(Motion::PageDown, 2);
+    assert_eq!((page_down.cursor.line, page_down.viewport_offset), (87, 79));
+
+    let mut page_up = centered_editor(24);
+    page_up.apply_motion(Motion::PageUp, 2);
+    assert_eq!((page_up.cursor.line, page_up.viewport_offset), (13, 0));
+
+    let mut half_down = centered_editor(24);
+    half_down.apply_motion(Motion::HalfPageDown, 3);
+    assert_eq!((half_down.cursor.line, half_down.viewport_offset), (52, 42));
+
+    let mut half_up = centered_editor(24);
+    half_up.apply_motion(Motion::HalfPageUp, 3);
+    assert_eq!((half_up.cursor.line, half_up.viewport_offset), (46, 36));
+}
+
+#[test]
+fn full_page_scroll_matches_neovim_for_partial_boundary_pages() {
+    let mut at_end = centered_editor(24);
+    at_end.apply_motion(Motion::FileEnd, 1);
+    at_end.apply_motion(Motion::PageDown, 1);
+    assert_eq!((at_end.cursor.line, at_end.viewport_offset), (99, 99));
+
+    let mut near_start = centered_editor(24);
+    near_start.apply_motion(Motion::GotoLine(11), 1);
+    near_start.scroll_cursor_top();
+    near_start.apply_motion(Motion::PageUp, 1);
+    assert_eq!(
+        (near_start.cursor.line, near_start.viewport_offset),
+        (13, 0)
+    );
+
+    at_end.apply_motion(Motion::PageUp, 1);
+    assert_eq!((at_end.cursor.line, at_end.viewport_offset), (90, 77));
+
+    let mut eof_visible = centered_editor(24);
+    eof_visible.apply_motion(Motion::FileEnd, 1);
+    eof_visible.apply_motion(Motion::Up, 13);
+    eof_visible.apply_motion(Motion::PageDown, 1);
+    assert_eq!(
+        (eof_visible.cursor.line, eof_visible.viewport_offset),
+        (99, 99)
+    );
+}
+
+#[test]
+fn full_page_scroll_matches_neovim_in_two_row_viewport() {
+    let mut page_down = centered_editor(4);
+    page_down.apply_motion(Motion::PageDown, 1);
+    assert_eq!((page_down.cursor.line, page_down.viewport_offset), (51, 51));
+
+    let mut page_up = centered_editor(4);
+    page_up.apply_motion(Motion::PageUp, 1);
+    assert_eq!((page_up.cursor.line, page_up.viewport_offset), (47, 47));
+}
+
+#[test]
+fn full_page_scroll_matches_neovim_in_three_and_four_row_viewports() {
+    for term_height in [5, 6] {
+        let mut page_down = centered_editor(term_height);
+        page_down.apply_motion(Motion::PageDown, 1);
+        assert_eq!(
+            (page_down.cursor.line, page_down.viewport_offset),
+            (52, 51),
+            "term_height={term_height}"
+        );
+
+        let mut page_up = centered_editor(term_height);
+        page_up.apply_motion(Motion::PageUp, 1);
+        assert_eq!(
+            (page_up.cursor.line, page_up.viewport_offset),
+            (46, 45),
+            "term_height={term_height}"
+        );
+    }
+}
+
+#[test]
+fn page_up_at_visible_file_start_clamps_cursor_to_scrolloff_area() {
+    let mut editor = centered_editor(12);
+    editor.apply_motion(Motion::GotoLine(6), 1);
+    editor.scroll_cursor_bottom();
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (5, 0));
+
+    editor.apply_motion(Motion::PageUp, 1);
+
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (4, 0));
+}
+
+#[test]
+fn page_scroll_repairs_horizontal_offset_after_landing_on_short_line() {
+    let mut editor = centered_editor(24);
+    let content = (1..=100)
+        .map(|line| {
+            if line == 50 {
+                format!("{}\n", "x".repeat(200))
+            } else {
+                format!("line {line:03}\n")
+            }
+        })
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.apply_motion(Motion::GotoLine(50), 1);
+    editor.cursor.col = 150;
+    editor.scroll_cursor_center();
+    editor.scroll_to_cursor();
+    assert!(editor.h_offset > 0);
+
+    editor.apply_motion(Motion::PageDown, 1);
+
+    assert_eq!(editor.cursor.col, 7);
+    assert_eq!(editor.h_offset, 0);
+    assert_eq!(editor.panes[editor.active_pane].h_offset, 0);
+}
+
+#[test]
+fn page_scroll_keeps_clamped_cursor_visible_on_medium_destination_line() {
+    let mut editor = centered_editor(24);
+    editor.set_size(40, 24);
+    let content = (1..=100)
+        .map(|line| {
+            if line == 50 {
+                format!("{}\n", "x".repeat(200))
+            } else {
+                format!("{}\n", "y".repeat(56))
+            }
+        })
+        .collect::<String>();
+    editor.replace_buffer_content(&content);
+    editor.apply_motion(Motion::GotoLine(50), 1);
+    editor.cursor.col = 150;
+    editor.scroll_cursor_center();
+    editor.scroll_to_cursor();
+    assert!(editor.h_offset > 0);
+
+    editor.apply_motion(Motion::PageDown, 1);
+
+    let visible_end = editor.h_offset + editor.text_area_width();
+    assert_eq!(editor.cursor.col, 55);
+    assert!(editor.h_offset <= editor.cursor.col);
+    assert!(editor.cursor.col < visible_end);
+}
+
+#[test]
+fn half_page_scroll_remembers_explicit_distance_per_pane() {
+    let mut editor = centered_editor(24);
+
+    editor.apply_page_motion(Motion::HalfPageDown, Some(2));
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (51, 41));
+    assert_eq!(
+        editor.panes[editor.active_pane].half_page_scroll_rows,
+        Some(2)
+    );
+
+    editor.apply_page_motion(Motion::HalfPageDown, None);
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (53, 43));
+
+    editor.apply_page_motion(Motion::HalfPageUp, None);
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (51, 41));
+
+    editor.hsplit(None).expect("horizontal split");
+    assert!(
+        editor
+            .panes
+            .iter()
+            .all(|pane| pane.half_page_scroll_rows.is_none())
+    );
+}
+
+#[test]
+fn explicit_one_half_page_scroll_moves_one_line() {
+    let mut editor = centered_editor(24);
+
+    editor.apply_page_motion(Motion::HalfPageDown, Some(1));
+
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (50, 40));
+    assert_eq!(
+        editor.panes[editor.active_pane].half_page_scroll_rows,
+        Some(1)
+    );
+}
+
+#[test]
+fn wrapped_page_motion_keeps_existing_motion_path() {
+    let mut expected = centered_editor(24);
+    expected.settings.editor.wrap = true;
+    expected.settings.editor.wrap_width = 20;
+    let content = (1..=100)
+        .map(|line| format!("line {line:03} {}\n", "x".repeat(60)))
+        .collect::<String>();
+    expected.replace_buffer_content(&content);
+    expected.apply_motion(Motion::GotoLine(50), 1);
+    expected.scroll_cursor_center();
+
+    let mut actual = centered_editor(24);
+    actual.settings.editor.wrap = true;
+    actual.settings.editor.wrap_width = 20;
+    actual.replace_buffer_content(&content);
+    actual.apply_motion(Motion::GotoLine(50), 1);
+    actual.scroll_cursor_center();
+    expected.apply_motion(Motion::HalfPageDown, 1);
+    actual.apply_page_motion(Motion::HalfPageDown, None);
+
+    assert_eq!(actual.cursor, expected.cursor);
+    assert_eq!(actual.viewport_offset, expected.viewport_offset);
+    assert_eq!(actual.h_offset, expected.h_offset);
+}
+
+#[test]
+fn wrap_enabled_file_with_unbroken_lines_uses_page_parity_at_eof() {
+    let mut editor = centered_editor(24);
+    editor.settings.editor.wrap = true;
+    editor.settings.editor.wrap_width = 9_999;
+
+    editor.apply_motion(Motion::FileEnd, 1);
+    editor.apply_page_motion(Motion::PageDown, None);
+
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (99, 99));
+    assert_eq!(editor.panes[editor.active_pane].cursor, editor.cursor);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 99);
+}
+
+#[test]
+fn page_scroll_uses_active_horizontal_split_height() {
+    let mut editor = centered_editor(24);
+    editor.hsplit(None).expect("horizontal split");
+    editor.cursor.line = 49;
+    editor.scroll_cursor_center();
+    assert_eq!(editor.panes[editor.active_pane].rect.height, 11);
+
+    editor.apply_page_motion(Motion::PageDown, None);
+
+    assert_eq!((editor.cursor.line, editor.viewport_offset), (58, 53));
+    assert_eq!(editor.panes[editor.active_pane].cursor, editor.cursor);
+    assert_eq!(editor.panes[editor.active_pane].viewport_offset, 53);
+}
+
+#[test]
+fn resizing_viewport_resets_remembered_half_page_distance() {
+    let mut editor = centered_editor(24);
+    editor.apply_page_motion(Motion::HalfPageDown, Some(2));
+    assert_eq!(
+        editor.panes[editor.active_pane].half_page_scroll_rows,
+        Some(2)
+    );
+
+    editor.set_size(80, 12);
+    assert_eq!(editor.panes[editor.active_pane].half_page_scroll_rows, None);
+
+    let before = (editor.cursor.line, editor.viewport_offset);
+    editor.apply_page_motion(Motion::HalfPageDown, None);
+    assert_eq!(
+        (editor.cursor.line, editor.viewport_offset),
+        (before.0 + 5, before.1 + 5)
     );
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -128,6 +128,8 @@ pub enum KeyAction {
     Pending,
     /// Execute a motion
     Motion(Motion, usize),
+    /// Execute a page motion while preserving whether a count was explicit.
+    PageMotion(Motion, Option<usize>),
     /// Execute an operator on a motion range
     OperatorMotion(Operator, Motion, usize),
     /// Execute an operator on the current line (dd, yy, cc)
@@ -1020,16 +1022,16 @@ impl InputState {
 
             // Page motions
             (KeyModifiers::CONTROL, KeyCode::Char('d')) => {
-                self.motion_or_operator(Motion::HalfPageDown, count)
+                self.page_motion_or_operator(Motion::HalfPageDown)
             }
             (KeyModifiers::CONTROL, KeyCode::Char('u')) => {
-                self.motion_or_operator(Motion::HalfPageUp, count)
+                self.page_motion_or_operator(Motion::HalfPageUp)
             }
             (KeyModifiers::CONTROL, KeyCode::Char('f')) => {
-                self.motion_or_operator(Motion::PageDown, count)
+                self.page_motion_or_operator(Motion::PageDown)
             }
             (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
-                self.motion_or_operator(Motion::PageUp, count)
+                self.page_motion_or_operator(Motion::PageUp)
             }
 
             // Insert mode entry (or text object modifier if operator pending)
@@ -1495,6 +1497,16 @@ impl InputState {
             self.reset();
             KeyAction::Motion(motion, count)
         }
+    }
+
+    fn page_motion_or_operator(&mut self, motion: Motion) -> KeyAction {
+        if self.pending_operator.is_some() {
+            return self.motion_or_operator(motion, self.effective_count());
+        }
+
+        let explicit_count = self.count;
+        self.reset();
+        KeyAction::PageMotion(motion, explicit_count)
     }
 
     /// Handle text object type key after i/a modifier
@@ -1990,6 +2002,20 @@ mod tests {
         }
     }
 
+    fn assert_page_motion(
+        keys: &[KeyEvent],
+        expected_motion: Motion,
+        expected_count: Option<usize>,
+    ) {
+        match run(keys) {
+            KeyAction::PageMotion(motion, count) => {
+                assert_eq!(motion, expected_motion);
+                assert_eq!(count, expected_count);
+            }
+            other => panic!("expected page motion, got {:?}", other),
+        }
+    }
+
     fn assert_operator_motion(
         keys: &[KeyEvent],
         expected_operator: Operator,
@@ -2153,10 +2179,12 @@ mod tests {
             1,
         );
 
-        assert_motion(&[ctrl('f')], Motion::PageDown, 1);
-        assert_motion(&[ctrl('b')], Motion::PageUp, 1);
-        assert_motion(&[ctrl('d')], Motion::HalfPageDown, 1);
-        assert_motion(&[ctrl('u')], Motion::HalfPageUp, 1);
+        assert_page_motion(&[ctrl('f')], Motion::PageDown, None);
+        assert_page_motion(&[ctrl('b')], Motion::PageUp, None);
+        assert_page_motion(&[ctrl('d')], Motion::HalfPageDown, None);
+        assert_page_motion(&[ctrl('u')], Motion::HalfPageUp, None);
+        assert_page_motion(&[key('2'), ctrl('f')], Motion::PageDown, Some(2));
+        assert_page_motion(&[key('1'), ctrl('d')], Motion::HalfPageDown, Some(1));
 
         match run(&[key('z'), key('z')]) {
             KeyAction::ScrollCenter => {}

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -25,6 +25,9 @@ pub(crate) enum CoverageState {
     ///
     /// Keeping explicit gaps in the inventory lets us grow coverage without
     /// pretending every documented key is already protected.
+    // Retained so a newly inventoried default can be tracked explicitly
+    // before its real-Neovim oracle case lands.
+    #[allow(dead_code)]
     NeedsCoverage { reason: &'static str },
 }
 
@@ -131,10 +134,10 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Repeat latest find-character search in reverse",
         "reverse repeat find char",
     ),
-    needs_oracle("<C-f>", "Scroll page down"),
-    needs_oracle("<C-b>", "Scroll page up"),
-    needs_oracle("<C-d>", "Scroll half page down"),
-    needs_oracle("<C-u>", "Scroll half page up"),
+    vim_oracle("<C-f>", "Scroll page down", "page down"),
+    vim_oracle("<C-b>", "Scroll page up", "page up"),
+    vim_oracle("<C-d>", "Scroll half page down", "half page down"),
+    vim_oracle("<C-u>", "Scroll half page up", "half page up"),
     vim_oracle("zz", "Center cursor line", "center cursor line"),
     vim_oracle("zt", "Move cursor line to top", "cursor line to top"),
     vim_oracle("zb", "Move cursor line to bottom", "cursor line to bottom"),
@@ -156,6 +159,7 @@ const fn vim_oracle(
     }
 }
 
+#[allow(dead_code)]
 const fn needs_oracle(key: &'static str, description: &'static str) -> KeybindCoverage {
     KeybindCoverage {
         mode: KeybindMode::Normal,
@@ -288,14 +292,10 @@ mod tests {
     }
 
     #[test]
-    fn known_gaps_are_explicit_instead_of_silent() {
+    fn tracked_inventory_has_no_current_oracle_gaps() {
         let gaps = uncovered_entries();
 
-        assert!(
-            gaps.iter()
-                .any(|entry| entry.mode == KeybindMode::Normal && entry.key == "<C-f>"),
-            "`<C-f>` should stay visible as a tracked Vim parity gap until oracle-covered"
-        );
+        assert!(gaps.is_empty(), "unprotected Vim defaults: {gaps:#?}");
     }
 
     #[test]
@@ -393,6 +393,30 @@ mod tests {
             ("zz", "center cursor line"),
             ("zt", "cursor line to top"),
             ("zb", "cursor line to bottom"),
+        ];
+
+        for (key, oracle_case) in expected {
+            let entry = coverage_for(KeybindMode::Normal, key)
+                .unwrap_or_else(|| panic!("missing coverage entry for `{key}`"));
+
+            assert_eq!(entry.kind, CoverageKind::VimOracle);
+            assert_eq!(
+                entry.state,
+                CoverageState::Protected {
+                    test_id: oracle_case,
+                },
+                "`{key}` should be protected by oracle case `{oracle_case}`"
+            );
+        }
+    }
+
+    #[test]
+    fn page_scroll_defaults_are_oracle_covered() {
+        let expected = [
+            ("<C-f>", "page down"),
+            ("<C-b>", "page up"),
+            ("<C-d>", "half page down"),
+            ("<C-u>", "half page up"),
         ];
 
         for (key, oracle_case) in expected {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7217,6 +7217,11 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.clear_search_highlights();
         }
 
+        KeyAction::PageMotion(motion, explicit_count) => {
+            editor.apply_page_motion(motion, explicit_count);
+            editor.clear_search_highlights();
+        }
+
         KeyAction::OperatorMotion(op, motion, count) => {
             let register = editor
                 .input_state

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -36,7 +36,9 @@ struct OracleComparison {
 const ORACLE_TERM_WIDTH: u16 = 80;
 const ORACLE_TERM_HEIGHT: u16 = 24;
 const ORACLE_SHORT_TERM_HEIGHT: u16 = 12;
+const ORACLE_SMALL_TERM_HEIGHTS: &[u16] = &[4, 5, 6];
 const ORACLE_SCROLL_OFF: usize = 8;
+const ORACLE_WRAP_WIDTH: usize = 9_999;
 
 const SCREEN_POSITION_TEXT: &str = concat!(
     "line 001\n",
@@ -293,6 +295,106 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "50Gzb",
     },
     OracleCase {
+        name: "page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-f>",
+    },
+    OracleCase {
+        name: "page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-b>",
+    },
+    OracleCase {
+        name: "half page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-d>",
+    },
+    OracleCase {
+        name: "half page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-u>",
+    },
+    OracleCase {
+        name: "page down near file end",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "95Gzz<C-f>",
+    },
+    OracleCase {
+        name: "page up near file start",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "5Gzz<C-b>",
+    },
+    OracleCase {
+        name: "half page down near file end",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "95Gzz<C-d>",
+    },
+    OracleCase {
+        name: "half page up near file start",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "5Gzz<C-u>",
+    },
+    OracleCase {
+        name: "counted page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz2<C-f>",
+    },
+    OracleCase {
+        name: "counted page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz2<C-b>",
+    },
+    OracleCase {
+        name: "counted half page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz3<C-d>",
+    },
+    OracleCase {
+        name: "counted half page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz3<C-u>",
+    },
+    OracleCase {
+        name: "explicit one half page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz1<C-d>",
+    },
+    OracleCase {
+        name: "remembered half page distance",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz2<C-d><C-d>",
+    },
+    OracleCase {
+        name: "shared half page distance",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz2<C-d><C-u>",
+    },
+    OracleCase {
+        name: "page down from file end",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "G<C-f>",
+    },
+    OracleCase {
+        name: "partial page up at file start",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "11Gzt<C-b>",
+    },
+    OracleCase {
+        name: "page back from file end",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "G<C-f><C-b>",
+    },
+    OracleCase {
+        name: "page down with file end visible",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "G13k<C-f>",
+    },
+    OracleCase {
+        name: "page down resets desired column",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50G7lzz<C-f>",
+    },
+    OracleCase {
         name: "enter next line first nonblank",
         initial_text: "zero\n    one\n  two\nthree\n",
         keys: "<CR>",
@@ -340,7 +442,51 @@ const SHORT_VIEWPORT_CASES: &[OracleCase] = &[
         initial_text: SCREEN_POSITION_TEXT,
         keys: "50Gzb",
     },
+    OracleCase {
+        name: "short viewport page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-f>",
+    },
+    OracleCase {
+        name: "short viewport page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-b>",
+    },
+    OracleCase {
+        name: "short viewport half page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-d>",
+    },
+    OracleCase {
+        name: "short viewport half page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-u>",
+    },
+    OracleCase {
+        name: "short viewport page up at file start",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "6Gzb<C-b>",
+    },
 ];
+
+const SMALL_VIEWPORT_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "two-row viewport page down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-f>",
+    },
+    OracleCase {
+        name: "two-row viewport page up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-b>",
+    },
+];
+
+const WRAP_ENABLED_CASES: &[OracleCase] = &[OracleCase {
+    name: "wrap enabled page down from file end",
+    initial_text: SCREEN_POSITION_TEXT,
+    keys: "G<C-f>",
+}];
 
 const EDITING_CASES: &[OracleCase] = &[
     OracleCase {
@@ -515,9 +661,19 @@ fn run_nevi_case(case: &OracleCase) -> Result<EditorSnapshot, String> {
 }
 
 fn run_nevi_case_at_height(case: &OracleCase, term_height: u16) -> Result<EditorSnapshot, String> {
+    run_nevi_case_with_options(case, term_height, false)
+}
+
+fn run_nevi_case_with_options(
+    case: &OracleCase,
+    term_height: u16,
+    wrap: bool,
+) -> Result<EditorSnapshot, String> {
     let mut editor = Editor::default();
     editor.set_size(ORACLE_TERM_WIDTH, term_height);
     editor.settings.editor.scroll_off = ORACLE_SCROLL_OFF;
+    editor.settings.editor.wrap = wrap;
+    editor.settings.editor.wrap_width = ORACLE_WRAP_WIDTH;
     editor.replace_buffer_content(case.initial_text);
 
     for key in parse_key_sequence(case.keys)? {
@@ -671,9 +827,27 @@ fn compare_with_neovim_at_height(
     Ok(compare_snapshots(case, nevi, nvim))
 }
 
+fn compare_with_neovim_with_options(
+    case: &OracleCase,
+    term_height: u16,
+    wrap: bool,
+) -> Result<OracleComparison, String> {
+    let nevi = run_nevi_case_with_options(case, term_height, wrap)?;
+    let nvim = run_neovim_case_with_options(case, term_height, wrap)?;
+    Ok(compare_snapshots(case, nevi, nvim))
+}
+
 fn run_neovim_case_at_height(
     case: &OracleCase,
     term_height: u16,
+) -> Result<EditorSnapshot, String> {
+    run_neovim_case_with_options(case, term_height, false)
+}
+
+fn run_neovim_case_with_options(
+    case: &OracleCase,
+    term_height: u16,
+    wrap: bool,
 ) -> Result<EditorSnapshot, String> {
     let tmp = unique_temp_dir("nevi_vim_oracle");
     std::fs::create_dir_all(&tmp).map_err(|err| format!("create temp dir: {err}"))?;
@@ -682,7 +856,7 @@ fn run_neovim_case_at_height(
     std::fs::write(&file_path, case.initial_text).map_err(|err| format!("write case: {err}"))?;
     std::fs::write(
         &script_path,
-        neovim_snapshot_lua(case.keys, term_height.saturating_sub(2)),
+        neovim_snapshot_lua(case.keys, term_height.saturating_sub(2), wrap),
     )
     .map_err(|err| format!("write lua script: {err}"))?;
 
@@ -711,12 +885,12 @@ fn run_neovim_case_at_height(
     snapshot_from_neovim_json(json_line)
 }
 
-fn neovim_snapshot_lua(keys: &str, text_rows: u16) -> String {
+fn neovim_snapshot_lua(keys: &str, text_rows: u16, wrap: bool) -> String {
     format!(
         r#"
 local keys = vim.api.nvim_replace_termcodes("{}", true, false, true)
 vim.o.scrolloff = {}
-vim.o.wrap = false
+vim.o.wrap = {}
 vim.api.nvim_win_set_width(0, {})
 vim.api.nvim_win_set_height(0, {})
 vim.api.nvim_feedkeys(keys, "xt", false)
@@ -732,6 +906,7 @@ io.stdout:write(vim.fn.json_encode(snapshot) .. "\n")
 "#,
         lua_escape(keys),
         ORACLE_SCROLL_OFF,
+        wrap,
         ORACLE_TERM_WIDTH,
         text_rows
     )
@@ -1026,6 +1201,25 @@ mod tests {
                 .expect("run short viewport oracle comparison");
             if !comparison.passed {
                 reports.push(format!("[short-viewport] {}", comparison.report));
+            }
+        }
+        for term_height in ORACLE_SMALL_TERM_HEIGHTS {
+            for case in SMALL_VIEWPORT_CASES {
+                let comparison = compare_with_neovim_at_height(case, *term_height)
+                    .expect("run small viewport oracle comparison");
+                if !comparison.passed {
+                    reports.push(format!(
+                        "[small-viewport height={term_height}] {}",
+                        comparison.report
+                    ));
+                }
+            }
+        }
+        for case in WRAP_ENABLED_CASES {
+            let comparison = compare_with_neovim_with_options(case, ORACLE_TERM_HEIGHT, true)
+                .expect("run wrap-enabled oracle comparison");
+            if !comparison.passed {
+                reports.push(format!("[wrap-enabled] {}", comparison.report));
             }
         }
 


### PR DESCRIPTION
## Summary

- match Vim/Neovim page and half-page scrolling for `Ctrl-f`, `Ctrl-b`, `Ctrl-d`, and `Ctrl-u`
- preserve explicit and remembered half-page counts per pane, including resize behavior
- handle short viewports, BOF/EOF boundaries, horizontal visibility, and wrap-enabled single-row ranges
- mark all four defaults as protected in the keybind coverage inventory
- expand unit and real-Neovim oracle coverage for counts, boundaries, viewport sizes, columns, splits, and wrapping

## Verification

- `cargo test --quiet` (`688` passed, `3` ignored; `26` binary tests passed)
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo fmt --check`
- `git diff --check`
- manual verification with the user's `wrap = true`, `wrap_width = 9999` configuration
