### PR TITLE
fix: align editing operators with Neovim

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -317,7 +317,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `cc` | Change entire line |
 | `C` | Change from cursor to end of line |
 | `yy` | Yank entire line |
-| `Y` | Yank entire line |
+| `Y` | Yank from cursor to end of line |
 | `x` / `{n}x` | Delete character(s) under cursor |
 | `X` / `{n}X` | Delete character(s) before cursor |
 | `s` / `{n}s` | Substitute character(s) under cursor |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4265,8 +4265,19 @@ impl Editor {
 
     /// Delete from cursor to motion target
     pub fn delete_motion(&mut self, motion: Motion, count: usize, register: Option<char>) {
-        if let Some((start_line, start_col, end_line, end_col)) = self.motion_range(motion, count) {
-            let linewise = Self::motion_is_linewise(motion);
+        if let Some((start_line, start_col, end_line, mut end_col)) =
+            self.motion_range(motion, count)
+        {
+            // Neovim promotes a counted d$ from column zero to a linewise
+            // deletion, including the target line's trailing newline.
+            let counted_line_end_is_linewise =
+                motion == Motion::LineEnd && count > 1 && start_col == 0;
+            let linewise = Self::motion_is_linewise(motion) || counted_line_end_is_linewise;
+            if counted_line_end_is_linewise {
+                end_col = self.buffers[self.current_buffer_idx]
+                    .line_len_including_newline(end_line)
+                    .saturating_sub(1);
+            }
             let original_col = self.cursor.col;
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
 
@@ -4408,44 +4419,54 @@ impl Editor {
 
     /// Change count lines (cc operation)
     pub fn change_line(&mut self, count: usize, register: Option<char>) {
+        let indentation = self.buffers[self.current_buffer_idx]
+            .line(self.cursor.line)
+            .map(|line| {
+                line.chars()
+                    .take_while(|ch| ch.is_whitespace() && *ch != '\n')
+                    .collect::<String>()
+            })
+            .unwrap_or_default();
+        let indentation_len = indentation.chars().count();
         let end_line = (self.cursor.line + count - 1).min(
             self.buffers[self.current_buffer_idx]
                 .len_lines()
                 .saturating_sub(1),
         );
 
-        // For cc, we delete the content but keep the line structure
-        // Get the text that will be deleted for undo
+        // Replace the changed lines with one line containing the original
+        // indentation. Modeling the operation as one replacement keeps the
+        // retained newline and undo/redo history consistent.
         let text = self.get_lines_text(self.cursor.line, end_line);
+        let replacement = if text.ends_with('\n') {
+            format!("{indentation}\n")
+        } else {
+            indentation.clone()
+        };
 
-        // Begin undo group (will include the delete and subsequent inserts)
+        // Vim anchors both undo and redo for cc at the retained indentation.
+        self.cursor.col = indentation_len;
         self.begin_change();
         self.undo_stack
-            .record_change(Change::delete(self.cursor.line, 0, text.clone()));
+            .prefer_current_cursor_after(self.cursor.line, indentation_len);
+        self.undo_stack.record_change(Change::new(
+            self.cursor.line,
+            0,
+            text.clone(),
+            replacement.clone(),
+        ));
 
+        self.buffers[self.current_buffer_idx].apply_change(
+            self.cursor.line,
+            0,
+            &text,
+            &replacement,
+        );
         self.registers
             .delete(register, RegisterContent::Lines(text), false);
 
-        // Delete all lines except keep one empty line
-        for _ in 0..count.saturating_sub(1) {
-            if self.cursor.line < self.buffers[self.current_buffer_idx].len_lines() - 1 {
-                self.delete_lines(self.cursor.line + 1, 1);
-            }
-        }
-
-        // Clear current line content (keep the newline)
-        let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
-        if line_len > 0 {
-            self.buffers[self.current_buffer_idx].delete_range(
-                self.cursor.line,
-                0,
-                self.cursor.line,
-                line_len,
-            );
-        }
-
         // Enter insert mode (don't start new undo group, reuse the one from change)
-        self.enter_insert_mode_at_change(self.cursor.line, 0);
+        self.enter_insert_mode_at_change(self.cursor.line, indentation_len);
     }
 
     /// Paste after cursor from a register
@@ -4493,66 +4514,79 @@ impl Editor {
 
     fn paste_after_with_cursor_after(&mut self, register: Option<char>, cursor_after: bool) {
         if let Some(content) = self.register_content_for_paste(register) {
-            self.begin_change();
+            self.paste_content_after(content, cursor_after, None);
+        }
+        self.check_clipboard_error();
+    }
 
-            match content {
-                RegisterContent::Lines(text) => {
-                    // Paste on new line below
-                    let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
+    fn paste_content_after(
+        &mut self,
+        content: RegisterContent,
+        cursor_after: bool,
+        preferred_redo_cursor: Option<(usize, usize)>,
+    ) {
+        self.begin_change();
+        if let Some((line, col)) = preferred_redo_cursor {
+            self.undo_stack.prefer_current_cursor_after(line, col);
+        }
 
-                    // Record the insertion for undo
-                    let trimmed = text.trim_end_matches('\n');
-                    let insert_text = format!("\n{}", trimmed);
-                    self.undo_stack.record_change(Change::insert(
-                        self.cursor.line,
-                        line_len,
-                        insert_text,
-                    ));
+        match content {
+            RegisterContent::Lines(text) => {
+                // Paste on new line below
+                let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
 
-                    self.buffers[self.current_buffer_idx].insert_char(
-                        self.cursor.line,
-                        line_len,
-                        '\n',
+                // Record the insertion for undo
+                let trimmed = text.strip_suffix('\n').unwrap_or(&text);
+                let insert_text = format!("\n{}", trimmed);
+                self.undo_stack.record_change(Change::insert(
+                    self.cursor.line,
+                    line_len,
+                    insert_text,
+                ));
+
+                self.buffers[self.current_buffer_idx].insert_char(self.cursor.line, line_len, '\n');
+                self.cursor.line += 1;
+                self.cursor.col = 0;
+                let first_inserted_line = self.cursor.line;
+                let inserted_line_count = Self::linewise_paste_line_count(trimmed);
+
+                // Insert the lines (without trailing newline if present)
+                self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, trimmed);
+                if cursor_after {
+                    self.cursor.line = (first_inserted_line + inserted_line_count).min(
+                        self.buffers[self.current_buffer_idx]
+                            .len_lines()
+                            .saturating_sub(1),
                     );
-                    self.cursor.line += 1;
                     self.cursor.col = 0;
-                    let first_inserted_line = self.cursor.line;
-                    let inserted_line_count = Self::linewise_paste_line_count(trimmed);
-
-                    // Insert the lines (without trailing newline if present)
-                    self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, trimmed);
-                    if cursor_after {
-                        self.cursor.line = (first_inserted_line + inserted_line_count).min(
-                            self.buffers[self.current_buffer_idx]
-                                .len_lines()
-                                .saturating_sub(1),
-                        );
-                        self.cursor.col = 0;
-                    }
-
-                    self.scroll_to_cursor();
+                } else {
+                    self.cursor.col = self.find_first_non_blank(first_inserted_line);
                 }
-                RegisterContent::Chars(text) => {
-                    // Paste after cursor
-                    let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
-                    let insert_col = if line_len > 0 {
-                        (self.cursor.col + 1).min(line_len)
-                    } else {
-                        0
-                    };
 
-                    // Record the insertion for undo
-                    self.undo_stack.record_change(Change::insert(
-                        self.cursor.line,
-                        insert_col,
-                        text.clone(),
-                    ));
+                self.scroll_to_cursor();
+            }
+            RegisterContent::Chars(text) => {
+                // Paste after cursor
+                let insert_line = self.cursor.line;
+                let line_len = self.buffers[self.current_buffer_idx].line_len(insert_line);
+                let insert_col = if line_len > 0 {
+                    (self.cursor.col + 1).min(line_len)
+                } else {
+                    0
+                };
 
-                    self.buffers[self.current_buffer_idx].insert_str(
-                        self.cursor.line,
-                        insert_col,
-                        &text,
-                    );
+                // Record the insertion for undo
+                self.undo_stack.record_change(Change::insert(
+                    insert_line,
+                    insert_col,
+                    text.clone(),
+                ));
+
+                self.buffers[self.current_buffer_idx].insert_str(insert_line, insert_col, &text);
+                if cursor_after && text.contains('\n') {
+                    (self.cursor.line, self.cursor.col) =
+                        Self::text_position_after_insert(insert_line, insert_col, &text);
+                } else {
                     let pasted_len = text.chars().count();
                     self.cursor.col = insert_col
                         + if cursor_after {
@@ -4560,28 +4594,41 @@ impl Editor {
                         } else {
                             pasted_len.saturating_sub(1)
                         };
-                    self.clamp_cursor();
                 }
+                self.clamp_cursor();
             }
-
-            self.undo_stack
-                .end_undo_group(self.cursor.line, self.cursor.col);
         }
-        self.check_clipboard_error();
+
+        self.undo_stack
+            .end_undo_group(self.cursor.line, self.cursor.col);
     }
 
     /// Paste after cursor count times.
     pub fn paste_after_count(&mut self, register: Option<char>, count: usize) {
-        for _ in 0..count.max(1) {
-            self.paste_after(register);
+        if let Some(content) = self.register_content_for_paste(register) {
+            let count = count.max(1);
+            let redo_cursor = (count > 1).then_some((self.cursor.line, self.cursor.col));
+            self.paste_content_after(
+                Self::repeat_register_content(content, count),
+                false,
+                redo_cursor,
+            );
         }
+        self.check_clipboard_error();
     }
 
     /// Paste after cursor count times and leave cursor after the pasted text.
     pub fn paste_after_move_count(&mut self, register: Option<char>, count: usize) {
-        for _ in 0..count.max(1) {
-            self.paste_after_move(register);
+        if let Some(content) = self.register_content_for_paste(register) {
+            let count = count.max(1);
+            let redo_cursor = (count > 1).then_some((self.cursor.line, self.cursor.col));
+            self.paste_content_after(
+                Self::repeat_register_content(content, count),
+                true,
+                redo_cursor,
+            );
         }
+        self.check_clipboard_error();
     }
 
     /// Paste before cursor from a register
@@ -4596,91 +4643,145 @@ impl Editor {
 
     fn paste_before_with_cursor_after(&mut self, register: Option<char>, cursor_after: bool) {
         if let Some(content) = self.register_content_for_paste(register) {
-            self.begin_change();
+            self.paste_content_before(content, cursor_after, None);
+        }
+        self.check_clipboard_error();
+    }
 
-            match content {
-                RegisterContent::Lines(text) => {
-                    // Paste on new line above
-                    let insert_line = self.cursor.line;
-                    let inserted_line_count = Self::linewise_paste_line_count(&text);
-                    let insert_text = if text.ends_with('\n') {
-                        text.clone()
-                    } else {
-                        format!("{}\n", text)
-                    };
+    fn paste_content_before(
+        &mut self,
+        content: RegisterContent,
+        cursor_after: bool,
+        preferred_redo_cursor: Option<(usize, usize)>,
+    ) {
+        self.begin_change();
+        if let Some((line, col)) = preferred_redo_cursor {
+            self.undo_stack.prefer_current_cursor_after(line, col);
+        }
 
-                    // Record the insertion for undo
-                    self.undo_stack.record_change(Change::insert(
+        match content {
+            RegisterContent::Lines(text) => {
+                // Paste on new line above
+                let insert_line = self.cursor.line;
+                let inserted_line_count = Self::linewise_paste_line_count(&text);
+                let insert_text = if text.ends_with('\n') {
+                    text.clone()
+                } else {
+                    format!("{}\n", text)
+                };
+
+                // Record the insertion for undo
+                self.undo_stack.record_change(Change::insert(
+                    self.cursor.line,
+                    0,
+                    insert_text.clone(),
+                ));
+
+                self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, &text);
+                if !text.ends_with('\n') {
+                    self.buffers[self.current_buffer_idx].insert_char(
                         self.cursor.line,
-                        0,
-                        insert_text.clone(),
-                    ));
-
-                    self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, &text);
-                    if !text.ends_with('\n') {
-                        self.buffers[self.current_buffer_idx].insert_char(
-                            self.cursor.line,
-                            text.len(),
-                            '\n',
-                        );
-                    }
-                    self.cursor.col = 0;
-                    if cursor_after {
-                        self.cursor.line = (insert_line + inserted_line_count).min(
-                            self.buffers[self.current_buffer_idx]
-                                .len_lines()
-                                .saturating_sub(1),
-                        );
-                    }
-                    self.scroll_to_cursor();
-                }
-                RegisterContent::Chars(text) => {
-                    // Record the insertion for undo
-                    self.undo_stack.record_change(Change::insert(
-                        self.cursor.line,
-                        self.cursor.col,
-                        text.clone(),
-                    ));
-
-                    // Paste before cursor
-                    self.buffers[self.current_buffer_idx].insert_str(
-                        self.cursor.line,
-                        self.cursor.col,
-                        &text,
+                        text.len(),
+                        '\n',
                     );
+                }
+                self.cursor.col = 0;
+                if cursor_after {
+                    self.cursor.line = (insert_line + inserted_line_count).min(
+                        self.buffers[self.current_buffer_idx]
+                            .len_lines()
+                            .saturating_sub(1),
+                    );
+                } else {
+                    self.cursor.col = self.find_first_non_blank(insert_line);
+                }
+                self.scroll_to_cursor();
+            }
+            RegisterContent::Chars(text) => {
+                let insert_line = self.cursor.line;
+                let insert_col = self.cursor.col;
+                // Record the insertion for undo
+                self.undo_stack.record_change(Change::insert(
+                    insert_line,
+                    insert_col,
+                    text.clone(),
+                ));
+
+                // Paste before cursor
+                self.buffers[self.current_buffer_idx].insert_str(insert_line, insert_col, &text);
+                if text.contains('\n') {
+                    if cursor_after {
+                        (self.cursor.line, self.cursor.col) =
+                            Self::text_position_after_insert(insert_line, insert_col, &text);
+                    } else {
+                        self.cursor.line = insert_line;
+                        self.cursor.col = insert_col;
+                    }
+                } else {
                     let pasted_len = text.chars().count();
-                    self.cursor.col = self.cursor.col
+                    self.cursor.col = insert_col
                         + if cursor_after {
                             pasted_len
                         } else {
                             pasted_len.saturating_sub(1)
                         };
-                    self.clamp_cursor();
                 }
+                self.clamp_cursor();
             }
-
-            self.undo_stack
-                .end_undo_group(self.cursor.line, self.cursor.col);
         }
-        self.check_clipboard_error();
+
+        self.undo_stack
+            .end_undo_group(self.cursor.line, self.cursor.col);
     }
 
     /// Paste before cursor count times.
     pub fn paste_before_count(&mut self, register: Option<char>, count: usize) {
-        for _ in 0..count.max(1) {
-            self.paste_before(register);
+        if let Some(content) = self.register_content_for_paste(register) {
+            let count = count.max(1);
+            let redo_cursor = (count > 1).then_some((self.cursor.line, self.cursor.col));
+            self.paste_content_before(
+                Self::repeat_register_content(content, count),
+                false,
+                redo_cursor,
+            );
         }
+        self.check_clipboard_error();
     }
 
     /// Paste before cursor count times and leave cursor after the pasted text.
     pub fn paste_before_move_count(&mut self, register: Option<char>, count: usize) {
-        for _ in 0..count.max(1) {
-            self.paste_before_move(register);
+        if let Some(content) = self.register_content_for_paste(register) {
+            let count = count.max(1);
+            let redo_cursor = (count > 1).then_some((self.cursor.line, self.cursor.col));
+            self.paste_content_before(
+                Self::repeat_register_content(content, count),
+                true,
+                redo_cursor,
+            );
+        }
+        self.check_clipboard_error();
+    }
+
+    fn repeat_register_content(content: RegisterContent, count: usize) -> RegisterContent {
+        match content {
+            RegisterContent::Chars(text) => RegisterContent::Chars(text.repeat(count.max(1))),
+            RegisterContent::Lines(text) => {
+                let block = if text.ends_with('\n') {
+                    text
+                } else {
+                    format!("{text}\n")
+                };
+                RegisterContent::Lines(block.repeat(count.max(1)))
+            }
         }
     }
 
     fn linewise_paste_line_count(text: &str) -> usize {
-        text.trim_end_matches('\n').split('\n').count().max(1)
+        text.strip_suffix('\n')
+            .unwrap_or(text)
+            .split('\n')
+            .count()
+            .max(1)
     }
 
     /// Enter insert mode
@@ -7631,9 +7732,17 @@ impl Editor {
         &self,
         text_object: TextObject,
     ) -> Option<(usize, usize, usize, usize)> {
+        self.find_text_object_range_with_count(text_object, 1)
+    }
+
+    fn find_text_object_range_with_count(
+        &self,
+        text_object: TextObject,
+        count: usize,
+    ) -> Option<(usize, usize, usize, usize)> {
         match text_object.object_type {
-            TextObjectType::Word => self.find_word_object(text_object.modifier, false),
-            TextObjectType::BigWord => self.find_word_object(text_object.modifier, true),
+            TextObjectType::Word => self.find_word_object(text_object.modifier, false, count),
+            TextObjectType::BigWord => self.find_word_object(text_object.modifier, true, count),
             TextObjectType::DoubleQuote => self.find_quote_object(text_object.modifier, '"'),
             TextObjectType::SingleQuote => self.find_quote_object(text_object.modifier, '\''),
             TextObjectType::BackTick => self.find_quote_object(text_object.modifier, '`'),
@@ -7654,6 +7763,7 @@ impl Editor {
         &self,
         modifier: TextObjectModifier,
         big_word: bool,
+        count: usize,
     ) -> Option<(usize, usize, usize, usize)> {
         let line = self.cursor.line;
         let col = self.cursor.col;
@@ -7718,6 +7828,37 @@ impl Editor {
             }
         } else {
             while end < chars.len() - 1 && chars[end + 1].is_whitespace() {
+                end += 1;
+            }
+        }
+
+        // A count extends the object through subsequent words while retaining
+        // the whitespace between them. Around-whitespace is applied once at
+        // the final boundary, matching Neovim's 2caw/c2aw behavior.
+        for _ in 1..count.max(1) {
+            let mut next = end.saturating_add(1);
+            while next < chars.len() && chars[next].is_whitespace() {
+                next += 1;
+            }
+            if next >= chars.len() {
+                break;
+            }
+
+            let next_is_word = is_word_char(chars[next]);
+            let next_is_whitespace = chars[next].is_whitespace();
+            end = next;
+            while end + 1 < chars.len() {
+                let following = chars[end + 1];
+                let same_class = if next_is_word {
+                    is_word_char(following)
+                } else if next_is_whitespace {
+                    following.is_whitespace()
+                } else {
+                    !is_word_char(following) && !following.is_whitespace()
+                };
+                if !same_class {
+                    break;
+                }
                 end += 1;
             }
         }
@@ -8212,9 +8353,14 @@ impl Editor {
     }
 
     /// Delete text object
-    pub fn delete_text_object(&mut self, text_object: TextObject, register: Option<char>) {
+    pub fn delete_text_object(
+        &mut self,
+        text_object: TextObject,
+        count: usize,
+        register: Option<char>,
+    ) {
         if let Some((start_line, start_col, end_line, end_col)) =
-            self.find_text_object_range(text_object)
+            self.find_text_object_range_with_count(text_object, count)
         {
             // Get text for register
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
@@ -8248,9 +8394,14 @@ impl Editor {
     }
 
     /// Change text object (delete and enter insert mode)
-    pub fn change_text_object(&mut self, text_object: TextObject, register: Option<char>) {
+    pub fn change_text_object(
+        &mut self,
+        text_object: TextObject,
+        count: usize,
+        register: Option<char>,
+    ) {
         if let Some((start_line, start_col, end_line, end_col)) =
-            self.find_text_object_range(text_object)
+            self.find_text_object_range_with_count(text_object, count)
         {
             // Get text for register
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
@@ -8279,9 +8430,14 @@ impl Editor {
     }
 
     /// Yank text object
-    pub fn yank_text_object(&mut self, text_object: TextObject, register: Option<char>) {
+    pub fn yank_text_object(
+        &mut self,
+        text_object: TextObject,
+        count: usize,
+        register: Option<char>,
+    ) {
         if let Some((start_line, start_col, end_line, end_col)) =
-            self.find_text_object_range(text_object)
+            self.find_text_object_range_with_count(text_object, count)
         {
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
             self.registers.yank(register, RegisterContent::Chars(text));
@@ -10993,6 +11149,7 @@ fn project_replace_display_path(root: &std::path::Path, path: &std::path::Path) 
 
 #[cfg(test)]
 mod tests {
+    mod editing_operators;
     mod screen_position;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};

--- a/src/editor/tests/editing_operators.rs
+++ b/src/editor/tests/editing_operators.rs
@@ -1,3 +1,4 @@
+use crate::editor::register::RegisterContent;
 use crate::editor::{Editor, Mode};
 use crate::input::Motion;
 
@@ -50,9 +51,9 @@ fn redo_after_indented_change_line_returns_to_indentation() {
 fn counted_linewise_paste_leaves_cursor_on_first_pasted_line() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\n");
-    editor.delete_line(1, None);
+    editor.delete_line(1, Some('a'));
 
-    editor.paste_after_count(None, 2);
+    editor.paste_after_count(Some('a'), 2);
 
     assert_eq!(editor.buffer().content(), "beta\nalpha\nalpha\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
@@ -62,8 +63,8 @@ fn counted_linewise_paste_leaves_cursor_on_first_pasted_line() {
 fn counted_linewise_paste_is_one_undo_and_redo_change() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\n");
-    editor.delete_line(1, None);
-    editor.paste_after_count(None, 2);
+    editor.delete_line(1, Some('a'));
+    editor.paste_after_count(Some('a'), 2);
 
     editor.undo();
     assert_eq!(editor.buffer().content(), "beta\n");
@@ -78,8 +79,8 @@ fn counted_linewise_paste_is_one_undo_and_redo_change() {
 fn counted_linewise_paste_before_is_one_undo_change() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\n");
-    editor.delete_line(1, None);
-    editor.paste_before_count(None, 2);
+    editor.delete_line(1, Some('a'));
+    editor.paste_before_count(Some('a'), 2);
 
     editor.undo();
 
@@ -91,9 +92,9 @@ fn counted_linewise_paste_before_is_one_undo_change() {
 fn counted_multiline_linewise_paste_repeats_complete_blocks() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\ngamma\ndelta\n");
-    editor.yank_line(3, None);
+    editor.yank_line(3, Some('a'));
 
-    editor.paste_after_count(None, 2);
+    editor.paste_after_count(Some('a'), 2);
 
     assert_eq!(
         editor.buffer().content(),
@@ -106,9 +107,9 @@ fn counted_multiline_linewise_paste_repeats_complete_blocks() {
 fn counted_empty_linewise_paste_preserves_each_blank_line() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("\nalpha\n");
-    editor.yank_line(1, None);
+    editor.yank_line(1, Some('a'));
 
-    editor.paste_after_count(None, 2);
+    editor.paste_after_count(Some('a'), 2);
 
     assert_eq!(editor.buffer().content(), "\n\n\nalpha\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
@@ -119,8 +120,11 @@ fn counted_characterwise_paste_keeps_cursor_on_last_inserted_character() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("abcd\n");
     editor.delete_char_at();
+    editor
+        .registers
+        .set(Some('a'), RegisterContent::Chars("a".to_string()));
 
-    editor.paste_after_count(None, 2);
+    editor.paste_after_count(Some('a'), 2);
 
     assert_eq!(editor.buffer().content(), "baacd\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
@@ -130,9 +134,9 @@ fn counted_characterwise_paste_keeps_cursor_on_last_inserted_character() {
 fn multiline_characterwise_paste_before_stays_at_insert_start() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\ngamma\n");
-    editor.yank_motion(Motion::LineEnd, 2, None);
+    editor.yank_motion(Motion::LineEnd, 2, Some('a'));
 
-    editor.paste_before(None);
+    editor.paste_before(Some('a'));
 
     assert_eq!(editor.buffer().content(), "alpha\nbetaalpha\nbeta\ngamma\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
@@ -142,9 +146,9 @@ fn multiline_characterwise_paste_before_stays_at_insert_start() {
 fn linewise_paste_lands_on_first_nonblank_of_inserted_line() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("  alpha\nsecond\n");
-    editor.yank_line(1, None);
+    editor.yank_line(1, Some('a'));
 
-    editor.paste_after(None);
+    editor.paste_after(Some('a'));
 
     assert_eq!(editor.buffer().content(), "  alpha\n  alpha\nsecond\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
@@ -155,11 +159,11 @@ fn counted_delete_to_line_end_from_column_zero_is_linewise() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\ngamma\n");
 
-    editor.delete_motion(Motion::LineEnd, 2, None);
+    editor.delete_motion(Motion::LineEnd, 2, Some('a'));
 
     assert_eq!(editor.buffer().content(), "gamma\n");
     assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
 
-    editor.paste_after(None);
+    editor.paste_after(Some('a'));
     assert_eq!(editor.buffer().content(), "gamma\nalpha\nbeta\n");
 }

--- a/src/editor/tests/editing_operators.rs
+++ b/src/editor/tests/editing_operators.rs
@@ -1,0 +1,165 @@
+use crate::editor::{Editor, Mode};
+use crate::input::Motion;
+
+#[test]
+fn change_line_preserves_existing_indentation() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("  alpha beta\nsecond\n");
+
+    editor.change_line(1, None);
+
+    assert_eq!(editor.buffer().content(), "  \nsecond\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+    assert_eq!(editor.mode, Mode::Insert);
+}
+
+#[test]
+fn undo_after_indented_change_line_restores_original_text() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("  alpha beta\nsecond\n");
+    editor.change_line(1, None);
+    for ch in "replacement".chars() {
+        editor.insert_char(ch);
+    }
+    editor.enter_normal_mode();
+
+    editor.undo();
+
+    assert_eq!(editor.buffer().content(), "  alpha beta\nsecond\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}
+
+#[test]
+fn redo_after_indented_change_line_returns_to_indentation() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("  alpha beta\nsecond\n");
+    editor.change_line(1, None);
+    for ch in "replacement".chars() {
+        editor.insert_char(ch);
+    }
+    editor.enter_normal_mode();
+    editor.undo();
+
+    editor.redo();
+
+    assert_eq!(editor.buffer().content(), "  replacement\nsecond\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}
+
+#[test]
+fn counted_linewise_paste_leaves_cursor_on_first_pasted_line() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\n");
+    editor.delete_line(1, None);
+
+    editor.paste_after_count(None, 2);
+
+    assert_eq!(editor.buffer().content(), "beta\nalpha\nalpha\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn counted_linewise_paste_is_one_undo_and_redo_change() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\n");
+    editor.delete_line(1, None);
+    editor.paste_after_count(None, 2);
+
+    editor.undo();
+    assert_eq!(editor.buffer().content(), "beta\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+
+    editor.redo();
+    assert_eq!(editor.buffer().content(), "beta\nalpha\nalpha\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}
+
+#[test]
+fn counted_linewise_paste_before_is_one_undo_change() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\n");
+    editor.delete_line(1, None);
+    editor.paste_before_count(None, 2);
+
+    editor.undo();
+
+    assert_eq!(editor.buffer().content(), "beta\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}
+
+#[test]
+fn counted_multiline_linewise_paste_repeats_complete_blocks() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\ngamma\ndelta\n");
+    editor.yank_line(3, None);
+
+    editor.paste_after_count(None, 2);
+
+    assert_eq!(
+        editor.buffer().content(),
+        "alpha\nalpha\nbeta\ngamma\nalpha\nbeta\ngamma\nbeta\ngamma\ndelta\n"
+    );
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn counted_empty_linewise_paste_preserves_each_blank_line() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("\nalpha\n");
+    editor.yank_line(1, None);
+
+    editor.paste_after_count(None, 2);
+
+    assert_eq!(editor.buffer().content(), "\n\n\nalpha\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn counted_characterwise_paste_keeps_cursor_on_last_inserted_character() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcd\n");
+    editor.delete_char_at();
+
+    editor.paste_after_count(None, 2);
+
+    assert_eq!(editor.buffer().content(), "baacd\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}
+
+#[test]
+fn multiline_characterwise_paste_before_stays_at_insert_start() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\ngamma\n");
+    editor.yank_motion(Motion::LineEnd, 2, None);
+
+    editor.paste_before(None);
+
+    assert_eq!(editor.buffer().content(), "alpha\nbetaalpha\nbeta\ngamma\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}
+
+#[test]
+fn linewise_paste_lands_on_first_nonblank_of_inserted_line() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("  alpha\nsecond\n");
+    editor.yank_line(1, None);
+
+    editor.paste_after(None);
+
+    assert_eq!(editor.buffer().content(), "  alpha\n  alpha\nsecond\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 2));
+}
+
+#[test]
+fn counted_delete_to_line_end_from_column_zero_is_linewise() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nbeta\ngamma\n");
+
+    editor.delete_motion(Motion::LineEnd, 2, None);
+
+    assert_eq!(editor.buffer().content(), "gamma\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+
+    editor.paste_after(None);
+    assert_eq!(editor.buffer().content(), "gamma\nalpha\nbeta\n");
+}

--- a/src/editor/undo.rs
+++ b/src/editor/undo.rs
@@ -61,6 +61,8 @@ pub struct UndoEntry {
     pub cursor_before: (usize, usize),
     /// Cursor position after this entry
     pub cursor_after: (usize, usize),
+    /// Optional semantic cursor anchor used by Vim-compatible redo behavior.
+    preferred_cursor_after: Option<(usize, usize)>,
 }
 
 impl UndoEntry {
@@ -69,6 +71,7 @@ impl UndoEntry {
             changes: Vec::new(),
             cursor_before: (cursor_line, cursor_col),
             cursor_after: (cursor_line, cursor_col),
+            preferred_cursor_after: None,
         }
     }
 
@@ -84,6 +87,11 @@ impl UndoEntry {
 
     /// Set the cursor position after all changes
     pub fn set_cursor_after(&mut self, line: usize, col: usize) {
+        self.cursor_after = self.preferred_cursor_after.unwrap_or((line, col));
+    }
+
+    pub fn prefer_cursor_after(&mut self, line: usize, col: usize) {
+        self.preferred_cursor_after = Some((line, col));
         self.cursor_after = (line, col);
     }
 }
@@ -219,6 +227,13 @@ impl UndoStack {
             entry.push(change);
             self.undo_stack.push_back(entry);
             self.redo_stack.clear();
+        }
+    }
+
+    /// Keep group finalization from replacing an operation-specific redo cursor.
+    pub fn prefer_current_cursor_after(&mut self, line: usize, col: usize) {
+        if let Some(entry) = self.current_entry.as_mut() {
+            entry.prefer_cursor_after(line, col);
         }
     }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -135,7 +135,7 @@ pub enum KeyAction {
     /// Execute an operator on the current line (dd, yy, cc)
     OperatorLine(Operator, usize),
     /// Execute an operator on a text object (diw, ca", etc.)
-    OperatorTextObject(Operator, TextObject),
+    OperatorTextObject(Operator, TextObject, usize),
     /// Select a text object in visual mode
     SelectTextObject(TextObject),
     /// Enter insert mode
@@ -1158,10 +1158,10 @@ impl InputState {
                 self.reset();
                 KeyAction::OperatorMotion(Operator::Change, Motion::LineEnd, count)
             }
-            // Y = yy (yank line) - vim behavior
+            // Neovim defaults Y to y$ (characterwise yank through line end).
             (KeyModifiers::SHIFT, KeyCode::Char('Y')) => {
                 self.reset();
-                KeyAction::OperatorLine(Operator::Yank, count)
+                KeyAction::OperatorMotion(Operator::Yank, Motion::LineEnd, count)
             }
 
             // Undo/Redo
@@ -1543,8 +1543,9 @@ impl InputState {
             };
 
             if let Some(op) = self.pending_operator.take() {
+                let count = self.combined_count();
                 self.reset();
-                KeyAction::OperatorTextObject(op, text_object)
+                KeyAction::OperatorTextObject(op, text_object, count)
             } else if let Some(case_op) = self.pending_case_operator.take() {
                 self.reset();
                 KeyAction::CaseTextObject(case_op, text_object)
@@ -2078,10 +2079,11 @@ mod tests {
         expected_object_type: TextObjectType,
     ) {
         match run(keys) {
-            KeyAction::OperatorTextObject(operator, text_object) => {
+            KeyAction::OperatorTextObject(operator, text_object, count) => {
                 assert_eq!(operator, expected_operator);
                 assert_eq!(text_object.modifier, expected_modifier);
                 assert_eq!(text_object.object_type, expected_object_type);
+                assert_eq!(count, 1);
             }
             other => panic!("expected text object action, got {:?}", other),
         }
@@ -2252,7 +2254,7 @@ mod tests {
         assert_operator_line(&[key('c'), key('c')], Operator::Change, 1);
         assert_operator_motion(&[shift('C')], Operator::Change, Motion::LineEnd, 1);
         assert_operator_line(&[key('y'), key('y')], Operator::Yank, 1);
-        assert_operator_line(&[shift('Y')], Operator::Yank, 1);
+        assert_operator_motion(&[shift('Y')], Operator::Yank, Motion::LineEnd, 1);
         assert_operator_line(&[key('>'), key('>')], Operator::Indent, 1);
         assert_operator_motion(&[key('>'), key('j')], Operator::Indent, Motion::Down, 1);
         assert_operator_line(&[key('<'), key('<')], Operator::Dedent, 1);
@@ -2316,6 +2318,29 @@ mod tests {
         match run(&[shift('R')]) {
             KeyAction::EnterReplace => {}
             other => panic!("expected EnterReplace, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn uppercase_y_maps_to_yank_through_line_end_like_neovim() {
+        assert_operator_motion(&[shift('Y')], Operator::Yank, Motion::LineEnd, 1);
+    }
+
+    #[test]
+    fn text_object_operator_combines_counts_from_either_position() {
+        for keys in [
+            vec![key('2'), key('c'), key('a'), key('w')],
+            vec![key('c'), key('2'), key('a'), key('w')],
+        ] {
+            match run(&keys) {
+                KeyAction::OperatorTextObject(operator, text_object, count) => {
+                    assert_eq!(operator, Operator::Change);
+                    assert_eq!(text_object.modifier, TextObjectModifier::Around);
+                    assert_eq!(text_object.object_type, TextObjectType::Word);
+                    assert_eq!(count, 2);
+                }
+                other => panic!("expected counted text object action, got {other:?}"),
+            }
         }
     }
 

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -261,8 +261,12 @@ pub fn apply_motion(
         }
 
         Motion::LineEnd => {
-            let line_len = buffer.line_len(line);
-            Some((line, line_len.saturating_sub(1)))
+            let target_line = line.checked_add(count.max(1).saturating_sub(1))?;
+            if target_line > last_addressable_line(buffer) {
+                return None;
+            }
+            let line_len = buffer.line_len(target_line);
+            Some((target_line, line_len.saturating_sub(1)))
         }
 
         Motion::NextLineFirstNonBlank => {

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -71,6 +71,24 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("O", "Open line above", "open line above"),
     vim_oracle("dw", "Delete word with motion", "delete word"),
     vim_oracle("ciw", "Change inner word", "change inner word"),
+    vim_oracle("cc", "Change current line", "change current line"),
+    vim_oracle("C", "Change to end of line", "change to line end"),
+    vim_oracle("yy", "Yank current line", "yank current line"),
+    vim_oracle("Y", "Yank through line end", "yank to line end"),
+    vim_oracle("p", "Paste after cursor", "paste after linewise yank"),
+    vim_oracle("P", "Paste before cursor", "paste before linewise yank"),
+    vim_oracle("de", "Delete through word end", "delete to word end"),
+    vim_oracle(
+        "db",
+        "Delete to previous word start",
+        "delete to previous word start",
+    ),
+    vim_oracle(
+        "d$",
+        "Delete through line end",
+        "delete with line-end motion",
+    ),
+    vim_oracle("caw", "Change around word", "change around word"),
     vim_oracle("u", "Undo latest change", "undo insert"),
     vim_oracle("<C-r>", "Redo latest undone change", "redo insert"),
     KeybindCoverage {
@@ -306,6 +324,36 @@ mod tests {
             ("E", "big word end"),
             ("ge", "previous word end"),
             ("gE", "previous big word end"),
+        ];
+
+        for (key, oracle_case) in expected {
+            let entry = coverage_for(KeybindMode::Normal, key)
+                .unwrap_or_else(|| panic!("missing coverage entry for `{key}`"));
+
+            assert_eq!(entry.kind, CoverageKind::VimOracle);
+            assert_eq!(
+                entry.state,
+                CoverageState::Protected {
+                    test_id: oracle_case,
+                },
+                "`{key}` should be protected by oracle case `{oracle_case}`"
+            );
+        }
+    }
+
+    #[test]
+    fn high_use_editing_operators_are_oracle_covered() {
+        let expected = [
+            ("cc", "change current line"),
+            ("C", "change to line end"),
+            ("yy", "yank current line"),
+            ("Y", "yank to line end"),
+            ("p", "paste after linewise yank"),
+            ("P", "paste before linewise yank"),
+            ("de", "delete to word end"),
+            ("db", "delete to previous word start"),
+            ("d$", "delete with line-end motion"),
+            ("caw", "change around word"),
         ];
 
         for (key, oracle_case) in expected {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7252,15 +7252,15 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             }
         }
 
-        KeyAction::OperatorTextObject(op, text_object) => {
+        KeyAction::OperatorTextObject(op, text_object, count) => {
             let register = editor
                 .input_state
                 .take_register()
                 .or(register_before_action);
             match op {
-                Operator::Delete => editor.delete_text_object(text_object, register),
-                Operator::Change => editor.change_text_object(text_object, register),
-                Operator::Yank => editor.yank_text_object(text_object, register),
+                Operator::Delete => editor.delete_text_object(text_object, count, register),
+                Operator::Change => editor.change_text_object(text_object, count, register),
+                Operator::Yank => editor.yank_text_object(text_object, count, register),
                 Operator::Indent => editor.indent_text_object(text_object),
                 Operator::Dedent => editor.dedent_text_object(text_object),
                 Operator::AutoIndent => editor.auto_indent_text_object(text_object),

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -5,6 +5,10 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+mod editing_cases;
+
+use editing_cases::EDITING_CASES;
+
 #[derive(Debug, Clone, Copy)]
 struct OracleCase {
     name: &'static str,
@@ -487,74 +491,6 @@ const WRAP_ENABLED_CASES: &[OracleCase] = &[OracleCase {
     initial_text: SCREEN_POSITION_TEXT,
     keys: "G<C-f>",
 }];
-
-const EDITING_CASES: &[OracleCase] = &[
-    OracleCase {
-        name: "delete first char on second line",
-        initial_text: "alpha\nbeta\n",
-        keys: "j0x",
-    },
-    OracleCase {
-        name: "append punctuation at line end",
-        initial_text: "alpha\n",
-        keys: "A!<Esc>",
-    },
-    OracleCase {
-        name: "delete current line",
-        initial_text: "alpha\nbeta\n",
-        keys: "dd",
-    },
-    OracleCase {
-        name: "counted char delete",
-        initial_text: "abcdef\n",
-        keys: "4x",
-    },
-    OracleCase {
-        name: "counted line delete",
-        initial_text: "alpha\nbeta\ngamma\n",
-        keys: "2dd",
-    },
-    OracleCase {
-        name: "delete to line end",
-        initial_text: "alpha beta\n",
-        keys: "wD",
-    },
-    OracleCase {
-        name: "insert before cursor",
-        initial_text: "alpha\n",
-        keys: "iX<Esc>",
-    },
-    OracleCase {
-        name: "append after cursor",
-        initial_text: "alpha\n",
-        keys: "aX<Esc>",
-    },
-    OracleCase {
-        name: "open line below",
-        initial_text: "alpha\n",
-        keys: "ochild<Esc>",
-    },
-    OracleCase {
-        name: "open line above",
-        initial_text: "alpha\n",
-        keys: "Oparent<Esc>",
-    },
-    OracleCase {
-        name: "delete word",
-        initial_text: "alpha beta\n",
-        keys: "dw",
-    },
-    OracleCase {
-        name: "delete enter motion",
-        initial_text: "zero\n    one\n  two\nthree\n",
-        keys: "d<CR>",
-    },
-    OracleCase {
-        name: "change inner word",
-        initial_text: "alpha beta\n",
-        keys: "ciwdone<Esc>",
-    },
-];
 
 const UNDO_REDO_CASES: &[OracleCase] = &[
     OracleCase {

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -1,0 +1,276 @@
+use super::OracleCase;
+
+/// Editing cases verify both the resulting text and Vim's final cursor/mode.
+/// Yank behavior is made observable by pasting the captured register contents.
+pub(super) const EDITING_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "delete first char on second line",
+        initial_text: "alpha\nbeta\n",
+        keys: "j0x",
+    },
+    OracleCase {
+        name: "append punctuation at line end",
+        initial_text: "alpha\n",
+        keys: "A!<Esc>",
+    },
+    OracleCase {
+        name: "delete current line",
+        initial_text: "alpha\nbeta\n",
+        keys: "dd",
+    },
+    OracleCase {
+        name: "counted char delete",
+        initial_text: "abcdef\n",
+        keys: "4x",
+    },
+    OracleCase {
+        name: "counted line delete",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2dd",
+    },
+    OracleCase {
+        name: "delete to line end",
+        initial_text: "alpha beta\n",
+        keys: "wD",
+    },
+    OracleCase {
+        name: "insert before cursor",
+        initial_text: "alpha\n",
+        keys: "iX<Esc>",
+    },
+    OracleCase {
+        name: "append after cursor",
+        initial_text: "alpha\n",
+        keys: "aX<Esc>",
+    },
+    OracleCase {
+        name: "open line below",
+        initial_text: "alpha\n",
+        keys: "ochild<Esc>",
+    },
+    OracleCase {
+        name: "open line above",
+        initial_text: "alpha\n",
+        keys: "Oparent<Esc>",
+    },
+    OracleCase {
+        name: "delete word",
+        initial_text: "alpha beta\n",
+        keys: "dw",
+    },
+    OracleCase {
+        name: "delete enter motion",
+        initial_text: "zero\n    one\n  two\nthree\n",
+        keys: "d<CR>",
+    },
+    OracleCase {
+        name: "change inner word",
+        initial_text: "alpha beta\n",
+        keys: "ciwdone<Esc>",
+    },
+    OracleCase {
+        name: "change current line",
+        initial_text: "  alpha beta\nsecond\n",
+        keys: "ccreplacement<Esc>",
+    },
+    OracleCase {
+        name: "change current line register shape",
+        initial_text: "  alpha beta\nsecond\n",
+        keys: "ccreplacement<Esc>p",
+    },
+    OracleCase {
+        name: "counted line change",
+        initial_text: "  alpha beta\nsecond\nthird\n",
+        keys: "2ccreplacement<Esc>",
+    },
+    OracleCase {
+        name: "undo indented line change",
+        initial_text: "  alpha beta\nsecond\n",
+        keys: "ccreplacement<Esc>u",
+    },
+    OracleCase {
+        name: "redo indented line change",
+        initial_text: "  alpha beta\nsecond\n",
+        keys: "ccreplacement<Esc>u<C-r>",
+    },
+    OracleCase {
+        name: "change to line end",
+        initial_text: "alpha beta gamma\n",
+        keys: "wCreplaced<Esc>",
+    },
+    OracleCase {
+        name: "change to line end register shape",
+        initial_text: "alpha beta gamma\n",
+        keys: "wCreplaced<Esc>p",
+    },
+    OracleCase {
+        name: "counted change to line end",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2Creplaced<Esc>",
+    },
+    OracleCase {
+        name: "counted change to line end past eof",
+        initial_text: "alpha\n",
+        keys: "2C",
+    },
+    OracleCase {
+        name: "yank current line",
+        initial_text: "alpha\nbeta\n",
+        keys: "yyp",
+    },
+    OracleCase {
+        name: "yank to line end",
+        initial_text: "alpha\nbeta\n",
+        keys: "YP",
+    },
+    OracleCase {
+        name: "counted yank to line end",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2YP",
+    },
+    OracleCase {
+        name: "counted yank to line end past eof",
+        initial_text: "alpha\n",
+        keys: "x2Yp",
+    },
+    OracleCase {
+        name: "paste after linewise yank",
+        initial_text: "alpha\nbeta\n",
+        keys: "ddp",
+    },
+    OracleCase {
+        name: "paste before linewise yank",
+        initial_text: "alpha\nbeta\n",
+        keys: "ddP",
+    },
+    OracleCase {
+        name: "delete to word end",
+        initial_text: "alpha beta gamma\n",
+        keys: "wde",
+    },
+    OracleCase {
+        name: "delete to word end register shape",
+        initial_text: "alpha beta gamma\n",
+        keys: "wdep",
+    },
+    OracleCase {
+        name: "delete to previous word start",
+        initial_text: "alpha beta gamma\n",
+        keys: "wdb",
+    },
+    OracleCase {
+        name: "delete to previous word start register shape",
+        initial_text: "alpha beta gamma\n",
+        keys: "wdbp",
+    },
+    OracleCase {
+        name: "delete with line-end motion",
+        initial_text: "alpha beta gamma\n",
+        keys: "wd$",
+    },
+    OracleCase {
+        name: "counted delete with line-end motion",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2d$",
+    },
+    OracleCase {
+        name: "counted delete with line-end motion past eof",
+        initial_text: "alpha\n",
+        keys: "2d$",
+    },
+    OracleCase {
+        name: "counted delete line-end register",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2d$p",
+    },
+    OracleCase {
+        name: "change around word",
+        initial_text: "alpha beta gamma\n",
+        keys: "wcawdone<Esc>",
+    },
+    OracleCase {
+        name: "change around word register shape",
+        initial_text: "alpha beta gamma\n",
+        keys: "wcawdone<Esc>p",
+    },
+    OracleCase {
+        name: "counted change around word before operator",
+        initial_text: "alpha beta gamma delta\n",
+        keys: "w2cawdone<Esc>",
+    },
+    OracleCase {
+        name: "counted change around word after operator",
+        initial_text: "alpha beta gamma delta\n",
+        keys: "wc2awdone<Esc>",
+    },
+    OracleCase {
+        name: "counted line yank",
+        initial_text: "alpha\nbeta\ngamma\ndelta\n",
+        keys: "3yyp",
+    },
+    OracleCase {
+        name: "counted linewise paste",
+        initial_text: "alpha\nbeta\n",
+        keys: "dd2p",
+    },
+    OracleCase {
+        name: "undo counted linewise paste",
+        initial_text: "alpha\nbeta\n",
+        keys: "dd2pu",
+    },
+    OracleCase {
+        name: "redo counted linewise paste",
+        initial_text: "alpha\nbeta\n",
+        keys: "dd2pu<C-r>",
+    },
+    OracleCase {
+        name: "undo counted linewise paste before",
+        initial_text: "alpha\nbeta\n",
+        keys: "dd2Pu",
+    },
+    OracleCase {
+        name: "counted multiline linewise paste",
+        initial_text: "alpha\nbeta\ngamma\ndelta\n",
+        keys: "3yy2p",
+    },
+    OracleCase {
+        name: "counted empty linewise paste",
+        initial_text: "\nalpha\n",
+        keys: "yy2p",
+    },
+    OracleCase {
+        name: "counted characterwise paste",
+        initial_text: "abcd\n",
+        keys: "x2p",
+    },
+    OracleCase {
+        name: "undo counted characterwise paste",
+        initial_text: "abcd\n",
+        keys: "x2pu",
+    },
+    OracleCase {
+        name: "redo counted characterwise paste",
+        initial_text: "abcd\n",
+        keys: "x2pu<C-r>",
+    },
+    OracleCase {
+        name: "counted characterwise paste before",
+        initial_text: "abcd\n",
+        keys: "x2P",
+    },
+    OracleCase {
+        name: "counted characterwise paste after and move",
+        initial_text: "abcd\n",
+        keys: "x2gp",
+    },
+    OracleCase {
+        name: "multiline characterwise paste after and move",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "2Ygp",
+    },
+    OracleCase {
+        name: "counted characterwise paste before and move",
+        initial_text: "abcd\n",
+        keys: "x2gP",
+    },
+];


### PR DESCRIPTION
## Summary
- align `cc`, `Y`, counted `d$`, counted text objects, and paste cursor behavior with Neovim
- make counted paste operations atomic for undo and preserve linewise/characterwise register shape
- expand the Vim oracle inventory and move editing cases into a focused module
- add focused operator regression tests and update keybinding documentation

## Verification
- `cargo test --quiet` (703 library tests passed, 3 ignored; 26 binary tests passed)
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo fmt --check`
- `git diff --check`
- manually verified `cc`, `Y`, counted `p`, counted `caw`, and counted `d$`