### PR TITLE
fix: preserve linewise edits in new files

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -30,6 +30,27 @@ use unicode_width::UnicodeWidthChar;
 
 const MAX_VISIBLE_SEARCH_MATCHES: usize = 2048;
 
+fn comparable_file_path(path: &std::path::Path) -> std::path::PathBuf {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(path))
+            .unwrap_or_else(|_| path.to_path_buf())
+    };
+
+    absolute.canonicalize().unwrap_or_else(|_| {
+        let Some(file_name) = absolute.file_name() else {
+            return absolute.clone();
+        };
+        absolute
+            .parent()
+            .and_then(|parent| parent.canonicalize().ok())
+            .map(|parent| parent.join(file_name))
+            .unwrap_or(absolute)
+    })
+}
+
 /// The current mode of the editor
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum Mode {
@@ -3396,12 +3417,13 @@ impl Editor {
         read_only: bool,
     ) -> anyhow::Result<()> {
         // Check if file is already open in an existing buffer
-        let canonical_path = path.canonicalize().ok();
-        if let Some(existing_idx) = self
-            .buffers
-            .iter()
-            .position(|b| b.path.as_ref().and_then(|p| p.canonicalize().ok()) == canonical_path)
-        {
+        let comparable_path = comparable_file_path(&path);
+        if let Some(existing_idx) = self.buffers.iter().position(|buffer| {
+            buffer
+                .path
+                .as_deref()
+                .is_some_and(|buffer_path| comparable_file_path(buffer_path) == comparable_path)
+        }) {
             // File already open, switch to that buffer
             if existing_idx != self.current_buffer_idx {
                 self.remember_current_file_as_alternate();
@@ -4534,10 +4556,18 @@ impl Editor {
             RegisterContent::Lines(text) => {
                 // Paste on new line below
                 let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
+                let line_has_terminator = self.buffers[self.current_buffer_idx]
+                    .line_len_including_newline(self.cursor.line)
+                    > line_len;
+                let trimmed = text.strip_suffix('\n').unwrap_or(&text);
+                let inserted_block = if line_has_terminator {
+                    trimmed.to_string()
+                } else {
+                    format!("{trimmed}\n")
+                };
 
                 // Record the insertion for undo
-                let trimmed = text.strip_suffix('\n').unwrap_or(&text);
-                let insert_text = format!("\n{}", trimmed);
+                let insert_text = format!("\n{inserted_block}");
                 self.undo_stack.record_change(Change::insert(
                     self.cursor.line,
                     line_len,
@@ -4550,8 +4580,13 @@ impl Editor {
                 let first_inserted_line = self.cursor.line;
                 let inserted_line_count = Self::linewise_paste_line_count(trimmed);
 
-                // Insert the lines (without trailing newline if present)
-                self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, trimmed);
+                // The existing line terminator separates a following line. At EOF,
+                // the inserted block supplies its own terminator instead.
+                self.buffers[self.current_buffer_idx].insert_str(
+                    self.cursor.line,
+                    0,
+                    &inserted_block,
+                );
                 if cursor_after {
                     self.cursor.line = (first_inserted_line + inserted_line_count).min(
                         self.buffers[self.current_buffer_idx]
@@ -11150,6 +11185,7 @@ fn project_replace_display_path(root: &std::path::Path, path: &std::path::Path) 
 #[cfg(test)]
 mod tests {
     mod editing_operators;
+    mod file_lifecycle;
     mod screen_position;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};

--- a/src/editor/register.rs
+++ b/src/editor/register.rs
@@ -33,6 +33,30 @@ impl RegisterContent {
     }
 }
 
+fn clipboard_text_for_content(content: &RegisterContent) -> String {
+    match content {
+        RegisterContent::Chars(text) => text.clone(),
+        RegisterContent::Lines(text) if text.ends_with('\n') => text.clone(),
+        RegisterContent::Lines(text) => format!("{text}\n"),
+    }
+}
+
+fn register_content_from_clipboard_text(text: String) -> Option<RegisterContent> {
+    if text.is_empty() {
+        None
+    } else if text.ends_with('\n') {
+        Some(RegisterContent::Lines(text))
+    } else {
+        Some(RegisterContent::Chars(text))
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Default)]
+struct InMemoryClipboard {
+    text: Option<String>,
+}
+
 /// Vim-style register system
 #[derive(Debug, Clone, Default)]
 pub struct Registers {
@@ -46,11 +70,18 @@ pub struct Registers {
     numbered: [Option<RegisterContent>; 9],
     /// Last clipboard error (for display to user)
     clipboard_error: Option<String>,
+    #[cfg(test)]
+    in_memory_clipboard: Option<InMemoryClipboard>,
 }
 
 impl Registers {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn use_in_memory_clipboard_for_tests(&mut self) {
+        self.in_memory_clipboard = Some(InMemoryClipboard::default());
     }
 
     /// Get the content of a register
@@ -84,25 +115,26 @@ impl Registers {
 
     /// Get content from the system clipboard
     pub fn get_clipboard(&mut self) -> Option<RegisterContent> {
+        #[cfg(test)]
+        if let Some(clipboard) = &self.in_memory_clipboard {
+            self.clipboard_error = None;
+            return clipboard
+                .text
+                .clone()
+                .and_then(register_content_from_clipboard_text);
+        }
+
         match Clipboard::new() {
-            Ok(mut clipboard) => {
-                match clipboard.get_text() {
-                    Ok(text) if !text.is_empty() => {
-                        self.clipboard_error = None;
-                        // Determine if it's line-wise (ends with newline)
-                        if text.ends_with('\n') {
-                            Some(RegisterContent::Lines(text))
-                        } else {
-                            Some(RegisterContent::Chars(text))
-                        }
-                    }
-                    Ok(_) => None, // Empty clipboard
-                    Err(e) => {
-                        self.clipboard_error = Some(format!("Clipboard read failed: {}", e));
-                        None
-                    }
+            Ok(mut clipboard) => match clipboard.get_text() {
+                Ok(text) => {
+                    self.clipboard_error = None;
+                    register_content_from_clipboard_text(text)
                 }
-            }
+                Err(e) => {
+                    self.clipboard_error = Some(format!("Clipboard read failed: {}", e));
+                    None
+                }
+            },
             Err(e) => {
                 self.clipboard_error = Some(format!("Clipboard unavailable: {}", e));
                 None
@@ -112,9 +144,17 @@ impl Registers {
 
     /// Set content to the system clipboard
     pub fn set_clipboard(&mut self, content: &RegisterContent) {
+        let text = clipboard_text_for_content(content);
+        #[cfg(test)]
+        if let Some(clipboard) = &mut self.in_memory_clipboard {
+            clipboard.text = Some(text);
+            self.clipboard_error = None;
+            return;
+        }
+
         match Clipboard::new() {
             Ok(mut clipboard) => {
-                if let Err(e) = clipboard.set_text(content.as_str().to_string()) {
+                if let Err(e) = clipboard.set_text(text) {
                     self.clipboard_error = Some(format!("Clipboard write failed: {}", e));
                 } else {
                     self.clipboard_error = None;
@@ -258,5 +298,41 @@ impl Registers {
         } else {
             self.get(name).cloned()
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        RegisterContent, clipboard_text_for_content, register_content_from_clipboard_text,
+    };
+
+    #[test]
+    fn linewise_clipboard_round_trip_preserves_shape_without_final_newline() {
+        let serialized = clipboard_text_for_content(&RegisterContent::Lines("abc".to_string()));
+
+        assert_eq!(serialized, "abc\n");
+        assert_eq!(
+            register_content_from_clipboard_text(serialized),
+            Some(RegisterContent::Lines("abc\n".to_string()))
+        );
+    }
+
+    #[test]
+    fn characterwise_clipboard_round_trip_does_not_add_a_newline() {
+        let serialized = clipboard_text_for_content(&RegisterContent::Chars("abc".to_string()));
+
+        assert_eq!(serialized, "abc");
+        assert_eq!(
+            register_content_from_clipboard_text(serialized),
+            Some(RegisterContent::Chars("abc".to_string()))
+        );
+    }
+
+    #[test]
+    fn linewise_clipboard_text_does_not_duplicate_an_existing_newline() {
+        let serialized = clipboard_text_for_content(&RegisterContent::Lines("abc\n".to_string()));
+
+        assert_eq!(serialized, "abc\n");
     }
 }

--- a/src/editor/tests/editing_operators.rs
+++ b/src/editor/tests/editing_operators.rs
@@ -155,6 +155,32 @@ fn linewise_paste_lands_on_first_nonblank_of_inserted_line() {
 }
 
 #[test]
+fn linewise_paste_after_unterminated_last_line_restores_final_newline() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc");
+    editor.yank_line(1, Some('a'));
+
+    editor.paste_after(Some('a'));
+    editor.paste_after(Some('a'));
+
+    assert_eq!(editor.buffer().content(), "abc\nabc\nabc\n");
+}
+
+#[test]
+fn linewise_paste_after_unterminated_last_line_remains_undoable() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc");
+    editor.yank_line(1, Some('a'));
+    editor.paste_after(Some('a'));
+
+    editor.undo();
+    assert_eq!(editor.buffer().content(), "abc");
+
+    editor.redo();
+    assert_eq!(editor.buffer().content(), "abc\nabc\n");
+}
+
+#[test]
 fn counted_delete_to_line_end_from_column_zero_is_linewise() {
     let mut editor = Editor::default();
     editor.replace_buffer_content("alpha\nbeta\ngamma\n");

--- a/src/editor/tests/file_lifecycle.rs
+++ b/src/editor/tests/file_lifecycle.rs
@@ -1,0 +1,126 @@
+use crate::editor::Editor;
+use crate::terminal::handle_key;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn unique_temp_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}_{}_{}", std::process::id(), nanos))
+}
+
+#[test]
+fn opening_nonexistent_path_attaches_it_to_the_unnamed_buffer() {
+    let temp_dir = unique_temp_dir("nevi_new_file_path");
+    std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let path = temp_dir.join("new.txt");
+    assert!(!path.exists(), "fixture path must not exist yet");
+
+    let mut editor = Editor::default();
+    editor.open_file(path.clone()).expect("open new file path");
+
+    assert_eq!(editor.buffer().path.as_ref(), Some(&path));
+    assert!(editor.buffer().is_file_backed());
+    assert_eq!(editor.buffer_count(), 1, "initial unnamed buffer is reused");
+
+    std::fs::remove_dir_all(temp_dir).expect("remove temp directory");
+}
+
+#[test]
+fn reported_new_file_yypp_zz_workflow_saves_three_terminated_lines() {
+    let temp_dir = unique_temp_dir("nevi_issue_238_workflow");
+    std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let path = temp_dir.join("new.txt");
+
+    let mut editor = Editor::default();
+    editor.registers.use_in_memory_clipboard_for_tests();
+    editor.open_file(path.clone()).expect("open new file path");
+
+    for key in [
+        KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('a'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('b'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('c'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('p'), KeyModifiers::NONE),
+        KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::SHIFT),
+        KeyEvent::new(KeyCode::Char('Z'), KeyModifiers::SHIFT),
+    ] {
+        handle_key(&mut editor, key);
+    }
+
+    assert!(editor.should_quit, "ZZ should save and request quit");
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read saved file"),
+        "abc\nabc\nabc\n"
+    );
+
+    std::fs::remove_dir_all(temp_dir).expect("remove temp directory");
+}
+
+#[test]
+fn newly_opened_path_saves_without_an_explicit_save_as() {
+    let temp_dir = unique_temp_dir("nevi_new_file_save");
+    std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let path = temp_dir.join("new.txt");
+
+    let mut editor = Editor::default();
+    editor.open_file(path.clone()).expect("open new file path");
+    editor.enter_insert_mode();
+    for ch in "abc".chars() {
+        editor.insert_char(ch);
+    }
+    editor.enter_normal_mode();
+
+    editor.save().expect("save to original path");
+
+    assert_eq!(
+        std::fs::read_to_string(&path).expect("read saved file"),
+        "abc"
+    );
+
+    std::fs::remove_dir_all(temp_dir).expect("remove temp directory");
+}
+
+#[test]
+fn reopening_same_nonexistent_path_reuses_its_buffer() {
+    let temp_dir = unique_temp_dir("nevi_new_file_reopen");
+    std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let path = temp_dir.join("new.txt");
+
+    let mut editor = Editor::default();
+    editor.open_file(path.clone()).expect("open new file path");
+    editor
+        .open_file(path.clone())
+        .expect("reopen same new file path");
+
+    assert_eq!(editor.buffer_count(), 1);
+    assert_eq!(editor.buffer().path.as_ref(), Some(&path));
+
+    std::fs::remove_dir_all(temp_dir).expect("remove temp directory");
+}
+
+#[test]
+fn distinct_nonexistent_paths_open_in_distinct_buffers() {
+    let temp_dir = unique_temp_dir("nevi_new_file_distinct");
+    std::fs::create_dir_all(&temp_dir).expect("create temp directory");
+    let first = temp_dir.join("first.txt");
+    let second = temp_dir.join("second.txt");
+
+    let mut editor = Editor::default();
+    editor.open_file(first).expect("open first new file path");
+    editor
+        .open_file(second.clone())
+        .expect("open second new file path");
+
+    assert_eq!(editor.buffer_count(), 2);
+    assert_eq!(editor.buffer().path.as_ref(), Some(&second));
+
+    std::fs::remove_dir_all(temp_dir).expect("remove temp directory");
+}

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -119,6 +119,11 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         keys: "yyp",
     },
     OracleCase {
+        name: "linewise yank without final newline",
+        initial_text: "abc",
+        keys: "yypp",
+    },
+    OracleCase {
         name: "yank to line end",
         initial_text: "alpha\nbeta\n",
         keys: "YP",


### PR DESCRIPTION
## Summary
- retain nonexistent file paths instead of matching them to the unnamed buffer through failed canonicalization
- preserve linewise register shape through system clipboard serialization
- restore the final newline when linewise text is pasted below an unterminated last line
- add deterministic file-lifecycle, clipboard, undo/redo, and real-Neovim oracle regressions for the reported workflow

## Verification
- `cargo test --quiet` (713 library tests passed, 3 ignored; 26 binary tests passed)
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo fmt --check`
- `git diff --check`
- manually verified `iabc<Esc>yyppZZ` saves `abc\nabc\nabc\n` to a newly created path
- independent Rust review: no findings

Closes #238