### PR TITLE
fix: match Vim counted open-line behavior

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -453,8 +453,8 @@ Record and replay sequences of commands.
 | `a` | Insert after cursor |
 | `I` | Insert at first non-blank of line |
 | `A` | Insert at end of line |
-| `o` | Open new line below |
-| `O` | Open new line above |
+| `o` / `{n}o` | Open line(s) below; a count repeats the entered line |
+| `O` / `{n}O` | Open line(s) above; a count repeats the entered line |
 | `gi` | Go to last insert position and enter insert mode |
 
 **While in Insert Mode:**

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1085,8 +1085,10 @@ pub struct Editor {
     pub last_inserted_text: Option<String>,
     /// Text inserted during the active insert session.
     current_inserted_text: String,
-    /// Number of times the active `I`/`A` insertion is repeated on exit.
+    /// Number of times the active counted insertion is repeated on exit.
     insert_session_repeat_count: usize,
+    /// Inherited indentation when the active session was started by `o` or `O`.
+    insert_session_open_line_indent: Option<String>,
     /// Insert mode is waiting for a register name after `<C-r>`.
     pub pending_insert_register: bool,
     /// Expression register input is active after `"=` or `<C-r>=`.
@@ -1580,6 +1582,7 @@ impl Editor {
             last_inserted_text: None,
             current_inserted_text: String::new(),
             insert_session_repeat_count: 1,
+            insert_session_open_line_indent: None,
             pending_insert_register: false,
             pending_expression_register: None,
             expression_register_input: String::new(),
@@ -4929,13 +4932,25 @@ impl Editor {
     fn begin_insert_session(&mut self) {
         self.current_inserted_text.clear();
         self.insert_session_repeat_count = 1;
+        self.insert_session_open_line_indent = None;
     }
 
     fn finish_insert_session(&mut self) {
         let repeat_count = std::mem::replace(&mut self.insert_session_repeat_count, 1);
         if repeat_count > 1 && !self.current_inserted_text.is_empty() {
-            let repeated = self.current_inserted_text.repeat(repeat_count - 1);
+            let repeated = if let Some(indent) = self.insert_session_open_line_indent.take() {
+                let structural_len = indent.len() + 1;
+                let typed_text = self
+                    .current_inserted_text
+                    .get(structural_len..)
+                    .unwrap_or_default();
+                format!("\n{indent}{typed_text}").repeat(repeat_count - 1)
+            } else {
+                self.current_inserted_text.repeat(repeat_count - 1)
+            };
             self.insert_text_at_cursor(&repeated);
+        } else {
+            self.insert_session_open_line_indent = None;
         }
 
         if !self.current_inserted_text.is_empty() {
@@ -5759,6 +5774,7 @@ impl Editor {
 
     /// Open a new line below and enter insert mode
     pub fn open_line_below(&mut self) {
+        let redo_cursor = (self.cursor.line, self.cursor.col);
         let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
 
         // Calculate indent for new line
@@ -5780,6 +5796,8 @@ impl Editor {
         // Start undo group and record the insertion
         let insert_text = format!("\n{}", indent);
         self.begin_change();
+        self.undo_stack
+            .prefer_current_cursor_after(redo_cursor.0, redo_cursor.1);
         self.undo_stack.record_change(Change::insert(
             self.cursor.line,
             line_len,
@@ -5792,12 +5810,22 @@ impl Editor {
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
         self.begin_insert_session();
+        self.insert_session_open_line_indent = Some(indent);
         self.record_inserted_text(&insert_text);
         self.scroll_to_cursor();
     }
 
+    /// Open a line below and repeat the completed insertion `count` times.
+    pub fn open_line_below_counted(&mut self, count: usize) {
+        self.open_line_below();
+        if self.mode == Mode::Insert {
+            self.insert_session_repeat_count = count.max(1);
+        }
+    }
+
     /// Open a new line above and enter insert mode
     pub fn open_line_above(&mut self) {
+        let redo_cursor = (self.cursor.line, self.cursor.col);
         // Calculate indent for new line (match current line's indent)
         let indent = if self.settings.editor.auto_indent {
             let buffer = &self.buffers[self.current_buffer_idx];
@@ -5810,6 +5838,8 @@ impl Editor {
         let insert_text = format!("{}\n", indent);
         self.begin_change();
         self.undo_stack
+            .prefer_current_cursor_after(redo_cursor.0, redo_cursor.1);
+        self.undo_stack
             .record_change(Change::insert(self.cursor.line, 0, insert_text.clone()));
 
         self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, 0, &insert_text);
@@ -5818,8 +5848,17 @@ impl Editor {
         self.last_insert_position = Some((self.cursor.line, self.cursor.col));
         self.mode = Mode::Insert;
         self.begin_insert_session();
+        self.insert_session_open_line_indent = Some(indent);
         self.record_inserted_text(&insert_text);
         self.scroll_to_cursor();
+    }
+
+    /// Open a line above and repeat the completed insertion `count` times.
+    pub fn open_line_above_counted(&mut self, count: usize) {
+        self.open_line_above();
+        if self.mode == Mode::Insert {
+            self.insert_session_repeat_count = count.max(1);
+        }
     }
 
     /// Save the current buffer
@@ -11219,6 +11258,7 @@ mod tests {
     mod editing_operators;
     mod file_lifecycle;
     mod insert_entry;
+    mod open_line;
     mod screen_position;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};

--- a/src/editor/tests/open_line.rs
+++ b/src/editor/tests/open_line.rs
@@ -1,0 +1,101 @@
+use crate::editor::Editor;
+use crate::terminal::handle_key;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+fn char_key(ch: char) -> KeyEvent {
+    let modifiers = if ch.is_ascii_uppercase() {
+        KeyModifiers::SHIFT
+    } else {
+        KeyModifiers::NONE
+    };
+    KeyEvent::new(KeyCode::Char(ch), modifiers)
+}
+
+fn type_chars(editor: &mut Editor, chars: &str) {
+    for ch in chars.chars() {
+        handle_key(editor, char_key(ch));
+    }
+}
+
+fn escape(editor: &mut Editor) {
+    handle_key(editor, KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+}
+
+#[test]
+fn counted_o_repeats_indented_line_as_one_change() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("    alpha\nomega\n");
+
+    type_chars(&mut editor, "3obelow");
+    escape(&mut editor);
+
+    assert_eq!(
+        editor.buffer().content(),
+        "    alpha\n    below\n    below\n    below\nomega\n"
+    );
+    assert_eq!((editor.cursor.line, editor.cursor.col), (3, 8));
+
+    editor.undo();
+    assert_eq!(editor.buffer().content(), "    alpha\nomega\n");
+}
+
+#[test]
+fn counted_uppercase_o_repeats_indented_line_as_one_change() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\n    omega\n");
+
+    type_chars(&mut editor, "j3Oabove");
+    escape(&mut editor);
+
+    assert_eq!(
+        editor.buffer().content(),
+        "alpha\n    above\n    above\n    above\n    omega\n"
+    );
+    assert_eq!((editor.cursor.line, editor.cursor.col), (3, 8));
+
+    editor.undo();
+    assert_eq!(editor.buffer().content(), "alpha\n    omega\n");
+}
+
+#[test]
+fn counted_o_without_text_opens_requested_blank_lines() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nomega\n");
+
+    type_chars(&mut editor, "3o");
+    escape(&mut editor);
+
+    assert_eq!(editor.buffer().content(), "alpha\n\n\n\nomega\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+}
+
+#[test]
+fn open_line_redo_uses_the_original_command_coordinate() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nomega\n");
+
+    type_chars(&mut editor, "$obelow");
+    escape(&mut editor);
+    editor.undo();
+    editor.redo();
+
+    assert_eq!(editor.buffer().content(), "alpha\nbelow\nomega\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 4));
+}
+
+#[test]
+fn counted_uppercase_o_redo_restores_all_lines_and_original_coordinate() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("alpha\nomega\n");
+
+    type_chars(&mut editor, "j3Oabove");
+    escape(&mut editor);
+    editor.undo();
+    editor.redo();
+
+    assert_eq!(
+        editor.buffer().content(),
+        "alpha\nabove\nabove\nabove\nomega\n"
+    );
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1023,7 +1023,7 @@ vim_default = true
 [[normal.mode]]
 key = "o"
 action = "open_below"
-desc = "Open new line below and enter insert"
+desc = "Open line(s) below and enter insert (count repeats)"
 status = "implemented"
 vim_default = true
 locked = true
@@ -1031,7 +1031,7 @@ locked = true
 [[normal.mode]]
 key = "O"
 action = "open_above"
-desc = "Open new line above and enter insert"
+desc = "Open line(s) above and enter insert (count repeats)"
 status = "implemented"
 vim_default = true
 locked = true

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2316,6 +2316,8 @@ mod tests {
         assert_insert(&[shift('A')], InsertPosition::LineEnd, 1);
         assert_insert(&[key('o')], InsertPosition::NewLineBelow, 1);
         assert_insert(&[shift('O')], InsertPosition::NewLineAbove, 1);
+        assert_insert(&[key('3'), key('o')], InsertPosition::NewLineBelow, 3);
+        assert_insert(&[key('3'), shift('O')], InsertPosition::NewLineAbove, 3);
         assert_insert(&[key('3'), shift('I')], InsertPosition::LineStart, 3);
         assert_insert(&[key('3'), shift('A')], InsertPosition::LineEnd, 3);
         match run(&[shift('R')]) {

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7340,8 +7340,8 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
                 InsertPosition::AfterCursor => editor.enter_insert_mode_append(),
                 InsertPosition::LineStart => editor.enter_insert_mode_start_counted(count),
                 InsertPosition::LineEnd => editor.enter_insert_mode_end_counted(count),
-                InsertPosition::NewLineBelow => editor.open_line_below(),
-                InsertPosition::NewLineAbove => editor.open_line_above(),
+                InsertPosition::NewLineBelow => editor.open_line_below_counted(count),
+                InsertPosition::NewLineAbove => editor.open_line_above_counted(count),
             }
             let action_elapsed = t_action.elapsed();
             let total = t_start.elapsed();

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -7,9 +7,11 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 mod editing_cases;
 mod insert_entry_cases;
+mod open_line_cases;
 
 use editing_cases::EDITING_CASES;
 use insert_entry_cases::INSERT_ENTRY_CASES;
+use open_line_cases::OPEN_LINE_CASES;
 
 #[derive(Debug, Clone, Copy)]
 struct OracleCase {
@@ -519,6 +521,10 @@ const ORACLE_CATEGORIES: &[OracleCategory] = &[
     OracleCategory {
         name: "insert-entry",
         cases: INSERT_ENTRY_CASES,
+    },
+    OracleCategory {
+        name: "open-line",
+        cases: OPEN_LINE_CASES,
     },
     OracleCategory {
         name: "undo-redo",

--- a/src/vim_oracle/open_line_cases.rs
+++ b/src/vim_oracle/open_line_cases.rs
@@ -1,0 +1,96 @@
+use super::OracleCase;
+
+/// Open-line cases protect Vim's indentation, count, cursor, and undo semantics
+/// for the normal-mode `o` and `O` commands.
+pub(super) const OPEN_LINE_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "open below inherits indentation",
+        initial_text: "    alpha\n",
+        keys: "ochild<Esc>",
+    },
+    OracleCase {
+        name: "open above inherits indentation",
+        initial_text: "    alpha\n",
+        keys: "Oparent<Esc>",
+    },
+    OracleCase {
+        name: "open below from empty line",
+        initial_text: "\n",
+        keys: "obelow<Esc>",
+    },
+    OracleCase {
+        name: "open above from empty line",
+        initial_text: "\n",
+        keys: "Oabove<Esc>",
+    },
+    OracleCase {
+        name: "open below without final newline",
+        initial_text: "alpha",
+        keys: "obelow<Esc>",
+    },
+    OracleCase {
+        name: "open above without final newline",
+        initial_text: "alpha",
+        keys: "Oabove<Esc>",
+    },
+    OracleCase {
+        name: "counted open below",
+        initial_text: "alpha\nomega\n",
+        keys: "3obelow<Esc>",
+    },
+    OracleCase {
+        name: "counted open above",
+        initial_text: "alpha\nomega\n",
+        keys: "j3Oabove<Esc>",
+    },
+    OracleCase {
+        name: "counted open below inherits indentation",
+        initial_text: "    alpha\nomega\n",
+        keys: "3obelow<Esc>",
+    },
+    OracleCase {
+        name: "counted open above inherits indentation",
+        initial_text: "alpha\n    omega\n",
+        keys: "j3Oabove<Esc>",
+    },
+    OracleCase {
+        name: "counted open below without text",
+        initial_text: "alpha\nomega\n",
+        keys: "3o<Esc>",
+    },
+    OracleCase {
+        name: "counted open above without text",
+        initial_text: "alpha\nomega\n",
+        keys: "j3O<Esc>",
+    },
+    OracleCase {
+        name: "undo counted open below",
+        initial_text: "alpha\nomega\n",
+        keys: "3obelow<Esc>u",
+    },
+    OracleCase {
+        name: "redo counted open below",
+        initial_text: "alpha\nomega\n",
+        keys: "3obelow<Esc>u<C-r>",
+    },
+    OracleCase {
+        name: "undo counted open above",
+        initial_text: "alpha\nomega\n",
+        keys: "j3Oabove<Esc>u",
+    },
+    OracleCase {
+        name: "redo counted open above",
+        initial_text: "alpha\nomega\n",
+        keys: "j3Oabove<Esc>u<C-r>",
+    },
+    OracleCase {
+        name: "redo open below from line end",
+        initial_text: "alpha\nomega\n",
+        keys: "$obelow<Esc>u<C-r>",
+    },
+    OracleCase {
+        name: "redo open above from line end",
+        initial_text: "alpha\nomega\n",
+        keys: "j$Oabove<Esc>u<C-r>",
+    },
+];


### PR DESCRIPTION
## Summary

- match Vim/Neovim counted `o` and `O` behavior, including inherited indentation and blank lines
- keep counted open-line edits in one undoable change and restore Vim-compatible redo cursor placement
- add dedicated real-Neovim oracle cases and focused Nevi regressions
- document counted `o`/`O` behavior in `KEYBINDINGS.md` and `:Keymaps` metadata

## Verification

- `cargo fmt --all -- --check`
- `cargo test --quiet`
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo test render_frame_budget -- --ignored --nocapture`
- `cargo build --release --quiet`
- manual verification of counted `o`/`O`, indentation, one-step undo, and redo cursor placement
