### PR TITLE
fix: match Vim replace behavior

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -161,6 +161,7 @@ When specifying keys, use these formats:
 - [Marks](#marks)
 - [Macros](#macros)
 - [Insert Mode](#insert-mode)
+- [Replace Mode](#replace-mode)
 - [Visual Mode](#visual-mode)
 - [Text Objects](#text-objects)
 - [Registers](#registers)
@@ -326,7 +327,8 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `P` / `{n}P` | Paste before cursor |
 | `gp` / `{n}gp` | Paste after and leave cursor after pasted text |
 | `gP` / `{n}gP` | Paste before and leave cursor after pasted text |
-| `r{char}` / `{n}r{char}` | Replace character(s) under cursor |
+| `r{char}` / `{n}r{char}` | Replace exactly one/count characters; `Enter` replaces them with one newline |
+| `R` / `{n}R` | Enter replace mode; a count repeats the entered replacement text |
 | `.` | Repeat last change |
 
 > **Examples:**
@@ -478,6 +480,22 @@ Record and replay sequences of commands.
 | `Ctrl+l` | Accept visible Copilot suggestion |
 | `Alt+]` | Next visible Copilot suggestion |
 | `Alt+[` | Previous visible Copilot suggestion |
+
+---
+
+## Replace Mode
+
+Enter replace mode with `R`. Printable characters overwrite existing text and
+extend the line when the cursor reaches its end. `Enter` inserts a newline and
+keeps replace mode active. During straight-line input, `Backspace` restores
+text overwritten in the current session and a count repeats the entered text.
+Moving the cursor cancels that restoration and counted replay history.
+
+| Key | Action |
+|-----|--------|
+| `Esc` or `Ctrl+[` | Exit replace mode |
+| `Backspace` | Restore the previous straight-line replacement, or navigate backward after cursor movement |
+| `Enter` | Insert a newline and continue replacing |
 
 ---
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3,6 +3,7 @@ mod cursor;
 mod macros;
 mod marks;
 mod register;
+mod replace;
 mod undo;
 
 pub use buffer::Buffer;
@@ -11,6 +12,8 @@ pub use macros::MacroState;
 pub use marks::{Mark, Marks};
 pub use register::{RegisterContent, Registers};
 pub use undo::{Change, UndoEntry, UndoStack};
+
+use replace::ReplaceSession;
 
 use crate::commands::CommandLine;
 use crate::config::{KeymapLookup, LeaderAction, LeaderHint, Settings};
@@ -1089,6 +1092,8 @@ pub struct Editor {
     insert_session_repeat_count: usize,
     /// Inherited indentation when the active session was started by `o` or `O`.
     insert_session_open_line_indent: Option<String>,
+    /// State needed to reproduce Vim's interactive `R` replace semantics.
+    replace_session: ReplaceSession,
     /// Insert mode is waiting for a register name after `<C-r>`.
     pub pending_insert_register: bool,
     /// Expression register input is active after `"=` or `<C-r>=`.
@@ -1583,6 +1588,7 @@ impl Editor {
             current_inserted_text: String::new(),
             insert_session_repeat_count: 1,
             insert_session_open_line_indent: None,
+            replace_session: ReplaceSession::default(),
             pending_insert_register: false,
             pending_expression_register: None,
             expression_register_input: String::new(),
@@ -5104,47 +5110,6 @@ impl Editor {
         true
     }
 
-    /// Enter replace mode
-    pub fn enter_replace_mode(&mut self) {
-        self.begin_change();
-        self.mode = Mode::Replace;
-    }
-
-    /// Replace character at cursor position (for replace mode)
-    pub fn replace_mode_char(&mut self, ch: char) {
-        let buffer = &self.buffers[self.current_buffer_idx];
-        let line_len = buffer.line_len(self.cursor.line);
-
-        if ch == '\n' {
-            // Newline exits replace mode and goes to next line
-            self.enter_normal_mode();
-            return;
-        }
-
-        if self.cursor.col < line_len {
-            // Replace existing character
-            if let Some(old_char) = buffer.char_at(self.cursor.line, self.cursor.col) {
-                self.undo_stack.record_change(Change::delete(
-                    self.cursor.line,
-                    self.cursor.col,
-                    old_char.to_string(),
-                ));
-            }
-            self.buffers[self.current_buffer_idx].delete_char(self.cursor.line, self.cursor.col);
-        }
-
-        // Insert the new character
-        self.undo_stack.record_change(Change::insert(
-            self.cursor.line,
-            self.cursor.col,
-            ch.to_string(),
-        ));
-        self.buffers[self.current_buffer_idx].insert_char(self.cursor.line, self.cursor.col, ch);
-        self.cursor.col += 1;
-
-        self.scroll_to_cursor();
-    }
-
     /// Enter rename prompt mode with the word under cursor
     pub fn enter_rename_prompt(&mut self) {
         let word = self.get_word_under_cursor().unwrap_or_default();
@@ -5194,6 +5159,8 @@ impl Editor {
         if self.mode == Mode::Insert {
             self.replay_pending_visual_block_edit();
             self.finish_insert_session();
+        } else if self.mode == Mode::Replace {
+            self.finish_replace_session();
         }
 
         // End any current undo group
@@ -8575,51 +8542,6 @@ impl Editor {
     // New Commands (r, J, zz/zt/zb, .)
     // ============================================
 
-    /// Replace character at cursor with given character (r command)
-    pub fn replace_char(&mut self, ch: char) {
-        self.replace_chars(ch, 1);
-    }
-
-    /// Replace count characters at cursor with the given character (r with count)
-    pub fn replace_chars(&mut self, ch: char, count: usize) {
-        let count = count.max(1);
-        let line_len = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
-        if line_len == 0 || self.cursor.col >= line_len {
-            return;
-        }
-
-        let start_col = self.cursor.col;
-        let end_col = (start_col + count - 1).min(line_len.saturating_sub(1));
-        let old_text = self.get_range_text(self.cursor.line, start_col, self.cursor.line, end_col);
-        if old_text.is_empty() {
-            return;
-        }
-        let replacement: String = std::iter::repeat(ch)
-            .take(old_text.chars().count())
-            .collect();
-
-        self.begin_change();
-        self.undo_stack
-            .record_change(Change::delete(self.cursor.line, start_col, old_text));
-        self.undo_stack.record_change(Change::insert(
-            self.cursor.line,
-            start_col,
-            replacement.clone(),
-        ));
-
-        self.buffers[self.current_buffer_idx].delete_range(
-            self.cursor.line,
-            start_col,
-            self.cursor.line,
-            end_col + 1,
-        );
-        self.buffers[self.current_buffer_idx].insert_str(self.cursor.line, start_col, &replacement);
-        self.cursor.col = start_col + replacement.chars().count().saturating_sub(1);
-        self.undo_stack
-            .end_undo_group(self.cursor.line, self.cursor.col);
-        self.clamp_cursor();
-    }
-
     /// Join current line with next line (J command)
     pub fn join_lines(&mut self) {
         let total_lines = self.buffers[self.current_buffer_idx].len_lines();
@@ -11259,6 +11181,7 @@ mod tests {
     mod file_lifecycle;
     mod insert_entry;
     mod open_line;
+    mod replace;
     mod screen_position;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};

--- a/src/editor/replace.rs
+++ b/src/editor/replace.rs
@@ -1,0 +1,249 @@
+use super::{Change, Editor, Mode};
+
+#[derive(Debug)]
+enum ReplaceEdit {
+    Character {
+        line: usize,
+        col: usize,
+        original: Option<char>,
+        replacement: char,
+    },
+    Newline {
+        line: usize,
+        col: usize,
+    },
+}
+
+/// Transient state for one interactive `R` session.
+#[derive(Debug)]
+pub(super) struct ReplaceSession {
+    repeat_count: usize,
+    inserted_text: String,
+    edits: Vec<ReplaceEdit>,
+}
+
+impl Default for ReplaceSession {
+    fn default() -> Self {
+        Self {
+            repeat_count: 1,
+            inserted_text: String::new(),
+            edits: Vec::new(),
+        }
+    }
+}
+
+impl ReplaceSession {
+    fn with_count(count: usize) -> Self {
+        Self {
+            repeat_count: count.max(1),
+            ..Self::default()
+        }
+    }
+}
+
+impl Editor {
+    /// Enter interactive replace mode, preserving the command coordinate for redo.
+    pub fn enter_replace_mode(&mut self, count: usize) {
+        let start = (self.cursor.line, self.cursor.col);
+        self.begin_change();
+        self.undo_stack
+            .prefer_current_cursor_after(start.0, start.1);
+        self.replace_session = ReplaceSession::with_count(count);
+        self.mode = Mode::Replace;
+    }
+
+    /// Replace the character under the cursor while remaining in `R` mode.
+    pub fn replace_mode_char(&mut self, ch: char) {
+        self.apply_replace_mode_char(ch, true);
+    }
+
+    fn apply_replace_mode_char(&mut self, ch: char, track_session: bool) {
+        if ch == '\n' {
+            self.apply_replace_mode_newline(track_session);
+            return;
+        }
+
+        let line = self.cursor.line;
+        let col = self.cursor.col;
+        let original = if col < self.buffers[self.current_buffer_idx].line_len(line) {
+            self.buffers[self.current_buffer_idx].char_at(line, col)
+        } else {
+            None
+        };
+
+        if let Some(old_char) = original {
+            self.undo_stack
+                .record_change(Change::delete(line, col, old_char.to_string()));
+            self.buffers[self.current_buffer_idx].delete_char(line, col);
+        }
+
+        self.undo_stack
+            .record_change(Change::insert(line, col, ch.to_string()));
+        self.buffers[self.current_buffer_idx].insert_char(line, col, ch);
+
+        if track_session {
+            self.replace_session.edits.push(ReplaceEdit::Character {
+                line,
+                col,
+                original,
+                replacement: ch,
+            });
+            self.replace_session.inserted_text.push(ch);
+        }
+
+        self.cursor.col += 1;
+        self.scroll_to_cursor();
+    }
+
+    /// Insert a newline in `R` mode and continue replacing on the new line.
+    pub fn replace_mode_newline(&mut self) {
+        self.apply_replace_mode_newline(true);
+    }
+
+    fn apply_replace_mode_newline(&mut self, track_session: bool) {
+        let line = self.cursor.line;
+        let col = self.cursor.col;
+
+        self.undo_stack
+            .record_change(Change::insert(line, col, "\n".to_string()));
+        self.buffers[self.current_buffer_idx].insert_char(line, col, '\n');
+
+        if track_session {
+            self.replace_session
+                .edits
+                .push(ReplaceEdit::Newline { line, col });
+            self.replace_session.inserted_text.push('\n');
+        }
+
+        self.cursor.line += 1;
+        self.cursor.col = 0;
+        self.scroll_to_cursor();
+    }
+
+    /// Backspace in `R` mode restores text overwritten during this session.
+    pub fn replace_mode_backspace(&mut self) {
+        let Some(edit) = self.replace_session.edits.pop() else {
+            let moved = if self.cursor.col > 0 {
+                self.cursor.col -= 1;
+                true
+            } else if self.cursor.line > 0 {
+                self.cursor.line -= 1;
+                self.cursor.col = self.buffers[self.current_buffer_idx].line_len(self.cursor.line);
+                true
+            } else {
+                false
+            };
+            if moved {
+                self.replace_mode_cursor_moved();
+                self.scroll_to_cursor();
+            }
+            return;
+        };
+        self.replace_session.inserted_text.pop();
+
+        match edit {
+            ReplaceEdit::Character {
+                line,
+                col,
+                original,
+                replacement,
+            } => {
+                self.undo_stack
+                    .record_change(Change::delete(line, col, replacement.to_string()));
+                self.buffers[self.current_buffer_idx].delete_char(line, col);
+
+                if let Some(old_char) = original {
+                    self.undo_stack
+                        .record_change(Change::insert(line, col, old_char.to_string()));
+                    self.buffers[self.current_buffer_idx].insert_char(line, col, old_char);
+                }
+
+                self.cursor.line = line;
+                self.cursor.col = col;
+            }
+            ReplaceEdit::Newline { line, col } => {
+                self.undo_stack
+                    .record_change(Change::delete(line, col, "\n".to_string()));
+                self.buffers[self.current_buffer_idx].delete_char(line, col);
+                self.cursor.line = line;
+                self.cursor.col = col;
+            }
+        }
+
+        self.scroll_to_cursor();
+    }
+
+    /// Cursor movement ends Vim's straight-line replacement history.
+    /// Subsequent Backspace must not restore text from before the move, and a
+    /// numeric prefix must not replay text entered after the move.
+    pub fn replace_mode_cursor_moved(&mut self) {
+        self.replace_session.repeat_count = 1;
+        self.replace_session.inserted_text.clear();
+        self.replace_session.edits.clear();
+    }
+
+    /// Apply the numeric prefix's extra copies before leaving `R` mode.
+    pub(super) fn finish_replace_session(&mut self) {
+        let repeat_count = self.replace_session.repeat_count;
+        let inserted_text = self.replace_session.inserted_text.clone();
+
+        for _ in 1..repeat_count {
+            for ch in inserted_text.chars() {
+                self.apply_replace_mode_char(ch, false);
+            }
+        }
+
+        self.replace_session = ReplaceSession::default();
+    }
+
+    /// Replace one character under the cursor with the `r` command.
+    pub fn replace_char(&mut self, ch: char) {
+        self.replace_chars(ch, 1);
+    }
+
+    /// Replace exactly `count` characters; Vim leaves the line untouched if they do not fit.
+    pub fn replace_chars(&mut self, ch: char, count: usize) {
+        let count = count.max(1);
+        let line = self.cursor.line;
+        let start_col = self.cursor.col;
+        let line_len = self.buffers[self.current_buffer_idx].line_len(line);
+        let available = line_len.saturating_sub(start_col);
+        if available < count {
+            return;
+        }
+
+        let end_col = start_col + count - 1;
+        let old_text = self.get_range_text(line, start_col, line, end_col);
+        if old_text.chars().count() != count {
+            return;
+        }
+
+        let replacement = if ch == '\n' {
+            "\n".to_string()
+        } else {
+            std::iter::repeat(ch).take(count).collect()
+        };
+
+        self.begin_change();
+        self.undo_stack.prefer_current_cursor_after(line, start_col);
+        self.undo_stack
+            .record_change(Change::delete(line, start_col, old_text));
+        self.undo_stack
+            .record_change(Change::insert(line, start_col, replacement.clone()));
+
+        self.buffers[self.current_buffer_idx].delete_range(line, start_col, line, end_col + 1);
+        self.buffers[self.current_buffer_idx].insert_str(line, start_col, &replacement);
+
+        if ch == '\n' {
+            self.cursor.line += 1;
+            self.cursor.col = 0;
+        } else {
+            self.cursor.col = start_col + count - 1;
+        }
+
+        self.undo_stack
+            .end_undo_group(self.cursor.line, self.cursor.col);
+        self.clamp_cursor();
+        self.scroll_to_cursor();
+    }
+}

--- a/src/editor/tests/replace.rs
+++ b/src/editor/tests/replace.rs
@@ -1,0 +1,205 @@
+use crate::editor::Editor;
+use crate::terminal::handle_key;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+fn char_key(ch: char) -> KeyEvent {
+    let modifiers = if ch.is_ascii_uppercase() {
+        KeyModifiers::SHIFT
+    } else {
+        KeyModifiers::NONE
+    };
+    KeyEvent::new(KeyCode::Char(ch), modifiers)
+}
+
+fn type_chars(editor: &mut Editor, chars: &str) {
+    for ch in chars.chars() {
+        handle_key(editor, char_key(ch));
+    }
+}
+
+fn key(editor: &mut Editor, code: KeyCode) {
+    handle_key(editor, KeyEvent::new(code, KeyModifiers::NONE));
+}
+
+#[test]
+fn counted_replace_past_line_end_leaves_the_line_unchanged() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\n");
+
+    type_chars(&mut editor, "4rx");
+
+    assert_eq!(editor.buffer().content(), "abc\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}
+
+#[test]
+fn counted_replace_redo_restores_the_original_command_coordinate() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdef\n");
+
+    type_chars(&mut editor, "l3rx");
+    editor.undo();
+    editor.redo();
+
+    assert_eq!(editor.buffer().content(), "axxxef\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+}
+
+#[test]
+fn replace_with_enter_splits_the_line_at_the_cursor() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\n");
+
+    type_chars(&mut editor, "lr");
+    key(&mut editor, KeyCode::Enter);
+
+    assert_eq!(editor.buffer().content(), "a\nc\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn counted_replace_with_enter_removes_the_count_and_inserts_one_newline() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcd\n");
+
+    type_chars(&mut editor, "2r");
+    key(&mut editor, KeyCode::Enter);
+
+    assert_eq!(editor.buffer().content(), "\ncd\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn replace_mode_backspace_restores_the_overwritten_character() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\n");
+
+    type_chars(&mut editor, "RXY");
+    key(&mut editor, KeyCode::Backspace);
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "Xbc\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}
+
+#[test]
+fn replace_mode_movement_invalidates_backspace_restore_history() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdef\n");
+
+    type_chars(&mut editor, "RXY");
+    key(&mut editor, KeyCode::Left);
+    key(&mut editor, KeyCode::Backspace);
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "XYcdef\n");
+}
+
+#[test]
+fn replace_mode_vertical_movement_keeps_backspace_navigation_without_restoring_text() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdef\nuvwxyz\n");
+
+    type_chars(&mut editor, "RXY");
+    key(&mut editor, KeyCode::Down);
+    key(&mut editor, KeyCode::Backspace);
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "XYcdef\nuvwxyz\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn replace_mode_backspace_crosses_to_the_previous_line_end_after_movement() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\nuvwxyz\n");
+
+    type_chars(&mut editor, "R");
+    key(&mut editor, KeyCode::Down);
+    key(&mut editor, KeyCode::Backspace);
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "abc\nuvwxyz\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}
+
+#[test]
+fn replace_mode_continues_replacing_after_backspace_crosses_a_line_boundary() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\nuvwxyz\n");
+
+    type_chars(&mut editor, "jR");
+    key(&mut editor, KeyCode::Backspace);
+    type_chars(&mut editor, "X");
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "abcX\nuvwxyz\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 3));
+}
+
+#[test]
+fn replace_mode_line_boundary_backspace_cancels_counted_replay() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\nuvwxyz\n");
+
+    type_chars(&mut editor, "j2R");
+    key(&mut editor, KeyCode::Backspace);
+    type_chars(&mut editor, "X");
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "abcX\nuvwxyz\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 3));
+}
+
+#[test]
+fn replace_mode_enter_inserts_a_newline_and_keeps_replacing() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc\ndef\n");
+
+    type_chars(&mut editor, "lRXY");
+    key(&mut editor, KeyCode::Enter);
+    type_chars(&mut editor, "Z");
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "aXY\nZ\ndef\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+}
+
+#[test]
+fn counted_replace_mode_repeats_the_entered_text() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdefghij\n");
+
+    type_chars(&mut editor, "2RXY");
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "XYXYefghij\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 3));
+}
+
+#[test]
+fn replace_mode_movement_cancels_counted_replay() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdefghi\n");
+
+    type_chars(&mut editor, "2R");
+    key(&mut editor, KeyCode::Right);
+    type_chars(&mut editor, "X");
+    key(&mut editor, KeyCode::Esc);
+
+    assert_eq!(editor.buffer().content(), "aXcdefghi\n");
+}
+
+#[test]
+fn replace_mode_redo_restores_the_original_command_coordinate() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abcdef\n");
+
+    type_chars(&mut editor, "llRXY");
+    key(&mut editor, KeyCode::Esc);
+    editor.undo();
+    editor.redo();
+
+    assert_eq!(editor.buffer().content(), "abXYef\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -549,7 +549,7 @@ vim_default = true
 [[normal.editing]]
 key = "r{char}"
 action = "replace_char"
-desc = "Replace character under cursor"
+desc = "Replace character(s); Enter inserts one newline"
 status = "implemented"
 vim_default = true
 
@@ -1070,7 +1070,7 @@ locked = true
 [[normal.mode]]
 key = "R"
 action = "enter_replace"
-desc = "Enter replace mode"
+desc = "Replace mode; a count repeats straight-line input"
 status = "implemented"
 vim_default = true
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -198,8 +198,8 @@ pub enum KeyAction {
     EnterVisualLine,
     /// Enter visual block mode
     EnterVisualBlock,
-    /// Enter replace mode
-    EnterReplace,
+    /// Enter replace mode with the normal-mode numeric prefix.
+    EnterReplace(usize),
     /// Quit
     Quit,
     /// Save
@@ -488,6 +488,9 @@ impl InputState {
             if let KeyCode::Char(c) = key.code {
                 self.reset();
                 return KeyAction::ReplaceChar(c, count);
+            } else if key.code == KeyCode::Enter {
+                self.reset();
+                return KeyAction::ReplaceChar('\n', count);
             } else if key.code == KeyCode::Esc {
                 self.reset();
                 return KeyAction::Pending;
@@ -1098,7 +1101,7 @@ impl InputState {
             | (KeyModifiers::NONE, KeyCode::Char('R')) => {
                 // R - enter replace mode
                 self.reset();
-                KeyAction::EnterReplace
+                KeyAction::EnterReplace(count)
             }
             (KeyModifiers::SHIFT, KeyCode::Char('J')) => {
                 // J - join lines
@@ -2297,6 +2300,14 @@ mod tests {
             KeyAction::ReplaceChar('x', 1) => {}
             other => panic!("expected ReplaceChar, got {:?}", other),
         }
+        match run(&[key('r'), enter()]) {
+            KeyAction::ReplaceChar('\n', 1) => {}
+            other => panic!("expected newline ReplaceChar, got {:?}", other),
+        }
+        match run(&[key('2'), key('r'), enter()]) {
+            KeyAction::ReplaceChar('\n', 2) => {}
+            other => panic!("expected counted newline ReplaceChar, got {:?}", other),
+        }
         match run(&[key('.')]) {
             KeyAction::RepeatLastChange => {}
             other => panic!("expected RepeatLastChange, got {:?}", other),
@@ -2321,8 +2332,12 @@ mod tests {
         assert_insert(&[key('3'), shift('I')], InsertPosition::LineStart, 3);
         assert_insert(&[key('3'), shift('A')], InsertPosition::LineEnd, 3);
         match run(&[shift('R')]) {
-            KeyAction::EnterReplace => {}
+            KeyAction::EnterReplace(1) => {}
             other => panic!("expected EnterReplace, got {:?}", other),
+        }
+        match run(&[key('3'), shift('R')]) {
+            KeyAction::EnterReplace(3) => {}
+            other => panic!("expected counted EnterReplace, got {:?}", other),
         }
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7497,8 +7497,8 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.enter_visual_block_mode();
         }
 
-        KeyAction::EnterReplace => {
-            editor.enter_replace_mode();
+        KeyAction::EnterReplace(count) => {
+            editor.enter_replace_mode(count);
         }
 
         KeyAction::Quit => {
@@ -8307,23 +8307,28 @@ fn handle_replace_mode(editor: &mut Editor, key: KeyEvent) {
             editor.enter_normal_mode();
         }
 
-        // Backspace - move back (don't undo replacement)
+        // Backspace restores text overwritten during this replace session.
         (KeyModifiers::NONE, KeyCode::Backspace) => {
-            if editor.cursor.col > 0 {
-                editor.cursor.col -= 1;
-            }
+            editor.replace_mode_backspace();
+        }
+
+        // Enter inserts a newline and keeps replace mode active.
+        (KeyModifiers::NONE, KeyCode::Enter) => {
+            editor.replace_mode_newline();
         }
 
         // Arrow keys for navigation
         (_, KeyCode::Left) => {
             if editor.cursor.col > 0 {
                 editor.cursor.col -= 1;
+                editor.replace_mode_cursor_moved();
             }
         }
         (_, KeyCode::Right) => {
             let line_len = editor.buffer().line_len(editor.cursor.line);
             if editor.cursor.col < line_len {
                 editor.cursor.col += 1;
+                editor.replace_mode_cursor_moved();
             }
         }
         (_, KeyCode::Up) => {
@@ -8331,6 +8336,7 @@ fn handle_replace_mode(editor: &mut Editor, key: KeyEvent) {
                 editor.cursor.line -= 1;
                 editor.clamp_cursor();
                 editor.scroll_to_cursor();
+                editor.replace_mode_cursor_moved();
             }
         }
         (_, KeyCode::Down) => {
@@ -8338,6 +8344,7 @@ fn handle_replace_mode(editor: &mut Editor, key: KeyEvent) {
                 editor.cursor.line += 1;
                 editor.clamp_cursor();
                 editor.scroll_to_cursor();
+                editor.replace_mode_cursor_moved();
             }
         }
 

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -8,10 +8,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 mod editing_cases;
 mod insert_entry_cases;
 mod open_line_cases;
+mod replace_cases;
 
 use editing_cases::EDITING_CASES;
 use insert_entry_cases::INSERT_ENTRY_CASES;
 use open_line_cases::OPEN_LINE_CASES;
+use replace_cases::REPLACE_CASES;
 
 #[derive(Debug, Clone, Copy)]
 struct OracleCase {
@@ -527,6 +529,10 @@ const ORACLE_CATEGORIES: &[OracleCategory] = &[
         cases: OPEN_LINE_CASES,
     },
     OracleCategory {
+        name: "replace",
+        cases: REPLACE_CASES,
+    },
+    OracleCategory {
         name: "undo-redo",
         cases: UNDO_REDO_CASES,
     },
@@ -579,6 +585,10 @@ fn parse_key_token(token: &str) -> Result<KeyEvent, String> {
         "cr" | "enter" | "return" => Ok(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
         "tab" => Ok(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
         "bs" | "backspace" => Ok(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        "left" => Ok(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)),
+        "right" => Ok(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        "up" => Ok(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+        "down" => Ok(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
         "space" => Ok(char_key(' ')),
         "lt" => Ok(char_key('<')),
         _ => {
@@ -944,9 +954,10 @@ mod tests {
 
     #[test]
     fn parses_plain_shift_control_and_named_keys() {
-        let keys = parse_key_sequence("jG<C-d><Esc><CR>").expect("parse keys");
+        let keys =
+            parse_key_sequence("jG<C-d><Esc><CR><Left><Right><Up><Down>").expect("parse keys");
 
-        assert_eq!(keys.len(), 5);
+        assert_eq!(keys.len(), 9);
         assert_eq!(keys[0].code, KeyCode::Char('j'));
         assert_eq!(keys[0].modifiers, KeyModifiers::NONE);
         assert_eq!(keys[1].code, KeyCode::Char('G'));
@@ -955,6 +966,10 @@ mod tests {
         assert_eq!(keys[2].modifiers, KeyModifiers::CONTROL);
         assert_eq!(keys[3].code, KeyCode::Esc);
         assert_eq!(keys[4].code, KeyCode::Enter);
+        assert_eq!(keys[5].code, KeyCode::Left);
+        assert_eq!(keys[6].code, KeyCode::Right);
+        assert_eq!(keys[7].code, KeyCode::Up);
+        assert_eq!(keys[8].code, KeyCode::Down);
     }
 
     #[test]
@@ -1071,6 +1086,12 @@ mod tests {
                 .any(|category| category.name == "undo-redo" && category.cases.len() >= 2),
             "undo-redo category should cover timeline basics"
         );
+        assert!(
+            categories
+                .iter()
+                .any(|category| category.name == "replace" && category.cases.len() >= 15),
+            "replace category should cover one-shot and interactive replacement"
+        );
 
         let all_keys = categories
             .iter()
@@ -1083,6 +1104,8 @@ mod tests {
             "G",
             "2dd",
             "ciwdone<Esc>",
+            "2r<CR>",
+            "2RXY<Esc>",
             "A!<Esc>u",
             "A!<Esc>u<C-r>",
         ] {

--- a/src/vim_oracle/replace_cases.rs
+++ b/src/vim_oracle/replace_cases.rs
@@ -1,0 +1,141 @@
+use super::OracleCase;
+
+/// Replace cases cover both the one-shot `r` command and interactive `R` mode.
+/// The oracle compares text, cursor position, viewport, and final mode.
+pub(super) const REPLACE_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "replace character",
+        initial_text: "abc\n",
+        keys: "rx",
+    },
+    OracleCase {
+        name: "counted replace character",
+        initial_text: "abcdef\n",
+        keys: "3rx",
+    },
+    OracleCase {
+        name: "counted replace character at exact line boundary",
+        initial_text: "abc\n",
+        keys: "3rx",
+    },
+    OracleCase {
+        name: "counted replace character past line boundary",
+        initial_text: "abc\n",
+        keys: "4rx",
+    },
+    OracleCase {
+        name: "replace character with newline",
+        initial_text: "abc\n",
+        keys: "lr<CR>",
+    },
+    OracleCase {
+        name: "counted replace character with newlines",
+        initial_text: "abcd\n",
+        keys: "2r<CR>",
+    },
+    OracleCase {
+        name: "replace multibyte characters",
+        initial_text: "🙂éz\n",
+        keys: "2rX",
+    },
+    OracleCase {
+        name: "undo counted replace character",
+        initial_text: "abcdef\n",
+        keys: "l3rxu",
+    },
+    OracleCase {
+        name: "redo counted replace character",
+        initial_text: "abcdef\n",
+        keys: "l3rxu<C-r>",
+    },
+    OracleCase {
+        name: "replace mode overwrites characters",
+        initial_text: "abcdef\n",
+        keys: "llRXY<Esc>",
+    },
+    OracleCase {
+        name: "replace mode escape without edits",
+        initial_text: "abcdef\n",
+        keys: "llR<Esc>",
+    },
+    OracleCase {
+        name: "replace mode extends past line end",
+        initial_text: "abc\n",
+        keys: "llRXYZ<Esc>",
+    },
+    OracleCase {
+        name: "replace mode backspace restores original text",
+        initial_text: "abc\n",
+        keys: "RXY<BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode backspace removes text appended past line end",
+        initial_text: "abc\n",
+        keys: "$RXY<BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode inserts newline and continues",
+        initial_text: "abc\ndef\n",
+        keys: "lRXY<CR>Z<Esc>",
+    },
+    OracleCase {
+        name: "replace mode backspace removes inserted newline",
+        initial_text: "abc\ndef\n",
+        keys: "lRXY<CR><BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode movement invalidates backspace restore history",
+        initial_text: "abcdef\n",
+        keys: "RXY<Left><BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode vertical movement invalidates backspace restore history",
+        initial_text: "abcdef\nuvwxyz\n",
+        keys: "RXY<Down><BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode backspace crosses a line boundary after movement",
+        initial_text: "abc\nuvwxyz\n",
+        keys: "R<Down><BS><Esc>",
+    },
+    OracleCase {
+        name: "replace mode continues replacing after backspace crosses a line boundary",
+        initial_text: "abc\nuvwxyz\n",
+        keys: "jR<BS>X<Esc>",
+    },
+    OracleCase {
+        name: "replace mode line-boundary backspace cancels counted replay",
+        initial_text: "abc\nuvwxyz\n",
+        keys: "j2R<BS>X<Esc>",
+    },
+    OracleCase {
+        name: "counted replace mode repeats inserted text",
+        initial_text: "abcdefghij\n",
+        keys: "2RXY<Esc>",
+    },
+    OracleCase {
+        name: "counted replace mode repeats newline",
+        initial_text: "abc\ndef\n",
+        keys: "2RZ<CR><Esc>",
+    },
+    OracleCase {
+        name: "replace mode movement cancels counted replay",
+        initial_text: "abcdefghi\n",
+        keys: "2R<Right>X<Esc>",
+    },
+    OracleCase {
+        name: "replace mode vertical movement cancels counted replay",
+        initial_text: "abcdefghi\nuvwxyz\n",
+        keys: "2R<Down>X<Esc>",
+    },
+    OracleCase {
+        name: "undo replace mode session",
+        initial_text: "abcdef\n",
+        keys: "llRXY<Esc>u",
+    },
+    OracleCase {
+        name: "redo replace mode session",
+        initial_text: "abcdef\n",
+        keys: "llRXY<Esc>u<C-r>",
+    },
+];


### PR DESCRIPTION
## Summary
- match Vim/Neovim `r` count, end-of-line, newline, Unicode, undo, and redo behavior
- implement `R` overwrite, extension, newline, Backspace restoration/navigation, counted replay, and movement cancellation semantics
- isolate replace logic and regression coverage in dedicated modules and update `:Keymaps` metadata and public documentation

## Verification
- `cargo fmt --all -- --check`
- `cargo test --quiet` (737 library passed, 3 ignored; 26 binary passed)
- `NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture`
- `cargo test render_frame_budget -- --ignored --nocapture`
- `cargo build --release --quiet`
- manual verification of counted replacement, over-count rejection, newline replacement, Unicode, Backspace restoration, movement cancellation, and line-boundary navigation