### PR TITLE
fix: hide trailing newline sentinel line

### DIFF
--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -203,6 +203,20 @@ impl Buffer {
         self.text.len_lines()
     }
 
+    /// Get the number of user-addressable lines.
+    ///
+    /// Ropey represents a trailing newline with an additional empty line slice.
+    /// That slice is a storage boundary, not a line the cursor can enter or the
+    /// terminal should render. An empty buffer still has one addressable line.
+    pub fn addressable_line_count(&self) -> usize {
+        let line_count = self.text.len_lines();
+        if line_count > 1 && self.text.line(line_count - 1).len_chars() == 0 {
+            line_count - 1
+        } else {
+            line_count
+        }
+    }
+
     /// Get a specific line (0-indexed)
     pub fn line(&self, idx: usize) -> Option<ropey::RopeSlice<'_>> {
         if idx < self.text.len_lines() {
@@ -570,7 +584,7 @@ fn sync_parent_dir(_parent: &Path) {}
 
 #[cfg(test)]
 mod tests {
-    use super::write_file_atomically;
+    use super::{Buffer, write_file_atomically};
     use std::io;
     use std::path::PathBuf;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -581,6 +595,28 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn addressable_line_count_ignores_only_the_trailing_rope_sentinel() {
+        let cases = [
+            ("", 1),
+            ("alpha", 1),
+            ("alpha\n", 1),
+            ("alpha\nbeta\n", 2),
+            ("alpha\nbeta\n\n", 3),
+        ];
+
+        for (content, expected) in cases {
+            let mut buffer = Buffer::new();
+            buffer.insert_str(0, 0, content);
+
+            assert_eq!(
+                buffer.addressable_line_count(),
+                expected,
+                "content={content:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2836,7 +2836,7 @@ impl Editor {
         self.reset_current_undo_stack();
 
         // Try to restore cursor position (clamp to valid range)
-        let max_line = self.buffer().len_lines().saturating_sub(1);
+        let max_line = self.buffer().addressable_line_count().saturating_sub(1);
         self.cursor.line = cursor_line.min(max_line);
         let max_col = self.buffer().line_len(self.cursor.line);
         self.cursor.col = cursor_col.min(max_col);
@@ -2861,7 +2861,7 @@ impl Editor {
 
         self.buffer_mut().set_content(content);
 
-        let max_line = self.buffer().len_lines().saturating_sub(1);
+        let max_line = self.buffer().addressable_line_count().saturating_sub(1);
         self.cursor.line = cursor_line.min(max_line);
         let max_col = self.buffer().line_len(self.cursor.line);
         self.cursor.col = cursor_col.min(max_col);
@@ -3694,7 +3694,7 @@ impl Editor {
     pub fn clamp_cursor(&mut self) {
         // Clamp line
         let max_line = self.buffers[self.current_buffer_idx]
-            .len_lines()
+            .addressable_line_count()
             .saturating_sub(1);
         if self.cursor.line > max_line {
             self.cursor.line = max_line;
@@ -3723,7 +3723,7 @@ impl Editor {
         self.begin_insert_session();
         self.cursor.line = line.min(
             self.buffers[self.current_buffer_idx]
-                .len_lines()
+                .addressable_line_count()
                 .saturating_sub(1),
         );
         self.cursor.col = col.min(self.buffers[self.current_buffer_idx].line_len(self.cursor.line));
@@ -3997,7 +3997,12 @@ impl Editor {
             self.term_width as usize
         };
         const SIGN_COLUMN_WIDTH: usize = 2;
-        let line_num_width = self.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = self
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
         if self.settings.editor.line_numbers {
             pane_width.saturating_sub(SIGN_COLUMN_WIDTH + line_num_width + 1)
         } else {
@@ -4596,7 +4601,7 @@ impl Editor {
                 if cursor_after {
                     self.cursor.line = (first_inserted_line + inserted_line_count).min(
                         self.buffers[self.current_buffer_idx]
-                            .len_lines()
+                            .addressable_line_count()
                             .saturating_sub(1),
                     );
                     self.cursor.col = 0;
@@ -4730,7 +4735,7 @@ impl Editor {
                 if cursor_after {
                     self.cursor.line = (insert_line + inserted_line_count).min(
                         self.buffers[self.current_buffer_idx]
-                            .len_lines()
+                            .addressable_line_count()
                             .saturating_sub(1),
                     );
                 } else {

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -116,7 +116,7 @@ pub fn apply_motion(
         Motion::Up => Some((line.saturating_sub(count), col)),
 
         Motion::Down => {
-            let max_line = buffer.len_lines().saturating_sub(1);
+            let max_line = last_addressable_line(buffer);
             let new_line = (line + count).min(max_line);
             Some((new_line, col))
         }
@@ -124,7 +124,7 @@ pub fn apply_motion(
         Motion::DisplayLineUp => Some((line.saturating_sub(count), col)),
 
         Motion::DisplayLineDown => {
-            let max_line = buffer.len_lines().saturating_sub(1);
+            let max_line = last_addressable_line(buffer);
             let new_line = (line + count).min(max_line);
             Some((new_line, col))
         }
@@ -270,7 +270,7 @@ pub fn apply_motion(
         }
 
         Motion::NextLineFirstNonBlank => {
-            let max_line = buffer.len_lines().saturating_sub(1);
+            let max_line = last_addressable_line(buffer);
             let target_line = (line + count).min(max_line);
             let first_non_blank = find_first_non_blank(buffer, target_line);
             Some((target_line, first_non_blank))
@@ -296,7 +296,7 @@ pub fn apply_motion(
 
         Motion::HalfPageDown => {
             let half = text_rows / 2;
-            let max_line = buffer.len_lines().saturating_sub(1);
+            let max_line = last_addressable_line(buffer);
             let new_line = (line + half * count).min(max_line);
             Some((new_line, col))
         }
@@ -308,7 +308,7 @@ pub fn apply_motion(
         }
 
         Motion::PageDown => {
-            let max_line = buffer.len_lines().saturating_sub(1);
+            let max_line = last_addressable_line(buffer);
             let new_line = (line + text_rows * count).min(max_line);
             Some((new_line, col))
         }
@@ -351,7 +351,7 @@ pub fn apply_motion(
         Motion::ParagraphForward => {
             // } - move to next paragraph (next blank line after non-blank content)
             let mut l = line;
-            let total_lines = buffer.len_lines();
+            let total_lines = buffer.addressable_line_count();
 
             // Apply count times
             for _ in 0..count {
@@ -658,7 +658,7 @@ fn find_word_forward(
 ) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
-    let total_lines = buffer.len_lines();
+    let total_lines = buffer.addressable_line_count();
 
     // Get current character class
     let start_class = buffer.char_at(l, c).map(|ch| classify_char(ch));
@@ -828,7 +828,7 @@ fn find_word_end(
 ) -> Option<(usize, usize)> {
     let mut l = line;
     let mut c = col;
-    let total_lines = buffer.len_lines();
+    let total_lines = buffer.addressable_line_count();
 
     // Move forward one character first
     c += 1;
@@ -925,15 +925,7 @@ fn find_first_non_blank(buffer: &Buffer, line: usize) -> usize {
 }
 
 pub(crate) fn last_addressable_line(buffer: &Buffer) -> usize {
-    let last_line = buffer.len_lines().saturating_sub(1);
-    if last_line > 0
-        && buffer.line_len(last_line) == 0
-        && buffer.line_len_including_newline(last_line) == 0
-    {
-        last_line - 1
-    } else {
-        last_line
-    }
+    buffer.addressable_line_count().saturating_sub(1)
 }
 
 /// Find character forward on the same line (f/t motions)
@@ -1109,5 +1101,39 @@ mod tests {
         let position = apply_motion(&buffer, Motion::GotoLine(999), 0, 0, 1, 22);
 
         assert_eq!(position, Some((29, 0)));
+    }
+
+    #[test]
+    fn downward_motions_ignore_trailing_empty_rope_line() {
+        let buffer = buffer_with("alpha\nbeta\n");
+
+        for motion in [
+            Motion::Down,
+            Motion::DisplayLineDown,
+            Motion::NextLineFirstNonBlank,
+            Motion::HalfPageDown,
+            Motion::PageDown,
+        ] {
+            let position = apply_motion(&buffer, motion, 1, 0, 1, 24);
+
+            assert_eq!(position, Some((1, 0)), "motion={motion:?}");
+        }
+    }
+
+    #[test]
+    fn downward_motions_reach_real_final_blank_line() {
+        let buffer = buffer_with("alpha\nbeta\n\n");
+
+        for motion in [
+            Motion::Down,
+            Motion::DisplayLineDown,
+            Motion::NextLineFirstNonBlank,
+            Motion::HalfPageDown,
+            Motion::PageDown,
+        ] {
+            let position = apply_motion(&buffer, motion, 1, 0, 1, 24);
+
+            assert_eq!(position, Some((2, 0)), "motion={motion:?}");
+        }
     }
 }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1169,7 +1169,12 @@ impl Terminal {
             }
 
             // Render status line
-            let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+            let line_num_width = editor
+                .buffer()
+                .addressable_line_count()
+                .to_string()
+                .len()
+                .max(3);
             self.render_status_line(editor, line_num_width)?;
 
             // Render command/message line
@@ -1314,7 +1319,12 @@ impl Terminal {
 
         match kind {
             PartialRenderKind::StatusLine => {
-                let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+                let line_num_width = editor
+                    .buffer()
+                    .addressable_line_count()
+                    .to_string()
+                    .len()
+                    .max(3);
                 self.render_status_line(editor, line_num_width)?;
             }
             PartialRenderKind::EditorRows(rows) => {
@@ -1322,7 +1332,12 @@ impl Terminal {
             }
             PartialRenderKind::EditorRowsAndStatusLine(rows) => {
                 self.render_editor_rows_partial(editor, &rows)?;
-                let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+                let line_num_width = editor
+                    .buffer()
+                    .addressable_line_count()
+                    .to_string()
+                    .len()
+                    .max(3);
                 self.render_status_line(editor, line_num_width)?;
             }
         }
@@ -1347,7 +1362,8 @@ impl Terminal {
             return Ok(());
         };
         let buffer_path = buffer.path.clone();
-        let line_num_width = buffer.len_lines().to_string().len().max(3);
+        let line_count = buffer.addressable_line_count();
+        let line_num_width = line_count.to_string().len().max(3);
 
         let show_line_numbers = editor.settings.editor.line_numbers;
         let show_relative = editor.settings.editor.relative_numbers;
@@ -1528,7 +1544,8 @@ impl Terminal {
         let rect = &pane.rect;
 
         // Calculate line number width for this buffer
-        let line_num_width = buffer.len_lines().to_string().len().max(3);
+        let line_count = buffer.addressable_line_count();
+        let line_num_width = line_count.to_string().len().max(3);
 
         // Get visual selection range if in visual mode and this is active pane
         let visual_range = if is_active && editor.mode.is_visual() {
@@ -1630,6 +1647,7 @@ impl Terminal {
         let editor_bg = theme.ui.background;
         let editor_fg = theme.ui.foreground;
         let tab_width = editor.get_effective_tab_width();
+        let line_count = buffer.addressable_line_count();
         let line_context_factory = RenderLineContextFactory::new(editor, visual_range, tab_width);
 
         // Pre-compute URI for diagnostic lookups (avoids repeated string allocations)
@@ -1642,7 +1660,7 @@ impl Terminal {
         let mut current_row = 0;
         let mut file_line = pane.viewport_offset;
 
-        while current_row < pane_height && file_line < buffer.len_lines() {
+        while current_row < pane_height && file_line < line_count {
             let is_cursor_line = is_active && file_line == pane.cursor.line;
 
             // Get line content
@@ -1983,6 +2001,7 @@ impl Terminal {
         let editor_bg = theme.ui.background;
         let editor_fg = theme.ui.foreground;
         let tab_width = editor.get_effective_tab_width();
+        let line_count = buffer.addressable_line_count();
         let line_context_factory = RenderLineContextFactory::new(editor, visual_range, tab_width);
 
         // Pre-compute URI for diagnostic lookups (avoids repeated string allocations)
@@ -2002,12 +2021,11 @@ impl Terminal {
             execute!(self.stdout, cursor::MoveTo(rect.x, screen_y))?;
 
             // Set background color for this row (cursor line or normal)
-            let row_bg =
-                if highlight_cursor_line && is_cursor_line && file_line < buffer.len_lines() {
-                    cursor_line_bg
-                } else {
-                    editor_bg
-                };
+            let row_bg = if highlight_cursor_line && is_cursor_line && file_line < line_count {
+                cursor_line_bg
+            } else {
+                editor_bg
+            };
             execute!(
                 self.stdout,
                 SetAttribute(Attribute::Reset),
@@ -2015,7 +2033,7 @@ impl Terminal {
                 SetForegroundColor(editor_fg)
             )?;
 
-            if file_line < buffer.len_lines() {
+            if file_line < line_count {
                 // Check for diagnostics on this line (only for active pane)
                 let line_diagnostics = match &cached_uri {
                     Some(uri) => editor.diagnostics_for_line_cached(file_line, uri),
@@ -2775,7 +2793,12 @@ impl Terminal {
     /// Position the cursor based on editor mode
     fn position_cursor(&mut self, editor: &Editor) -> anyhow::Result<()> {
         let show_line_numbers = editor.settings.editor.line_numbers;
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
 
         match editor.mode {
             Mode::Command => {
@@ -3412,7 +3435,12 @@ impl Terminal {
         let pane_x = active_pane.rect.x;
         let pane_y = active_pane.rect.y;
 
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
         let cursor_in_pane_col = (line_num_width + 1 + completion.trigger_col) as u16;
         let cursor_in_pane_row = (editor
             .cursor
@@ -3920,7 +3948,12 @@ impl Terminal {
         let pane_x = active_pane.rect.x;
         let pane_y = active_pane.rect.y;
 
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
         let cursor_in_pane_col = (line_num_width + 1 + editor.cursor.col) as u16;
         let cursor_in_pane_row = (editor.cursor.line - editor.viewport_offset) as u16;
 
@@ -4190,7 +4223,12 @@ impl Terminal {
         let signature = &help.signatures[active_idx];
 
         // Calculate popup position (above cursor)
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
         let cursor_screen_col = (line_num_width + 1 + editor.cursor.col) as u16;
         let cursor_screen_row = (editor.cursor.line - editor.viewport_offset) as u16;
 
@@ -4321,7 +4359,12 @@ impl Terminal {
 
     fn diagnostic_float_text_area_x(editor: &Editor) -> u16 {
         let active_pane = &editor.panes()[editor.active_pane_idx()];
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3) as u16;
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3) as u16;
         active_pane.rect.x.saturating_add(2 + line_num_width + 1)
     }
 
@@ -4921,7 +4964,12 @@ impl Terminal {
         let popup_height = (picker.items.len() as u16 + 2).min(max_height);
 
         // Position near cursor
-        let line_num_width = editor.buffer().len_lines().to_string().len().max(3);
+        let line_num_width = editor
+            .buffer()
+            .addressable_line_count()
+            .to_string()
+            .len()
+            .max(3);
         let cursor_screen_col = (2 + line_num_width + 1 + editor.cursor.col) as u16;
         let cursor_screen_row = (editor.cursor.line - editor.viewport_offset) as u16;
 
@@ -8226,7 +8274,7 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
             }
         }
         (_, KeyCode::Down) => {
-            if editor.cursor.line < editor.buffer().len_lines() - 1 {
+            if editor.cursor.line + 1 < editor.buffer().addressable_line_count() {
                 editor.cursor.line += 1;
                 editor.clamp_cursor();
                 editor.scroll_to_cursor();
@@ -8334,7 +8382,7 @@ fn handle_replace_mode(editor: &mut Editor, key: KeyEvent) {
             }
         }
         (_, KeyCode::Down) => {
-            if editor.cursor.line < editor.buffer().len_lines() - 1 {
+            if editor.cursor.line + 1 < editor.buffer().addressable_line_count() {
                 editor.cursor.line += 1;
                 editor.clamp_cursor();
                 editor.scroll_to_cursor();

--- a/src/terminal/tests/viewport_rendering.rs
+++ b/src/terminal/tests/viewport_rendering.rs
@@ -2,6 +2,38 @@ use super::render_editor_to_string;
 use crate::editor::Editor;
 use crate::input::Motion;
 
+fn rendered_tilde_count(content: &str, wrap: bool) -> usize {
+    let mut editor = Editor::default();
+    editor.set_size(80, 12);
+    editor.settings.editor.wrap = wrap;
+    editor.settings.editor.wrap_width = 80;
+    editor.replace_buffer_content(content);
+
+    render_editor_to_string(&editor).matches('~').count()
+}
+
+#[test]
+fn full_render_treats_trailing_empty_rope_line_as_end_of_buffer() {
+    for wrap in [false, true] {
+        assert_eq!(
+            rendered_tilde_count("alpha\nbeta\n", wrap),
+            8,
+            "wrap={wrap}"
+        );
+    }
+}
+
+#[test]
+fn full_render_keeps_real_final_blank_line_visible() {
+    for wrap in [false, true] {
+        assert_eq!(
+            rendered_tilde_count("alpha\nbeta\n\n", wrap),
+            7,
+            "wrap={wrap}"
+        );
+    }
+}
+
 #[test]
 fn full_render_after_wrapped_file_end_shows_context_above_last_line() {
     let mut editor = Editor::default();

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -124,6 +124,11 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         keys: "yypp",
     },
     OracleCase {
+        name: "linewise paste does not expose trailing newline as a line",
+        initial_text: "",
+        keys: "iabc<Esc>yypj",
+    },
+    OracleCase {
         name: "yank to line end",
         initial_text: "alpha\nbeta\n",
         keys: "YP",


### PR DESCRIPTION
## Summary

- treat Ropey trailing empty slice as a storage sentinel instead of a user-addressable line
- use the logical line count for cursor movement, rendering, line numbers, and cursor clamping
- preserve genuine final blank lines while removing the extra navigable display row
- add focused rendering and motion regressions plus the exact Neovim oracle case from issue #242

## Testing

- cargo fmt --all -- --check
- cargo test --quiet
- cargo test render_frame_budget -- --ignored --nocapture
- NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke_matches_neovim_for_basic_normal_edit -- --ignored --nocapture
- manually verified the original reproduction, undo/redo, existing files with and without a final newline, and genuine final blank lines

Fixes #242