### PR TITLE
fix: respect theme colors in hover and completion UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Nevi comes with 15+ built-in themes. You can also create your own custom themes.
 
 Select a theme with `:theme <name>` or `<Space>ft` to open the theme picker.
 
-Available themes: `onedark`, `dracula`, `gruvbox`, `nord`, `tokyonight`, `catppuccin-mocha`, `rose-pine`, `solarized-dark`, `kanagawa`, `monokai`, `everforest`, `github-dark`, `ayu-dark`, `palenight`, `nightfox`
+Available themes: `onedark`, `dracula`, `gruvbox`, `nord`, `tokyonight`, `catppuccin-mocha`, `rose-pine`, `solarized-dark`, `kanagawa`, `monokai`, `everforest`, `github-dark`, `github-light`, `ayu-dark`, `palenight`, `nightfox`
 
 ### Creating Custom Themes
 

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -534,38 +534,6 @@ impl CompletionKind {
             CompletionKind::TypeParameter => "t",
         }
     }
-
-    /// Get the color for this kind (RGB values)
-    pub fn color(&self) -> (u8, u8, u8) {
-        match self {
-            // Functions/Methods - Blue
-            CompletionKind::Method | CompletionKind::Function => (97, 175, 239),
-            // Types/Classes - Yellow/Orange
-            CompletionKind::Class | CompletionKind::Interface | CompletionKind::Struct => {
-                (229, 192, 123)
-            }
-            // Variables/Fields - Cyan
-            CompletionKind::Variable | CompletionKind::Field | CompletionKind::Property => {
-                (86, 182, 194)
-            }
-            // Constants/Values - Purple
-            CompletionKind::Constant | CompletionKind::Value | CompletionKind::EnumMember => {
-                (198, 120, 221)
-            }
-            // Enums - Green
-            CompletionKind::Enum => (152, 195, 121),
-            // Keywords - Red/Pink
-            CompletionKind::Keyword => (224, 108, 117),
-            // Snippets - Gray
-            CompletionKind::Snippet => (150, 150, 160),
-            // Modules - Teal
-            CompletionKind::Module => (78, 201, 176),
-            // Constructors - Orange
-            CompletionKind::Constructor => (209, 154, 102),
-            // Default - Light blue
-            _ => (130, 180, 250),
-        }
-    }
 }
 
 /// A location in a document

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3852,6 +3852,7 @@ impl Terminal {
             Some(c) => c,
             None => return Ok(()),
         };
+        let theme = editor.theme();
 
         // Parse content into sections
         let sections = Self::parse_hover_content(content);
@@ -3914,47 +3915,14 @@ impl Terminal {
             .saturating_sub(2)
             .min(editor.term_width.saturating_sub(popup_width + 1));
 
-        // Colors (Neovim-inspired)
-        let border_color = Color::Rgb {
-            r: 90,
-            g: 90,
-            b: 120,
-        };
-        let bg_color = Color::Rgb {
-            r: 25,
-            g: 25,
-            b: 35,
-        };
-        let code_bg = Color::Rgb {
-            r: 35,
-            g: 35,
-            b: 50,
-        };
-        let text_color = Color::Rgb {
-            r: 200,
-            g: 200,
-            b: 210,
-        };
-        let code_color = Color::Rgb {
-            r: 150,
-            g: 200,
-            b: 255,
-        }; // Blue for signatures
-        let keyword_color = Color::Rgb {
-            r: 255,
-            g: 150,
-            b: 150,
-        }; // Red/pink for keywords
-        let type_color = Color::Rgb {
-            r: 180,
-            g: 220,
-            b: 180,
-        }; // Green for types
-        let separator_color = Color::Rgb {
-            r: 70,
-            g: 70,
-            b: 90,
-        };
+        let border_color = theme.ui.popup_border;
+        let bg_color = theme.ui.popup_bg;
+        let code_bg = theme.ui.popup_bg;
+        let text_color = theme.ui.foreground;
+        let code_color = theme.syntax.function.fg;
+        let keyword_color = theme.syntax.keyword.fg;
+        let type_color = theme.syntax.type_.fg;
+        let separator_color = theme.ui.popup_border;
 
         // Draw top border (rounded corners)
         execute!(self.stdout, cursor::MoveTo(popup_x, popup_y))?;
@@ -10821,6 +10789,16 @@ mod tests {
         output.into_string()
     }
 
+    fn render_hover_to_string(editor: &Editor) -> String {
+        crossterm::style::force_color_output(true);
+        let output = SharedOutput::default();
+        let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
+        terminal
+            .render_hover(editor)
+            .expect("hover render should succeed");
+        output.into_string()
+    }
+
     fn measure_render(editor: &Editor) -> Duration {
         crossterm::style::force_color_output(true);
         let output = SharedOutput::default();
@@ -10969,6 +10947,87 @@ mod tests {
         let dark_render = render_completion_to_string(&editor);
         assert!(dark_render.contains(&background_sequence(dark_theme.ui.completion_bg)));
         assert_ne!(light_theme.ui.completion_bg, dark_theme.ui.completion_bg);
+        assert_ne!(light_render, dark_render);
+    }
+
+    #[test]
+    fn hover_render_uses_active_theme_colors() {
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor.replace_buffer_content("demo\n");
+        editor.hover_content = Some(
+            "```rust\npub fn demo(value: ExampleType)\n```\nReturns an example value.".to_string(),
+        );
+        assert!(editor.set_theme("github-light"));
+
+        let light_theme = editor.theme().clone();
+        let light_render = render_hover_to_string(&editor);
+        for sequence in [
+            background_sequence(light_theme.ui.popup_bg),
+            foreground_sequence(light_theme.ui.popup_border),
+            foreground_sequence(light_theme.ui.foreground),
+            foreground_sequence(light_theme.syntax.function.fg),
+            foreground_sequence(light_theme.syntax.keyword.fg),
+            foreground_sequence(light_theme.syntax.type_.fg),
+        ] {
+            assert!(
+                light_render.contains(&sequence),
+                "hover render is missing theme sequence {sequence:?}"
+            );
+        }
+        for old_sequence in [
+            foreground_sequence(Color::Rgb {
+                r: 90,
+                g: 90,
+                b: 120,
+            }),
+            background_sequence(Color::Rgb {
+                r: 25,
+                g: 25,
+                b: 35,
+            }),
+            background_sequence(Color::Rgb {
+                r: 35,
+                g: 35,
+                b: 50,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 200,
+                g: 200,
+                b: 210,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 150,
+                g: 200,
+                b: 255,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 255,
+                g: 150,
+                b: 150,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 180,
+                g: 220,
+                b: 180,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 70,
+                g: 70,
+                b: 90,
+            }),
+        ] {
+            assert!(
+                !light_render.contains(&old_sequence),
+                "hover render leaked old palette sequence {old_sequence:?}"
+            );
+        }
+
+        assert!(editor.set_theme("onedark"));
+        let dark_theme = editor.theme().clone();
+        let dark_render = render_hover_to_string(&editor);
+        assert!(dark_render.contains(&background_sequence(dark_theme.ui.popup_bg)));
+        assert_ne!(light_theme.ui.popup_bg, dark_theme.ui.popup_bg);
         assert_ne!(light_render, dark_render);
     }
 

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -104,6 +104,33 @@ enum HoverLineType {
     Separator,
 }
 
+fn completion_kind_color(kind: CompletionKind, theme: &crate::theme::Theme) -> Color {
+    match kind {
+        CompletionKind::Text => theme.ui.foreground,
+        CompletionKind::Method => theme.syntax.method.fg,
+        CompletionKind::Function => theme.syntax.function.fg,
+        CompletionKind::Constructor => theme.syntax.constructor.fg,
+        CompletionKind::Field | CompletionKind::Property => theme.syntax.property.fg,
+        CompletionKind::Variable | CompletionKind::Reference => theme.syntax.variable.fg,
+        CompletionKind::Class
+        | CompletionKind::Interface
+        | CompletionKind::Unit
+        | CompletionKind::Enum
+        | CompletionKind::Struct
+        | CompletionKind::TypeParameter => theme.syntax.type_.fg,
+        CompletionKind::Module => theme.syntax.namespace.fg,
+        CompletionKind::Value
+        | CompletionKind::Color
+        | CompletionKind::EnumMember
+        | CompletionKind::Constant => theme.syntax.constant.fg,
+        CompletionKind::Keyword => theme.syntax.keyword.fg,
+        CompletionKind::Snippet => theme.syntax.embedded.fg,
+        CompletionKind::File | CompletionKind::Folder => theme.syntax.string.fg,
+        CompletionKind::Event => theme.syntax.label.fg,
+        CompletionKind::Operator => theme.syntax.operator.fg,
+    }
+}
+
 /// A wrapped segment of a line
 #[derive(Debug, Clone)]
 struct WrapSegment {
@@ -3400,6 +3427,7 @@ impl Terminal {
     /// Render the completion popup with documentation
     fn render_completion(&mut self, editor: &Editor) -> anyhow::Result<()> {
         let completion = &editor.completion;
+        let theme = editor.theme();
         // Use filtered list instead of raw items
         if completion.filtered.is_empty() {
             return Ok(());
@@ -3463,32 +3491,13 @@ impl Terminal {
         };
         let popup_x = popup_screen_col.min(editor.term_width.saturating_sub(popup_width + 2));
 
-        // Colors (Zed-inspired dark theme)
-        let border_color = Color::Rgb {
-            r: 55,
-            g: 55,
-            b: 65,
-        };
-        let bg_color = Color::Rgb {
-            r: 30,
-            g: 30,
-            b: 36,
-        };
-        let selected_bg = Color::Rgb {
-            r: 55,
-            g: 65,
-            b: 95,
-        };
-        let detail_color = Color::Rgb {
-            r: 100,
-            g: 100,
-            b: 115,
-        };
-        let doc_bg = Color::Rgb {
-            r: 35,
-            g: 35,
-            b: 42,
-        };
+        let border_color = theme.ui.completion_border;
+        let bg_color = theme.ui.completion_bg;
+        let selected_bg = theme.ui.completion_selected;
+        let detail_color = theme.ui.completion_detail;
+        let text_color = theme.ui.foreground;
+        let doc_bg = theme.ui.completion_bg;
+        let signature_color = theme.syntax.function.fg;
 
         // Draw top border (rounded corners for Zed-style)
         execute!(self.stdout, cursor::MoveTo(popup_x, popup_y))?;
@@ -3537,22 +3546,11 @@ impl Terminal {
             execute!(self.stdout, SetBackgroundColor(item_bg))?;
 
             // Kind indicator (colored per-kind)
-            let (r, g, b) = item.kind.color();
-            let kind_color = Color::Rgb { r, g, b };
+            let kind_color = completion_kind_color(item.kind, theme);
             execute!(self.stdout, SetForegroundColor(kind_color))?;
             terminal_print!(self, " {} ", item.kind.short_name());
 
-            // Label (brighter when selected)
-            let label_color = if is_selected {
-                Color::White
-            } else {
-                Color::Rgb {
-                    r: 220,
-                    g: 220,
-                    b: 225,
-                }
-            };
-            execute!(self.stdout, SetForegroundColor(label_color))?;
+            execute!(self.stdout, SetForegroundColor(text_color))?;
             let available_label_width = (popup_width as usize).saturating_sub(detail_col_width + 7);
             let label = if item.label.len() > available_label_width {
                 format!(
@@ -3627,12 +3625,12 @@ impl Terminal {
                                 current_line.push(' ');
                                 current_line.push_str(word);
                             } else {
-                                doc_lines.push((current_line, Color::Cyan));
+                                doc_lines.push((current_line, signature_color));
                                 current_line = word.to_string();
                             }
                         }
                         if !current_line.is_empty() {
-                            doc_lines.push((current_line, Color::Cyan));
+                            doc_lines.push((current_line, signature_color));
                         }
                     }
 
@@ -3655,14 +3653,7 @@ impl Terminal {
                             }
                             // Wrap long lines
                             if line.len() <= content_width {
-                                doc_lines.push((
-                                    line.to_string(),
-                                    Color::Rgb {
-                                        r: 180,
-                                        g: 180,
-                                        b: 180,
-                                    },
-                                ));
+                                doc_lines.push((line.to_string(), text_color));
                             } else {
                                 // Simple word wrap
                                 let words: Vec<&str> = line.split_whitespace().collect();
@@ -3674,26 +3665,12 @@ impl Terminal {
                                         current_line.push(' ');
                                         current_line.push_str(word);
                                     } else {
-                                        doc_lines.push((
-                                            current_line,
-                                            Color::Rgb {
-                                                r: 180,
-                                                g: 180,
-                                                b: 180,
-                                            },
-                                        ));
+                                        doc_lines.push((current_line, text_color));
                                         current_line = word.to_string();
                                     }
                                 }
                                 if !current_line.is_empty() {
-                                    doc_lines.push((
-                                        current_line,
-                                        Color::Rgb {
-                                            r: 180,
-                                            g: 180,
-                                            b: 180,
-                                        },
-                                    ));
+                                    doc_lines.push((current_line, text_color));
                                 }
                             }
                         }
@@ -3704,7 +3681,7 @@ impl Terminal {
                         let sig_line_count = if item.detail.is_some() {
                             doc_lines
                                 .iter()
-                                .take_while(|(_, c)| *c == Color::Cyan)
+                                .take_while(|(_, color)| *color == signature_color)
                                 .count()
                         } else {
                             0
@@ -10749,7 +10726,7 @@ mod tests {
     use crate::lsp::types::{CompletionItem, CompletionKind, Diagnostic, DiagnosticSeverity};
     use crate::syntax::{HighlightSpan, SyntaxStyle};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-    use crossterm::style::{Color, SetBackgroundColor};
+    use crossterm::style::{Color, SetBackgroundColor, SetForegroundColor};
     use std::cell::RefCell;
     use std::fmt::Write as FmtWrite;
     use std::io::{self, Write};
@@ -10834,6 +10811,16 @@ mod tests {
         output.into_string()
     }
 
+    fn render_completion_to_string(editor: &Editor) -> String {
+        crossterm::style::force_color_output(true);
+        let output = SharedOutput::default();
+        let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
+        terminal
+            .render_completion(editor)
+            .expect("completion render should succeed");
+        output.into_string()
+    }
+
     fn measure_render(editor: &Editor) -> Duration {
         crossterm::style::force_color_output(true);
         let output = SharedOutput::default();
@@ -10903,6 +10890,86 @@ mod tests {
         let mut output = Vec::new();
         crossterm::execute!(output, SetBackgroundColor(color)).expect("write ansi background");
         String::from_utf8(output).expect("ansi background should be utf-8")
+    }
+
+    fn foreground_sequence(color: Color) -> String {
+        let mut output = Vec::new();
+        crossterm::execute!(output, SetForegroundColor(color)).expect("write ansi foreground");
+        String::from_utf8(output).expect("ansi foreground should be utf-8")
+    }
+
+    #[test]
+    fn completion_render_uses_active_theme_colors() {
+        let mut editor = Editor::default();
+        editor.set_size(160, 30);
+        editor.replace_buffer_content("dem\n");
+        editor.mode = Mode::Insert;
+        editor.cursor.col = 3;
+        assert!(editor.set_theme("github-light"));
+        editor.show_completions(
+            vec![CompletionItem {
+                item_id: 1,
+                label: "demo".to_string(),
+                kind: CompletionKind::Function,
+                detail: Some("fn demo(value: ExampleType)".to_string()),
+                documentation: Some("Returns an example value.".to_string()),
+                insert_text: None,
+                filter_text: None,
+                sort_text: Some("01".to_string()),
+                text_edit: None,
+                additional_text_edits: Vec::new(),
+                raw_data: None,
+            }],
+            0,
+            0,
+            false,
+        );
+
+        let light_theme = editor.theme().clone();
+        let light_render = render_completion_to_string(&editor);
+        for sequence in [
+            background_sequence(light_theme.ui.completion_bg),
+            background_sequence(light_theme.ui.completion_selected),
+            foreground_sequence(light_theme.ui.completion_border),
+            foreground_sequence(light_theme.ui.completion_detail),
+            foreground_sequence(light_theme.ui.foreground),
+            foreground_sequence(light_theme.syntax.function.fg),
+        ] {
+            assert!(
+                light_render.contains(&sequence),
+                "completion render is missing theme sequence {sequence:?}"
+            );
+        }
+        for old_sequence in [
+            background_sequence(Color::Rgb {
+                r: 30,
+                g: 30,
+                b: 36,
+            }),
+            background_sequence(Color::Rgb {
+                r: 35,
+                g: 35,
+                b: 42,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 220,
+                g: 220,
+                b: 225,
+            }),
+            foreground_sequence(Color::Cyan),
+        ] {
+            assert!(
+                !light_render.contains(&old_sequence),
+                "completion render leaked old palette sequence {old_sequence:?}"
+            );
+        }
+
+        assert!(editor.set_theme("onedark"));
+        let dark_theme = editor.theme().clone();
+        let dark_render = render_completion_to_string(&editor);
+        assert!(dark_render.contains(&background_sequence(dark_theme.ui.completion_bg)));
+        assert_ne!(light_theme.ui.completion_bg, dark_theme.ui.completion_bg);
+        assert_ne!(light_render, dark_render);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -4371,17 +4371,18 @@ impl Terminal {
         if diagnostics.is_empty() {
             return Ok(());
         }
+        let theme = editor.theme();
 
         // Prepare diagnostic lines with numbers
         let mut lines: Vec<(Color, String)> = Vec::new();
-        lines.push((Color::White, "Diagnostics:".to_string()));
+        lines.push((theme.ui.foreground, "Diagnostics:".to_string()));
 
         for (idx, diag) in diagnostics.iter().enumerate() {
             let (color, prefix) = match diag.severity {
-                DiagnosticSeverity::Error => (Color::Red, ""),
-                DiagnosticSeverity::Warning => (Color::Yellow, ""),
-                DiagnosticSeverity::Information => (Color::Blue, ""),
-                DiagnosticSeverity::Hint => (Color::Cyan, ""),
+                DiagnosticSeverity::Error => (theme.diagnostic.error, ""),
+                DiagnosticSeverity::Warning => (theme.diagnostic.warning, ""),
+                DiagnosticSeverity::Information => (theme.diagnostic.info, ""),
+                DiagnosticSeverity::Hint => (theme.diagnostic.hint, ""),
             };
 
             // Split message into lines and indent continuation lines
@@ -4408,22 +4409,9 @@ impl Terminal {
         // Position at the active pane's text area, below the cursor line.
         let (popup_x, popup_y) = Self::diagnostic_float_position(editor, popup_width, popup_height);
 
-        // Colors
-        let border_color = Color::Rgb {
-            r: 100,
-            g: 100,
-            b: 140,
-        };
-        let bg_color = Color::Rgb {
-            r: 30,
-            g: 30,
-            b: 45,
-        };
-        let title_color = Color::Rgb {
-            r: 180,
-            g: 180,
-            b: 200,
-        };
+        let border_color = theme.ui.popup_border;
+        let bg_color = theme.ui.popup_bg;
+        let title_color = theme.ui.foreground;
 
         // Draw top border with title
         execute!(self.stdout, cursor::MoveTo(popup_x, popup_y))?;
@@ -5515,7 +5503,8 @@ impl Terminal {
         queue!(
             self.stdout,
             cursor::MoveTo(win.x, win.y),
-            SetForegroundColor(border_color)
+            SetForegroundColor(border_color),
+            SetBackgroundColor(finder_bg)
         )?;
         write!(self.stdout, "\u{250c}")?; // ┌
         let title = match editor.finder.mode {
@@ -10799,6 +10788,28 @@ mod tests {
         output.into_string()
     }
 
+    fn render_diagnostic_float_to_string(editor: &Editor) -> String {
+        crossterm::style::force_color_output(true);
+        let output = SharedOutput::default();
+        let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
+        terminal
+            .render_diagnostic_float(editor)
+            .expect("diagnostic float render should succeed");
+        output.into_string()
+    }
+
+    fn render_finder_to_string(editor: &Editor, inherited_background: Color) -> String {
+        crossterm::style::force_color_output(true);
+        let output = SharedOutput::default();
+        let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
+        crossterm::execute!(terminal.stdout, SetBackgroundColor(inherited_background))
+            .expect("seed inherited terminal background");
+        terminal
+            .render_finder(editor)
+            .expect("finder render should succeed");
+        output.into_string()
+    }
+
     fn measure_render(editor: &Editor) -> Duration {
         crossterm::style::force_color_output(true);
         let output = SharedOutput::default();
@@ -10874,6 +10885,13 @@ mod tests {
         let mut output = Vec::new();
         crossterm::execute!(output, SetForegroundColor(color)).expect("write ansi foreground");
         String::from_utf8(output).expect("ansi foreground should be utf-8")
+    }
+
+    fn cursor_position_sequence(x: u16, y: u16) -> String {
+        let mut output = Vec::new();
+        crossterm::execute!(output, crossterm::cursor::MoveTo(x, y))
+            .expect("write cursor position");
+        String::from_utf8(output).expect("ansi cursor position should be utf-8")
     }
 
     #[test]
@@ -11029,6 +11047,115 @@ mod tests {
         assert!(dark_render.contains(&background_sequence(dark_theme.ui.popup_bg)));
         assert_ne!(light_theme.ui.popup_bg, dark_theme.ui.popup_bg);
         assert_ne!(light_render, dark_render);
+    }
+
+    #[test]
+    fn diagnostic_float_render_uses_active_theme_colors() {
+        let root = unique_temp_dir("nevi_diagnostic_float_theme");
+        std::fs::create_dir_all(&root).expect("create temp dir");
+        let path = root.join("diagnostic.rs");
+        std::fs::write(&path, "demo\n").expect("write diagnostic fixture");
+
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor
+            .open_file(path.clone())
+            .expect("open diagnostic fixture");
+        editor.set_diagnostics(
+            crate::lsp::path_to_uri(&path),
+            vec![
+                diagnostic(0, 0, 4, DiagnosticSeverity::Error),
+                diagnostic(0, 0, 4, DiagnosticSeverity::Warning),
+                diagnostic(0, 0, 4, DiagnosticSeverity::Information),
+                diagnostic(0, 0, 4, DiagnosticSeverity::Hint),
+            ],
+        );
+        editor.show_diagnostic_float = true;
+        assert!(editor.set_theme("github-light"));
+
+        let light_theme = editor.theme().clone();
+        let light_render = render_diagnostic_float_to_string(&editor);
+        for sequence in [
+            background_sequence(light_theme.ui.popup_bg),
+            foreground_sequence(light_theme.ui.popup_border),
+            foreground_sequence(light_theme.ui.foreground),
+            foreground_sequence(light_theme.diagnostic.error),
+            foreground_sequence(light_theme.diagnostic.warning),
+            foreground_sequence(light_theme.diagnostic.info),
+            foreground_sequence(light_theme.diagnostic.hint),
+        ] {
+            assert!(
+                light_render.contains(&sequence),
+                "diagnostic float render is missing theme sequence {sequence:?}"
+            );
+        }
+        for old_sequence in [
+            background_sequence(Color::Rgb {
+                r: 30,
+                g: 30,
+                b: 45,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 100,
+                g: 100,
+                b: 140,
+            }),
+            foreground_sequence(Color::Rgb {
+                r: 180,
+                g: 180,
+                b: 200,
+            }),
+        ] {
+            assert!(
+                !light_render.contains(&old_sequence),
+                "diagnostic float render leaked old palette sequence {old_sequence:?}"
+            );
+        }
+
+        assert!(editor.set_theme("onedark"));
+        let dark_theme = editor.theme().clone();
+        let dark_render = render_diagnostic_float_to_string(&editor);
+        assert!(dark_render.contains(&background_sequence(dark_theme.ui.popup_bg)));
+        assert_ne!(light_theme.ui.popup_bg, dark_theme.ui.popup_bg);
+        assert_ne!(light_render, dark_render);
+
+        std::fs::remove_dir_all(root).expect("remove temp dir");
+    }
+
+    #[test]
+    fn finder_first_frame_sets_active_theme_background_before_top_border() {
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor
+            .finder
+            .open_harpoon(vec![PathBuf::from("manual-theme-test.rs")]);
+        editor.finder.preview_enabled = true;
+        editor.mode = Mode::Finder;
+
+        for (theme_name, inherited_background) in
+            [("github-light", Color::Black), ("onedark", Color::White)]
+        {
+            assert!(editor.set_theme(theme_name));
+            let theme = editor.theme().clone();
+            let win = crate::finder::FloatingWindow::centered_with_preview(
+                editor.term_width,
+                editor.term_height,
+                true,
+            );
+            let rendered = render_finder_to_string(&editor, inherited_background);
+            let expected_top_border = format!(
+                "{}{}{}┌",
+                cursor_position_sequence(win.x, win.y),
+                foreground_sequence(theme.ui.finder_border),
+                background_sequence(theme.ui.finder_bg),
+            );
+            let rendered_prefix: String = rendered.chars().take(80).collect();
+
+            assert!(
+                rendered.contains(&expected_top_border),
+                "finder top border should establish {theme_name} background on its first frame; expected={expected_top_border:?}, actual prefix={rendered_prefix:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/theme/bundled.rs
+++ b/src/theme/bundled.rs
@@ -19,6 +19,7 @@ const KANAGAWA_TOML: &str = include_str!("../../themes/kanagawa.toml");
 const MONOKAI_TOML: &str = include_str!("../../themes/monokai.toml");
 const EVERFOREST_TOML: &str = include_str!("../../themes/everforest.toml");
 const GITHUB_DARK_TOML: &str = include_str!("../../themes/github-dark.toml");
+const GITHUB_LIGHT_TOML: &str = include_str!("../../themes/github-light.toml");
 const AYU_DARK_TOML: &str = include_str!("../../themes/ayu-dark.toml");
 const PALENIGHT_TOML: &str = include_str!("../../themes/palenight.toml");
 const NIGHTFOX_TOML: &str = include_str!("../../themes/nightfox.toml");
@@ -82,6 +83,10 @@ pub fn get_bundled_themes() -> Vec<Theme> {
         themes.push(theme);
     }
 
+    if let Some(theme) = load_theme_from_toml("github-light", GITHUB_LIGHT_TOML) {
+        themes.push(theme);
+    }
+
     if let Some(theme) = load_theme_from_toml("ayu-dark", AYU_DARK_TOML) {
         themes.push(theme);
     }
@@ -113,8 +118,67 @@ pub fn bundled_theme_names() -> Vec<&'static str> {
         "monokai",
         "everforest",
         "github-dark",
+        "github-light",
         "ayu-dark",
         "palenight",
         "nightfox",
     ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{bundled_theme_names, get_bundled_themes};
+    use crossterm::style::Color;
+
+    #[test]
+    fn github_light_is_a_complete_bundled_theme() {
+        assert!(bundled_theme_names().contains(&"github-light"));
+
+        let themes = get_bundled_themes();
+        let theme = themes
+            .iter()
+            .find(|theme| theme.name == "github-light")
+            .expect("github-light should load");
+
+        assert_eq!(
+            theme.ui.background,
+            Color::Rgb {
+                r: 255,
+                g: 255,
+                b: 255
+            }
+        );
+        assert_eq!(
+            theme.ui.foreground,
+            Color::Rgb {
+                r: 31,
+                g: 35,
+                b: 40
+            }
+        );
+        assert_eq!(
+            theme.ui.popup_bg,
+            Color::Rgb {
+                r: 246,
+                g: 248,
+                b: 250
+            }
+        );
+        assert_eq!(
+            theme.ui.completion_bg,
+            Color::Rgb {
+                r: 246,
+                g: 248,
+                b: 250
+            }
+        );
+        assert_eq!(
+            theme.syntax.keyword.fg,
+            Color::Rgb {
+                r: 207,
+                g: 34,
+                b: 46
+            }
+        );
+    }
 }

--- a/themes/github-light.toml
+++ b/themes/github-light.toml
@@ -1,0 +1,107 @@
+# GitHub Light Theme for Nevi
+# Palette and token roles follow GitHub Primer/GitHub VS Code Theme.
+
+[palette]
+canvas_default = "#ffffff"
+canvas_subtle = "#f6f8fa"
+fg_default = "#1f2328"
+fg_muted = "#656d76"
+fg_subtle = "#6e7781"
+border_default = "#d0d7de"
+accent_fg = "#0969da"
+success_fg = "#1a7f37"
+attention_fg = "#9a6700"
+danger_fg = "#cf222e"
+done_fg = "#8250df"
+syntax_comment = "#6e7781"
+syntax_constant = "#0550ae"
+syntax_entity = "#8250df"
+syntax_keyword = "#cf222e"
+syntax_string = "#0a3069"
+syntax_variable = "#953800"
+selection = "#ddf4ff"
+
+[syntax]
+keyword = { fg = "syntax_keyword" }
+function = { fg = "syntax_entity" }
+type = { fg = "syntax_constant" }
+string = { fg = "syntax_string" }
+number = { fg = "syntax_constant" }
+comment = { fg = "syntax_comment", italic = true }
+operator = { fg = "syntax_keyword" }
+punctuation = { fg = "fg_muted" }
+variable = { fg = "syntax_variable" }
+constant = { fg = "syntax_constant" }
+attribute = { fg = "syntax_constant" }
+namespace = { fg = "syntax_keyword" }
+label = { fg = "syntax_constant" }
+property = { fg = "syntax_constant" }
+tag = { fg = "success_fg" }
+embedded = { fg = "accent_fg" }
+macro = { fg = "syntax_entity" }
+method = { fg = "syntax_entity" }
+constructor = { fg = "syntax_constant" }
+boolean = { fg = "syntax_constant" }
+
+[ui]
+background = "canvas_default"
+foreground = "fg_default"
+cursor_line = "canvas_subtle"
+selection = "selection"
+line_number = "fg_subtle"
+line_number_active = "fg_default"
+visual_bg = "selection"
+
+[ui.statusline]
+background = "canvas_subtle"
+foreground = "fg_default"
+mode_normal = "accent_fg"
+mode_insert = "success_fg"
+mode_visual = "done_fg"
+mode_command = "attention_fg"
+mode_replace = "danger_fg"
+
+[ui.popup]
+background = "canvas_subtle"
+border = "border_default"
+selection = "selection"
+
+[ui.completion]
+background = "canvas_subtle"
+border = "border_default"
+selected = "selection"
+match = "attention_fg"
+detail = "fg_muted"
+
+[ui.finder]
+background = "canvas_default"
+border = "border_default"
+selected = "selection"
+match = "attention_fg"
+prompt = "accent_fg"
+
+[ui.search]
+match_bg = "#fff8c5"
+match_fg = "fg_default"
+
+[ui.explorer]
+background = "canvas_subtle"
+border = "border_default"
+selected = "selection"
+directory = "accent_fg"
+
+[ui.harpoon]
+background = "canvas_subtle"
+border = "border_default"
+selected = "selection"
+
+[diagnostic]
+error = "danger_fg"
+warning = "attention_fg"
+info = "accent_fg"
+hint = "done_fg"
+
+[git]
+added = "success_fg"
+modified = "attention_fg"
+deleted = "danger_fg"


### PR DESCRIPTION
## Summary

- use the active theme for completion, hover, and diagnostic popup colors
- add a bundled GitHub Light theme for light-theme coverage
- initialize the finder background on its first frame to prevent inherited dark borders
- add light/dark regression coverage for popup rendering and finder initialization

## Testing

- cargo test --quiet
- cargo fmt --check
- manually verified completion, hover, diagnostics, file finder, and terminal picker with GitHub Light

Closes #245