### PR TITLE
Add Bash/shell highlighting and LSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.3.0 - UNRELEASED
+
+- Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
+- Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).
+
 ## 0.2.0 - 2026-07-07
 
 Nevi 0.2.0 is a feature and performance release focused on making the editor

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -974,6 +974,7 @@ dependencies = [
  "toml",
  "toml_edit",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-css",
  "tree-sitter-go",
  "tree-sitter-html",
@@ -1175,7 +1176,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1846,6 +1847,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tree-sitter-python = "0.23"
 tree-sitter-php = "0.24.2"
 tree-sitter-go = "0.25.0"
 tree-sitter-ruby = "0.23.1"
+tree-sitter-bash = "0.25"
 streaming-iterator = "0.1"
 
 # System clipboard

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A fast, native terminal editor where your existing vim/neovim muscle memory just
 
 - **Vim/neovim keybindings** - Most common keybinds implemented, more being added regularly
 - **Built-in LSP** - rust-analyzer, typescript-language-server, pyright, and more
-- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, Go, Ruby, PHP, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown
+- **Tree-sitter syntax highlighting** - Fast, accurate highlighting for Rust, Go, Ruby, PHP, TypeScript, JavaScript, Python, CSS, JSON, TOML, HTML, Markdown, Bash/shell
 - **Theme selection** - Multiple built-in colorschemes with easy switching
 - **Fuzzy file finder** - Telescope-style file and content search
 - **Previewed project replace** - Project-wide literal replace with a read-only preview and explicit apply step
@@ -179,6 +179,7 @@ Optional tools unlock optional features:
 | PHP LSP | PHP 8.2+ and `phpactor` | `brew install php`, then `mkdir -p ~/.local/bin && curl -Lo phpactor.phar https://github.com/phpactor/phpactor/releases/latest/download/phpactor.phar && chmod +x phpactor.phar && mv phpactor.phar ~/.local/bin/phpactor` |
 | Go LSP | `gopls` | `go install golang.org/x/tools/gopls@latest` |
 | Ruby LSP | `ruby-lsp` | `gem install ruby-lsp` |
+| Shell / Bash LSP | `bash-language-server` | `npm install -g bash-language-server` |
 | Markdown LSP | `marksman` | Optional and disabled by default |
 | External formatters | Whatever formatter you configure | Examples: `biome`, `prettier`, `black`, `gofmt` |
 | Git signs / `:GitChanges` | A Git repository | No external `git` CLI required |
@@ -423,6 +424,7 @@ Visual mode (`v/V/Ctrl+v`), macros (`q{a-z}/@{a-z}`), marks (`m{a-z}/'`), read-o
 | TOML | taplo | Supported |
 | HTML | vscode-html-language-server | Supported |
 | Go | gopls | Supported |
+| Shell / Bash | bash-language-server | Supported |
 | Markdown | marksman | Optional, disabled by default |
 
 LSP servers are auto-detected when installed. See [`~/.config/nevi/config.toml`](#configuration) for LSP configuration options.

--- a/src/config/languages.rs
+++ b/src/config/languages.rs
@@ -176,6 +176,14 @@ fn default_languages_template() -> &'static str {
 # [go]
 # formatter = { command = "gofmt", args = [] }
 # tab_width = 4
+
+# ============================================================================
+# SHELL (shfmt)
+# Install: go install mvdan.cc/sh/v3/cmd/shfmt@latest
+# ============================================================================
+# [shell]
+# formatter = { command = "shfmt", args = ["-filename", "{file}", "-"] }
+# tab_width = 2
 "#
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -650,6 +650,7 @@ pub struct LspServers {
     pub php: LspServerConfig,
     pub go: LspServerConfig,
     pub ruby: LspServerConfig,
+    pub shell: LspServerConfig,
 }
 
 impl Default for LspServers {
@@ -785,6 +786,22 @@ impl Default for LspServers {
                     "gemspec".to_string(),
                     "ru".to_string(),
                     "podspec".to_string(),
+                ],
+            },
+            shell: LspServerConfig {
+                enabled: true,
+                preset: None,
+                command: "bash-language-server".to_string(),
+                args: vec!["start".to_string()],
+                root_patterns: Vec::new(),
+                file_extensions: vec![
+                    "sh".to_string(),
+                    "bash".to_string(),
+                    "zsh".to_string(),
+                    "ksh".to_string(),
+                    "bats".to_string(),
+                    "ebuild".to_string(),
+                    "eclass".to_string(),
                 ],
             },
         }
@@ -1453,7 +1470,7 @@ fn default_config_template() -> &'static str {
 # LSP servers are auto-detected and enabled by default.
 # Supported: rust-analyzer, typescript-language-server, vscode-css-language-server,
 # vscode-json-language-server, taplo, vscode-html-language-server, pyright-langserver,
-# phpactor, gopls, ruby-lsp
+# phpactor, gopls, ruby-lsp, bash-language-server
 # Optional: marksman for Markdown (disabled by default)
 #
 # To disable LSP entirely:
@@ -1599,6 +1616,7 @@ fn merge_lsp_servers_with_defaults(user: LspServers) -> LspServers {
         php: merge_lsp_server_config(defaults.php, user.php),
         go: merge_lsp_server_config(defaults.go, user.go),
         ruby: merge_lsp_server_config(defaults.ruby, user.ruby),
+        shell: merge_lsp_server_config(defaults.shell, user.shell),
     }
 }
 
@@ -1789,6 +1807,33 @@ mod tests {
                 "gemspec".to_string(),
                 "ru".to_string(),
                 "podspec".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn shell_lsp_defaults_use_bash_language_server() {
+        let settings = Settings::default();
+
+        assert_eq!(
+            settings.lsp.servers.shell.effective_command(),
+            "bash-language-server"
+        );
+        assert_eq!(
+            settings.lsp.servers.shell.effective_args(),
+            vec!["start".to_string()]
+        );
+        assert!(settings.lsp.servers.shell.root_patterns.is_empty());
+        assert_eq!(
+            settings.lsp.servers.shell.file_extensions,
+            vec![
+                "sh".to_string(),
+                "bash".to_string(),
+                "zsh".to_string(),
+                "ksh".to_string(),
+                "bats".to_string(),
+                "ebuild".to_string(),
+                "eclass".to_string()
             ]
         );
     }

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -5,6 +5,9 @@ use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+/// Unicode scalar values taken from the first line for shebang detection.
+const FIRST_LINE_PREFIX_CHARS: usize = 256;
+
 /// A text buffer backed by a rope data structure.
 /// Ropes provide O(log n) insertions and deletions, making them
 /// ideal for text editors.
@@ -226,9 +229,11 @@ impl Buffer {
         }
     }
 
-    /// First line including a trailing newline if present.
-    pub fn first_line(&self) -> Option<String> {
-        self.line(0).map(|line| line.chars().collect())
+    /// Prefix of the first line, including a trailing newline when it falls
+    /// inside the cap. Capped at [`FIRST_LINE_PREFIX_CHARS`] Unicode scalar values.
+    pub fn first_line_prefix(&self) -> Option<String> {
+        self.line(0)
+            .map(|line| line.chars().take(FIRST_LINE_PREFIX_CHARS).collect())
     }
 
     /// Get the length of a specific line (excluding newline)
@@ -622,6 +627,25 @@ mod tests {
                 "content={content:?}"
             );
         }
+    }
+
+    #[test]
+    fn first_line_prefix_returns_short_first_line_including_newline() {
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, "#!/usr/bin/env bash\nrest\n");
+        assert_eq!(
+            buffer.first_line_prefix().as_deref(),
+            Some("#!/usr/bin/env bash\n")
+        );
+    }
+
+    #[test]
+    fn first_line_prefix_caps_at_256_chars_not_the_whole_line() {
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, &"a".repeat(1000));
+        let prefix = buffer.first_line_prefix().expect("first line");
+        assert_eq!(prefix.chars().count(), super::FIRST_LINE_PREFIX_CHARS);
+        assert_eq!(prefix, "a".repeat(super::FIRST_LINE_PREFIX_CHARS));
     }
 
     #[test]

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -226,6 +226,11 @@ impl Buffer {
         }
     }
 
+    /// First line including a trailing newline if present.
+    pub fn first_line(&self) -> Option<String> {
+        self.line(0).map(|line| line.chars().collect())
+    }
+
     /// Get the length of a specific line (excluding newline)
     pub fn line_len(&self, idx: usize) -> usize {
         self.line(idx)

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1673,17 +1673,15 @@ impl Editor {
             "py" | "pyi" | "pyw" => "python".to_string(),
             "go" => "go".to_string(),
             "yaml" | "yml" => "yaml".to_string(),
-            "sh" | "bash" | "zsh" => "shell".to_string(),
+            "sh" | "bash" | "zsh" | "ksh" | "bats" => "shell".to_string(),
             _ => ext_lower,
         }
     }
 
     /// Get the formatter config for the current buffer (if any)
     pub fn get_current_formatter(&self) -> Option<&crate::config::FormatterConfig> {
-        let buffer = self.buffer();
-        let path = buffer.path.as_ref()?;
-        let ext = path.extension()?.to_str()?;
-        let language = Self::extension_to_language(ext);
+        let path = self.buffer().path.as_ref()?;
+        let language = Self::config_language_for_path(path)?;
         self.languages_config.get_formatter(&language)
     }
 
@@ -1694,8 +1692,7 @@ impl Editor {
     ) -> Option<&crate::config::FormatterConfig> {
         let buffer = self.buffers.get(buffer_idx)?;
         let path = buffer.path.as_ref()?;
-        let ext = path.extension()?.to_str()?;
-        let language = Self::extension_to_language(ext);
+        let language = Self::config_language_for_path(path)?;
         self.languages_config.get_formatter(&language)
     }
 
@@ -1703,14 +1700,22 @@ impl Editor {
     /// Returns language-specific override or falls back to editor default
     pub fn get_effective_tab_width(&self) -> usize {
         if let Some(path) = self.buffer().path.as_ref() {
-            if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                let language = Self::extension_to_language(ext);
+            if let Some(language) = Self::config_language_for_path(path) {
                 if let Some(tab_width) = self.languages_config.get_tab_width(&language) {
                     return tab_width;
                 }
             }
         }
         self.settings.editor.tab_width
+    }
+
+    fn config_language_for_path(path: &std::path::Path) -> Option<String> {
+        if crate::syntax::is_shell_path(path) {
+            return Some("shell".to_string());
+        }
+        path.extension()
+            .and_then(|e| e.to_str())
+            .map(Self::extension_to_language)
     }
 
     /// Get the current theme
@@ -2794,11 +2799,12 @@ impl Editor {
     }
 
     fn sync_syntax_to_current_buffer(&mut self) {
-        let syntax_hint = self.buffers[self.current_buffer_idx]
-            .syntax_hint_path()
-            .cloned();
-        self.syntax
-            .set_language_from_path_option(syntax_hint.as_ref());
+        let syntax_hint = self.buffer().syntax_hint_path().cloned();
+        let first_line = self.buffer().first_line();
+        self.syntax.set_language_from_path_option_and_first_line(
+            syntax_hint.as_ref(),
+            first_line.as_deref(),
+        );
         self.parse_current_buffer();
     }
 
@@ -3457,20 +3463,19 @@ impl Editor {
                 self.panes[self.active_pane].h_offset = self.h_offset;
             }
             // Re-parse syntax for this buffer
-            self.syntax.set_language_from_path(&path);
+            let first_line = self.buffer().first_line();
+            self.syntax
+                .set_language_from_path_and_first_line(&path, first_line.as_deref());
             self.parse_current_buffer();
             // Update git diff for this buffer
             self.update_git_diff();
             return Ok(());
         }
 
-        // Set up syntax highlighting based on file extension
-        self.syntax.set_language_from_path(&path);
-
         let new_buffer = if read_only {
-            Buffer::from_file_read_only(path)?
+            Buffer::from_file_read_only(path.clone())?
         } else {
-            Buffer::from_file(path)?
+            Buffer::from_file(path.clone())?
         };
 
         // If current buffer is empty and unnamed, replace it; otherwise add new buffer
@@ -3504,6 +3509,11 @@ impl Editor {
             self.panes[self.active_pane].viewport_offset = self.viewport_offset;
             self.panes[self.active_pane].h_offset = self.h_offset;
         }
+
+        // Set up syntax highlighting from path, then shebang if needed
+        let first_line = self.buffer().first_line();
+        self.syntax
+            .set_language_from_path_and_first_line(&path, first_line.as_deref());
 
         // Parse the buffer for syntax highlighting
         self.parse_current_buffer();
@@ -3573,9 +3583,11 @@ impl Editor {
 
     /// Set the path of the current buffer (for rename operations)
     pub fn set_buffer_path(&mut self, path: std::path::PathBuf) {
-        self.buffers[self.current_buffer_idx].set_file_path(path.clone());
+        self.buffer_mut().set_file_path(path.clone());
         // Update syntax highlighting for new filename
-        self.syntax.set_language_from_path(&path);
+        let first_line = self.buffer().first_line();
+        self.syntax
+            .set_language_from_path_and_first_line(&path, first_line.as_deref());
         self.parse_current_buffer();
     }
 
@@ -10828,7 +10840,9 @@ impl Editor {
         }
 
         // Set up syntax highlighting for the preview file
-        self.preview_syntax.set_language_from_path(&selected_path);
+        let first_line = self.finder.preview_content.first().map(|s| s.as_str());
+        self.preview_syntax
+            .set_language_from_path_and_first_line(&selected_path, first_line);
 
         // Sync theme
         self.preview_syntax.sync_theme(self.theme_manager.theme());
@@ -11203,6 +11217,34 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn bashrc_uses_shell_languages_toml_settings() {
+        use crate::config::{FormatterConfig, LanguageConfig, LanguagesConfig};
+        use std::collections::HashMap;
+
+        let mut editor = Editor::default();
+        editor.set_buffer_path(PathBuf::from("/home/me/.bashrc"));
+        editor.languages_config = LanguagesConfig {
+            languages: HashMap::from([(
+                "shell".to_string(),
+                LanguageConfig {
+                    formatter: Some(FormatterConfig {
+                        command: "shfmt".to_string(),
+                        args: vec!["-".to_string()],
+                        timeout: 5,
+                    }),
+                    tab_width: Some(2),
+                },
+            )]),
+        };
+
+        assert_eq!(
+            editor.get_current_formatter().map(|f| f.command.as_str()),
+            Some("shfmt")
+        );
+        assert_eq!(editor.get_effective_tab_width(), 2);
     }
 
     fn commit_file(repo: &git2::Repository, relative_path: &Path, message: &str) {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2841,7 +2841,7 @@ impl Editor {
 
     fn sync_syntax_to_current_buffer(&mut self) {
         let syntax_hint = self.buffer().syntax_hint_path().cloned();
-        let first_line = self.buffer().first_line();
+        let first_line = self.buffer().first_line_prefix();
         self.syntax.set_language_from_path_option_and_first_line(
             syntax_hint.as_ref(),
             first_line.as_deref(),
@@ -3504,7 +3504,7 @@ impl Editor {
                 self.panes[self.active_pane].h_offset = self.h_offset;
             }
             // Re-parse syntax for this buffer
-            let first_line = self.buffer().first_line();
+            let first_line = self.buffer().first_line_prefix();
             self.syntax
                 .set_language_from_path_and_first_line(&path, first_line.as_deref());
             self.parse_current_buffer();
@@ -3552,7 +3552,7 @@ impl Editor {
         }
 
         // Set up syntax highlighting from path, then shebang if needed
-        let first_line = self.buffer().first_line();
+        let first_line = self.buffer().first_line_prefix();
         self.syntax
             .set_language_from_path_and_first_line(&path, first_line.as_deref());
 
@@ -3626,7 +3626,7 @@ impl Editor {
     pub fn set_buffer_path(&mut self, path: std::path::PathBuf) {
         self.buffer_mut().set_file_path(path.clone());
         // Update syntax highlighting for new filename
-        let first_line = self.buffer().first_line();
+        let first_line = self.buffer().first_line_prefix();
         self.syntax
             .set_language_from_path_and_first_line(&path, first_line.as_deref());
         self.parse_current_buffer();

--- a/src/health.rs
+++ b/src/health.rs
@@ -502,6 +502,7 @@ where
         command_tool_health_if_enabled("php", &servers.php, is_command_available),
         command_tool_health_if_enabled("go", &servers.go, is_command_available),
         command_tool_health_if_enabled("ruby", &servers.ruby, is_command_available),
+        command_tool_health_if_enabled("shell", &servers.shell, is_command_available),
     ]
     .into_iter()
     .flatten()
@@ -671,6 +672,7 @@ fn lsp_server_health(settings: &crate::config::Settings) -> Vec<LspServerHealth>
         server_health("php", &servers.php),
         server_health("go", &servers.go),
         server_health("ruby", &servers.ruby),
+        server_health("shell", &servers.shell),
     ]
 }
 

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -118,7 +118,7 @@ impl LspManager {
     /// Notify that a document was opened
     pub fn did_open(&self, path: &PathBuf, text: &str) -> anyhow::Result<()> {
         let uri = path_to_uri(path);
-        let language_id = detect_language(path);
+        let language_id = detect_language_for_document(path, text);
         self.send(LspRequest::DidOpen {
             uri,
             language_id,
@@ -605,9 +605,13 @@ pub fn uri_to_path(uri: &str) -> Option<PathBuf> {
     Url::parse(uri).ok().and_then(|url| url.to_file_path().ok())
 }
 
-/// Detect language ID from file extension
-fn detect_language(path: &PathBuf) -> String {
-    match path.extension().and_then(|e| e.to_str()) {
+/// Detect the LSP `languageId` for a document from path, then shebang if needed.
+fn detect_language_for_document(path: &PathBuf, text: &str) -> String {
+    if crate::syntax::is_shell_path(path) {
+        return "shellscript".to_string();
+    }
+
+    let from_path = match path.extension().and_then(|e| e.to_str()) {
         Some("rs") => "rust".to_string(),
         Some("py") | Some("pyi") | Some("pyw") => "python".to_string(),
         Some("js") => "javascript".to_string(),
@@ -643,12 +647,22 @@ fn detect_language(path: &PathBuf) -> String {
         Some("sql") => "sql".to_string(),
         Some("sh") | Some("bash") => "shellscript".to_string(),
         _ => "plaintext".to_string(),
+    };
+
+    if from_path != "plaintext" {
+        return from_path;
     }
+
+    if crate::syntax::shebang_is_shell(text.lines().next().unwrap_or("")) {
+        return "shellscript".to_string();
+    }
+
+    from_path
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{detect_language, join_thread_with_timeout};
+    use super::{detect_language_for_document, join_thread_with_timeout};
     use std::path::PathBuf;
     use std::sync::mpsc;
     use std::thread;
@@ -689,10 +703,35 @@ mod tests {
             ("file.gemspec", "ruby"),
             ("config.ru", "ruby"),
             ("file.podspec", "ruby"),
+            ("file.sh", "shellscript"),
+            ("file.bash", "shellscript"),
+            ("file.zsh", "shellscript"),
+            (".zshrc", "shellscript"),
+            (".bashrc", "shellscript"),
+            (".bash_profile", "shellscript"),
         ];
 
         for (path, language) in cases {
-            assert_eq!(detect_language(&PathBuf::from(path)), language);
+            assert_eq!(
+                detect_language_for_document(&PathBuf::from(path), ""),
+                language
+            );
         }
+    }
+
+    #[test]
+    fn detect_language_uses_shell_shebang_for_extensionless_files() {
+        assert_eq!(
+            detect_language_for_document(&PathBuf::from("bin/deploy"), "#!/usr/bin/env bash\n"),
+            "shellscript"
+        );
+        assert_eq!(
+            detect_language_for_document(&PathBuf::from("bin/deploy"), "#!/usr/bin/env python3\n"),
+            "plaintext"
+        );
+        assert_eq!(
+            detect_language_for_document(&PathBuf::from("main.py"), "#!/usr/bin/env bash\n"),
+            "python"
+        );
     }
 }

--- a/src/lsp/multi.rs
+++ b/src/lsp/multi.rs
@@ -27,6 +27,7 @@ pub enum LanguageId {
     Php,
     Go,
     Ruby,
+    Shell,
 }
 
 impl LanguageId {
@@ -45,12 +46,17 @@ impl LanguageId {
             "php" => Some(Self::Php),
             "go" => Some(Self::Go),
             "rb" | "rake" | "gemspec" | "ru" | "podspec" => Some(Self::Ruby),
+            "sh" | "bash" | "zsh" | "ksh" | "bats" | "ebuild" | "eclass" => Some(Self::Shell),
             _ => None,
         }
     }
 
     /// Detect language from file path
     pub fn from_path(path: &Path) -> Option<Self> {
+        if crate::syntax::is_shell_path(path) {
+            return Some(Self::Shell);
+        }
+
         if Self::is_ruby_path(path) {
             return Some(Self::Ruby);
         }
@@ -58,6 +64,14 @@ impl LanguageId {
         path.extension()
             .and_then(|ext| ext.to_str())
             .and_then(Self::from_extension)
+    }
+
+    pub fn from_path_and_first_line(path: &Path, first_line: Option<&str>) -> Option<Self> {
+        Self::from_path(path).or_else(|| {
+            first_line
+                .filter(|line| crate::syntax::shebang_is_shell(line))
+                .map(|_| Self::Shell)
+        })
     }
 
     fn is_ruby_path(path: &Path) -> bool {
@@ -95,6 +109,7 @@ impl LanguageId {
             Self::Php => "php",
             Self::Go => "go",
             Self::Ruby => "ruby",
+            Self::Shell => "shellscript",
         }
     }
 }
@@ -127,12 +142,26 @@ pub struct MultiLspManager {
     configs: HashMap<LanguageId, LspServerConfig>,
     /// Workspace root for all servers
     workspace_root: PathBuf,
+    /// Shebang-detected languages for extensionless files (cleared on did_close)
+    shebang_languages: HashMap<PathBuf, LanguageId>,
 }
 
 impl MultiLspManager {
     pub fn language_for_path(&self, path: &Path) -> Option<LanguageId> {
-        if let Some(lang) = LanguageId::from_path(path) {
+        self.language_for_path_and_first_line(path, None)
+    }
+
+    pub fn language_for_path_and_first_line(
+        &self,
+        path: &Path,
+        first_line: Option<&str>,
+    ) -> Option<LanguageId> {
+        if let Some(lang) = LanguageId::from_path_and_first_line(path, first_line) {
             return Some(lang);
+        }
+
+        if let Some(lang) = self.shebang_languages.get(path) {
+            return Some(*lang);
         }
 
         let ext = path.extension().and_then(|ext| ext.to_str())?;
@@ -150,6 +179,7 @@ impl MultiLspManager {
             LanguageId::Php,
             LanguageId::Go,
             LanguageId::Ruby,
+            LanguageId::Shell,
         ]
         .into_iter()
         .find(|lang| {
@@ -163,6 +193,16 @@ impl MultiLspManager {
                 })
                 .unwrap_or(false)
         })
+    }
+
+    fn remember_shebang_language(&mut self, path: &Path, first_line: Option<&str>) {
+        if LanguageId::from_path(path).is_some() {
+            return;
+        }
+        if first_line.is_some_and(crate::syntax::shebang_is_shell) {
+            self.shebang_languages
+                .insert(path.to_path_buf(), LanguageId::Shell);
+        }
     }
 
     fn resolve_server_root(&self, lang: LanguageId, file_path: Option<&Path>) -> PathBuf {
@@ -334,6 +374,7 @@ impl MultiLspManager {
         php_config: LspServerConfig,
         go_config: LspServerConfig,
         ruby_config: LspServerConfig,
+        shell_config: LspServerConfig,
     ) -> Self {
         let mut configs = HashMap::new();
         configs.insert(LanguageId::Rust, rust_config);
@@ -348,11 +389,13 @@ impl MultiLspManager {
         configs.insert(LanguageId::Php, php_config);
         configs.insert(LanguageId::Go, go_config);
         configs.insert(LanguageId::Ruby, ruby_config);
+        configs.insert(LanguageId::Shell, shell_config);
 
         Self {
             instances: HashMap::new(),
             configs,
             workspace_root,
+            shebang_languages: HashMap::new(),
         }
     }
 
@@ -414,7 +457,16 @@ impl MultiLspManager {
 
     /// Start a server for a file if needed
     pub fn ensure_server_for_file(&mut self, path: &Path) -> anyhow::Result<Option<LanguageId>> {
-        if let Some(lang) = self.language_for_path(path) {
+        self.ensure_server_for_file_with_first_line(path, None)
+    }
+
+    pub fn ensure_server_for_file_with_first_line(
+        &mut self,
+        path: &Path,
+        first_line: Option<&str>,
+    ) -> anyhow::Result<Option<LanguageId>> {
+        self.remember_shebang_language(path, first_line);
+        if let Some(lang) = self.language_for_path_and_first_line(path, first_line) {
             let Some(config) = self.configs.get(&lang) else {
                 return Ok(None);
             };
@@ -529,8 +581,10 @@ impl MultiLspManager {
 
     /// Send did_open notification to appropriate server
     pub fn did_open(&mut self, path: &PathBuf, text: &str) -> anyhow::Result<()> {
+        let first_line = text.lines().next();
+        self.remember_shebang_language(path, first_line);
         let lang = self
-            .language_for_path(path)
+            .language_for_path_and_first_line(path, first_line)
             .ok_or_else(|| anyhow::anyhow!("Unknown language for {:?}", path))?;
 
         if let Some(instance) = self.get_instance_mut(lang) {
@@ -574,6 +628,7 @@ impl MultiLspManager {
                 }
             }
         }
+        self.shebang_languages.remove(path);
         Ok(())
     }
 
@@ -910,6 +965,7 @@ mod tests {
             servers.php,
             servers.go,
             servers.ruby,
+            servers.shell,
         )
     }
 
@@ -1112,6 +1168,57 @@ mod tests {
         assert_eq!(
             manager.status(Some(Path::new("app/models/user.rb"))),
             "LSP: ruby-lsp not started (ruby)"
+        );
+
+        let _ = fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn shell_paths_route_to_bash_language_server() {
+        let tmp = unique_temp_dir("nevi_lsp_shell_route");
+        let workspace_root = tmp.join("workspace");
+        fs::create_dir_all(&workspace_root).expect("create workspace");
+
+        let mut manager = make_manager(workspace_root);
+
+        assert_eq!(LanguageId::from_extension("sh"), Some(LanguageId::Shell));
+        assert_eq!(LanguageId::from_extension("zsh"), Some(LanguageId::Shell));
+        assert_eq!(
+            LanguageId::from_path(Path::new(".zshrc")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(
+            LanguageId::from_path(Path::new(".bashrc")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(
+            LanguageId::from_path(Path::new(".bash_profile")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(LanguageId::Shell.as_lsp_id(), "shellscript");
+        assert_eq!(
+            manager.language_for_path(Path::new("bin/setup.sh")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(
+            manager.language_for_path(Path::new(".zshrc")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(
+            manager.language_for_path_and_first_line(
+                Path::new("bin/deploy"),
+                Some("#!/usr/bin/env bash")
+            ),
+            Some(LanguageId::Shell)
+        );
+        manager.remember_shebang_language(Path::new("bin/deploy"), Some("#!/bin/sh"));
+        assert_eq!(
+            manager.language_for_path(Path::new("bin/deploy")),
+            Some(LanguageId::Shell)
+        );
+        assert_eq!(
+            manager.status(Some(Path::new("bin/setup.sh"))),
+            "LSP: bash-language-server not started (shellscript)"
         );
 
         let _ = fs::remove_dir_all(&tmp);

--- a/src/main.rs
+++ b/src/main.rs
@@ -522,6 +522,7 @@ fn main() -> anyhow::Result<()> {
             &lsp_servers.php,
             &lsp_servers.go,
             &lsp_servers.ruby,
+            &lsp_servers.shell,
         ] {
             for marker in &cfg.root_patterns {
                 if marker.trim().is_empty() {
@@ -560,6 +561,7 @@ fn main() -> anyhow::Result<()> {
             lsp_servers.php,
             lsp_servers.go,
             lsp_servers.ruby,
+            lsp_servers.shell,
         );
         multi_lsp = Some(mgr);
         editor.set_lsp_status("LSP: (no server)");
@@ -870,7 +872,11 @@ fn main() -> anyhow::Result<()> {
                             if let Some(path) = editor.buffer().path.clone() {
                                 if !mlsp.is_ready_for_file(&path) {
                                     // Try to start server for this file type
-                                    if let Err(e) = mlsp.ensure_server_for_file(&path) {
+                                    let first_line = editor.buffer().first_line();
+                                    if let Err(e) = mlsp.ensure_server_for_file_with_first_line(
+                                        &path,
+                                        first_line.as_deref(),
+                                    ) {
                                         let message = mlsp
                                             .language_for_path(&path)
                                             .map(|lang| {
@@ -1020,7 +1026,11 @@ fn main() -> anyhow::Result<()> {
                             // Try to start server for new file type and open the file
                             if let Some(ref new_path) = current_file {
                                 // Ensure server is started for this file type
-                                match mlsp.ensure_server_for_file(new_path) {
+                                let first_line = editor.buffer().first_line();
+                                match mlsp.ensure_server_for_file_with_first_line(
+                                    new_path,
+                                    first_line.as_deref(),
+                                ) {
                                     Ok(Some(_lang)) => {
                                         editor
                                             .set_lsp_status(mlsp.status(Some(new_path.as_path())));
@@ -1073,9 +1083,13 @@ fn main() -> anyhow::Result<()> {
                                     let uri = lsp::path_to_uri(new_path);
                                     let text = editor.buffer().content();
                                     let version = editor.buffer().version() as i32;
-                                    let lang_id = LanguageId::from_path(new_path)
-                                        .map(|l| l.as_lsp_id().to_string())
-                                        .unwrap_or_else(|| "plaintext".to_string());
+                                    let first_line = editor.buffer().first_line();
+                                    let lang_id = LanguageId::from_path_and_first_line(
+                                        new_path,
+                                        first_line.as_deref(),
+                                    )
+                                    .map(|l| l.as_lsp_id().to_string())
+                                    .unwrap_or_else(|| "plaintext".to_string());
                                     let _ = cop.did_open(&uri, &lang_id, version, &text);
                                 }
                                 // Only update tracking when we actually sent did_open
@@ -1227,9 +1241,13 @@ fn main() -> anyhow::Result<()> {
                                             let source = editor.buffer().content();
 
                                             // Get language ID
-                                            let lang_id = LanguageId::from_path(&path)
-                                                .map(|l| l.as_lsp_id().to_string())
-                                                .unwrap_or_else(|| "plaintext".to_string());
+                                            let first_line = editor.buffer().first_line();
+                                            let lang_id = LanguageId::from_path_and_first_line(
+                                                &path,
+                                                first_line.as_deref(),
+                                            )
+                                            .map(|l| l.as_lsp_id().to_string())
+                                            .unwrap_or_else(|| "plaintext".to_string());
 
                                             // Get relative path
                                             let relative_path = editor
@@ -1857,9 +1875,13 @@ fn main() -> anyhow::Result<()> {
                                         let uri = lsp::path_to_uri(&path);
                                         let text = editor.buffer().content();
                                         let version = editor.buffer().version() as i32;
-                                        let lang_id = LanguageId::from_path(&path)
-                                            .map(|l| l.as_lsp_id().to_string())
-                                            .unwrap_or_else(|| "plaintext".to_string());
+                                        let first_line = editor.buffer().first_line();
+                                        let lang_id = LanguageId::from_path_and_first_line(
+                                            &path,
+                                            first_line.as_deref(),
+                                        )
+                                        .map(|l| l.as_lsp_id().to_string())
+                                        .unwrap_or_else(|| "plaintext".to_string());
                                         let _ = cop.did_open(&uri, &lang_id, version, &text);
                                         copilot_current_file = Some(path);
                                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -872,7 +872,7 @@ fn main() -> anyhow::Result<()> {
                             if let Some(path) = editor.buffer().path.clone() {
                                 if !mlsp.is_ready_for_file(&path) {
                                     // Try to start server for this file type
-                                    let first_line = editor.buffer().first_line();
+                                    let first_line = editor.buffer().first_line_prefix();
                                     if let Err(e) = mlsp.ensure_server_for_file_with_first_line(
                                         &path,
                                         first_line.as_deref(),
@@ -1026,7 +1026,7 @@ fn main() -> anyhow::Result<()> {
                             // Try to start server for new file type and open the file
                             if let Some(ref new_path) = current_file {
                                 // Ensure server is started for this file type
-                                let first_line = editor.buffer().first_line();
+                                let first_line = editor.buffer().first_line_prefix();
                                 match mlsp.ensure_server_for_file_with_first_line(
                                     new_path,
                                     first_line.as_deref(),
@@ -1083,7 +1083,7 @@ fn main() -> anyhow::Result<()> {
                                     let uri = lsp::path_to_uri(new_path);
                                     let text = editor.buffer().content();
                                     let version = editor.buffer().version() as i32;
-                                    let first_line = editor.buffer().first_line();
+                                    let first_line = editor.buffer().first_line_prefix();
                                     let lang_id = LanguageId::from_path_and_first_line(
                                         new_path,
                                         first_line.as_deref(),
@@ -1241,7 +1241,7 @@ fn main() -> anyhow::Result<()> {
                                             let source = editor.buffer().content();
 
                                             // Get language ID
-                                            let first_line = editor.buffer().first_line();
+                                            let first_line = editor.buffer().first_line_prefix();
                                             let lang_id = LanguageId::from_path_and_first_line(
                                                 &path,
                                                 first_line.as_deref(),
@@ -1875,7 +1875,7 @@ fn main() -> anyhow::Result<()> {
                                         let uri = lsp::path_to_uri(&path);
                                         let text = editor.buffer().content();
                                         let version = editor.buffer().version() as i32;
-                                        let first_line = editor.buffer().first_line();
+                                        let first_line = editor.buffer().first_line_prefix();
                                         let lang_id = LanguageId::from_path_and_first_line(
                                             &path,
                                             first_line.as_deref(),

--- a/src/syntax/highlighter.rs
+++ b/src/syntax/highlighter.rs
@@ -1367,6 +1367,11 @@ pub fn php_highlight_query() -> &'static str {
     tree_sitter_php::HIGHLIGHTS_QUERY
 }
 
+/// Get the highlight query for Bash / POSIX shell
+pub fn shell_highlight_query() -> &'static str {
+    tree_sitter_bash::HIGHLIGHT_QUERY
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1529,6 +1534,39 @@ mod tests {
             tree_sitter_php::LANGUAGE_PHP.into(),
             php_highlight_query(),
             "PHP",
+        );
+    }
+
+    #[test]
+    fn shell_highlight_query_compiles() {
+        assert_query_compiles(
+            tree_sitter_bash::LANGUAGE.into(),
+            shell_highlight_query(),
+            "Bash",
+        );
+    }
+
+    #[test]
+    fn shell_query_captures_keywords_and_commands() {
+        let captures = capture_texts(
+            tree_sitter_bash::LANGUAGE.into(),
+            shell_highlight_query(),
+            "if true; then echo hello; fi\n",
+        );
+
+        assert!(
+            captures
+                .iter()
+                .any(|(name, text)| name == "keyword" && text == "if"),
+            "expected shell if keyword to be captured, got {:?}",
+            captures
+        );
+        assert!(
+            captures
+                .iter()
+                .any(|(name, text)| name == "function" && text == "echo"),
+            "expected shell command name to be captured, got {:?}",
+            captures
         );
     }
 

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -60,10 +60,20 @@ impl SyntaxManager {
 
     /// Detect language from file path and set up parser
     pub fn set_language_from_path(&mut self, path: &Path) {
+        self.set_language_from_path_and_first_line(path, None);
+    }
+
+    /// Detect language from path, then the first line (shebang) if the path is unknown.
+    pub fn set_language_from_path_and_first_line(&mut self, path: &Path, first_line: Option<&str>) {
         let extension = path.extension().and_then(|e| e.to_str());
 
         if is_ruby_path(path, extension) {
             self.set_ruby_language();
+            return;
+        }
+
+        if is_shell_path(path) {
+            self.set_shell_language();
             return;
         }
 
@@ -84,32 +94,43 @@ impl SyntaxManager {
             Some("php") => self.set_php_language(),
             Some("go") => self.set_go_language(),
             _ => {
-                self.language = None;
-                self.query = None;
-                self.tree = None;
-                self.source_cache.clear();
-                self.line_start_bytes.clear();
-                self.highlight_cache.borrow_mut().clear();
-                self.cache_version.set(0);
-                self.parse_version = 0;
+                if first_line.is_some_and(shebang_is_shell) {
+                    self.set_shell_language();
+                    return;
+                }
+                self.clear_language();
             }
         }
     }
 
     /// Detect language from optional file path
     pub fn set_language_from_path_option(&mut self, path: Option<&std::path::PathBuf>) {
+        self.set_language_from_path_option_and_first_line(path, None);
+    }
+
+    pub fn set_language_from_path_option_and_first_line(
+        &mut self,
+        path: Option<&std::path::PathBuf>,
+        first_line: Option<&str>,
+    ) {
         if let Some(p) = path {
-            self.set_language_from_path(p);
+            self.set_language_from_path_and_first_line(p, first_line);
+        } else if first_line.is_some_and(shebang_is_shell) {
+            self.set_shell_language();
         } else {
-            self.language = None;
-            self.query = None;
-            self.tree = None;
-            self.source_cache.clear();
-            self.line_start_bytes.clear();
-            self.highlight_cache.borrow_mut().clear();
-            self.cache_version.set(0);
-            self.parse_version = 0;
+            self.clear_language();
         }
+    }
+
+    fn clear_language(&mut self) {
+        self.language = None;
+        self.query = None;
+        self.tree = None;
+        self.source_cache.clear();
+        self.line_start_bytes.clear();
+        self.highlight_cache.borrow_mut().clear();
+        self.cache_version.set(0);
+        self.parse_version = 0;
     }
 
     /// Set up Rust language parser
@@ -462,6 +483,30 @@ impl SyntaxManager {
         }
     }
 
+    /// Set up Bash / POSIX shell language parser
+    fn set_shell_language(&mut self) {
+        let language = tree_sitter_bash::LANGUAGE;
+        match self.parser.set_language(&language.into()) {
+            Ok(()) => {
+                self.language = Some("shell".to_string());
+
+                let query_source = highlighter::shell_highlight_query();
+                match Query::new(&language.into(), query_source) {
+                    Ok(query) => {
+                        self.query = Some(query);
+                    }
+                    Err(e) => {
+                        self.language = Some(format!("shell (query error: {:?})", e));
+                        self.query = None;
+                    }
+                }
+            }
+            Err(e) => {
+                self.language = Some(format!("shell (lang error: {:?})", e));
+            }
+        }
+    }
+
     /// Parse the entire buffer
     pub fn parse(&mut self, buffer: &Buffer) {
         if self.language.is_none() {
@@ -757,6 +802,84 @@ fn is_ruby_path(path: &Path, extension: Option<&str>) -> bool {
     )
 }
 
+/// True when the path is a shell script by extension or a common rc/profile filename.
+pub fn is_shell_path(path: &Path) -> bool {
+    let extension = path.extension().and_then(|e| e.to_str());
+    if matches!(
+        extension,
+        Some("sh" | "bash" | "zsh" | "ksh" | "bats" | "ebuild" | "eclass")
+    ) {
+        return true;
+    }
+
+    is_shell_filename(path)
+}
+
+fn is_shell_filename(path: &Path) -> bool {
+    matches!(
+        path.file_name().and_then(|name| name.to_str()),
+        Some(
+            ".bashrc"
+                | "bashrc"
+                | "bash.bashrc"
+                | ".bashrc.local"
+                | ".bash_profile"
+                | ".bashprofile"
+                | "bash_profile"
+                | ".bash_login"
+                | ".bash_logout"
+                | ".bash_aliases"
+                | ".bash_functions"
+                | ".profile"
+                | "profile"
+                | ".zshrc"
+                | "zshrc"
+                | ".zshrc.local"
+                | ".zshenv"
+                | "zshenv"
+                | ".zprofile"
+                | "zprofile"
+                | ".zlogin"
+                | "zlogin"
+                | ".zlogout"
+                | "zlogout"
+                | ".zaliases"
+                | ".zsh_aliases"
+                | ".kshrc"
+                | ".mkshrc"
+                | ".envrc"
+                | "PKGBUILD"
+                | "APKBUILD"
+        )
+    )
+}
+
+/// True when the first line is a POSIX/bash/zsh shebang (`#!/bin/bash`, `#!/usr/bin/env bash`).
+pub fn shebang_is_shell(first_line: &str) -> bool {
+    matches!(
+        shebang_interpreter(first_line),
+        Some("sh" | "bash" | "dash" | "ash" | "ksh" | "mksh" | "zsh")
+    )
+}
+
+fn shebang_interpreter(first_line: &str) -> Option<&str> {
+    let line = first_line.trim_end_matches(['\r', '\n']);
+    let rest = line.strip_prefix("#!")?.trim();
+    let mut parts = rest.split_whitespace();
+    let command = parts.next()?;
+    let name = Path::new(command).file_name()?.to_str()?;
+    if name.eq_ignore_ascii_case("env") {
+        for arg in parts {
+            if arg.starts_with('-') {
+                continue;
+            }
+            return Path::new(arg).file_name()?.to_str();
+        }
+        return None;
+    }
+    Some(name)
+}
+
 /// Get the line comment string for a language
 /// Returns the comment prefix (e.g., "// " for Rust/JS, "# " for Python)
 pub fn get_comment_string(language: Option<&str>) -> &'static str {
@@ -902,5 +1025,106 @@ mod tests {
     fn php_uses_slash_slash_line_comments() {
         assert_eq!(get_comment_string(Some("php")), "// ");
         assert_eq!(get_comment_end(Some("php")), None);
+    }
+
+    fn parse_shell_snippet(syntax: &mut SyntaxManager) {
+        let mut buffer = Buffer::new();
+        buffer.set_content("if true; then\n  echo hello\nfi\n");
+        syntax.parse(&buffer);
+        assert_eq!(syntax.language_name(), Some("shell"));
+        assert!(syntax.has_highlighting());
+        assert!(
+            !syntax.get_line_highlights(0).is_empty(),
+            "shell files should use Bash syntax highlighting"
+        );
+    }
+
+    #[test]
+    fn sh_extension_uses_shell_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("bin/setup.sh"));
+        parse_shell_snippet(&mut syntax);
+    }
+
+    #[test]
+    fn bash_and_zsh_extensions_use_shell_highlighting() {
+        for path in ["script.bash", "script.zsh"] {
+            let mut syntax = SyntaxManager::new();
+            syntax.set_language_from_path(Path::new(path));
+            parse_shell_snippet(&mut syntax);
+        }
+    }
+
+    #[test]
+    fn common_shell_rc_filenames_use_shell_highlighting() {
+        for path in [
+            ".bashrc",
+            ".bash_profile",
+            ".bashprofile",
+            ".zshrc",
+            ".zshenv",
+            ".profile",
+            "PKGBUILD",
+            ".envrc",
+        ] {
+            let mut syntax = SyntaxManager::new();
+            syntax.set_language_from_path(Path::new(path));
+            parse_shell_snippet(&mut syntax);
+        }
+    }
+
+    #[test]
+    fn extensionless_shebang_uses_shell_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path_and_first_line(
+            Path::new("bin/deploy"),
+            Some("#!/usr/bin/env bash\n"),
+        );
+        parse_shell_snippet(&mut syntax);
+    }
+
+    #[test]
+    fn env_dash_s_shebang_uses_shell_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path_and_first_line(
+            Path::new("bin/deploy"),
+            Some("#!/usr/bin/env -S bash -eu\n"),
+        );
+        parse_shell_snippet(&mut syntax);
+    }
+
+    #[test]
+    fn fish_and_python_shebangs_do_not_use_shell_highlighting() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path_and_first_line(
+            Path::new("bin/deploy"),
+            Some("#!/usr/bin/env fish\n"),
+        );
+        assert_eq!(syntax.language_name(), None);
+
+        syntax.set_language_from_path_and_first_line(
+            Path::new("bin/deploy"),
+            Some("#!/usr/bin/env python3\n"),
+        );
+        assert_eq!(syntax.language_name(), None);
+    }
+
+    #[test]
+    fn path_wins_over_mismatched_shebang() {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path_and_first_line(
+            Path::new("main.py"),
+            Some("#!/usr/bin/env bash\n"),
+        );
+        assert_eq!(syntax.language_name(), Some("python"));
+    }
+
+    #[test]
+    fn shebang_is_shell_recognizes_common_interpreters() {
+        assert!(shebang_is_shell("#!/bin/bash"));
+        assert!(shebang_is_shell("#!/bin/sh\n"));
+        assert!(shebang_is_shell("#!/usr/bin/env zsh"));
+        assert!(!shebang_is_shell("#!/usr/bin/env fish"));
+        assert!(!shebang_is_shell("echo hi"));
     }
 }

--- a/src/tool_installer.rs
+++ b/src/tool_installer.rs
@@ -124,6 +124,7 @@ where
         add_lsp_tool(&mut grouped, "php", &servers.php, &is_command_available);
         add_lsp_tool(&mut grouped, "go", &servers.go, &is_command_available);
         add_lsp_tool(&mut grouped, "ruby", &servers.ruby, &is_command_available);
+        add_lsp_tool(&mut grouped, "shell", &servers.shell, &is_command_available);
     }
 
     for (language, config) in &languages_config.languages {
@@ -220,6 +221,9 @@ pub fn install_command_for(command: &str) -> Option<&'static str> {
         ),
         "gopls" | "gopls.exe" => Some("go install golang.org/x/tools/gopls@latest"),
         "ruby-lsp" | "ruby-lsp.cmd" => Some("gem install ruby-lsp"),
+        "bash-language-server" | "bash-language-server.cmd" => {
+            Some("npm install -g bash-language-server")
+        }
         "pylsp" => Some("pipx install python-lsp-server"),
         "biome" | "biome.cmd" => Some("npm install -g @biomejs/biome"),
         "oxfmt" | "oxfmt.cmd" => Some("npm install -g oxfmt"),
@@ -256,6 +260,7 @@ mod tests {
         settings.lsp.servers.php.enabled = false;
         settings.lsp.servers.go.enabled = false;
         settings.lsp.servers.ruby.enabled = false;
+        settings.lsp.servers.shell.enabled = false;
     }
 
     #[test]
@@ -275,6 +280,10 @@ mod tests {
         assert_eq!(
             super::install_command_for("ruby-lsp"),
             Some("gem install ruby-lsp")
+        );
+        assert_eq!(
+            super::install_command_for("bash-language-server"),
+            Some("npm install -g bash-language-server")
         );
         assert_eq!(
             super::install_command_for("phpactor"),


### PR DESCRIPTION
Opening a `.sh` file in Nevi has no syntax highlighting. Language detection is compiled in, and shell never got a tree-sitter grammar or an LSP slot. `languages.toml` can already key formatters as `[shell]` (`.sh` / `.bash` / `.zsh` map there), comment toggling already knows `# ` for shell, and the explorer even colors those files — but `SyntaxManager` hits the default branch and clears highlighting. Same for `.bashrc` / `.zshrc` (dotfiles with no usable extension) and for executables like `bin/deploy` that only have a shebang.

This PR adds shell the same way Go and Ruby were added:

- `tree-sitter-bash` plus the crate's highlight query
- `LanguageId::Shell` and `[lsp.servers.shell]` defaulting to `bash-language-server start`
- path matching for `.sh` / `.bash` / `.zsh` and the usual rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …)
- shebang fallback on the already-loaded first line (`#!/usr/bin/env bash`, `env -S`, `/bin/sh`, zsh, …). Fish/python shebangs stay unhighlighted. A `.py` file with a bash shebang stays Python.

If `languages.toml` has `[shell]`, formatters and tab width now apply to those rc files too, not only to `*.sh`.
