### PR TITLE
feat: add g_, |, and section motions

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -210,6 +210,8 @@ When specifying keys, use these formats:
 | `0` | Move to start of line (column 0) |
 | `^` | Move to first non-blank character |
 | `$` | Move to end of line |
+| `g_` | Move to last non-blank character (count moves lines down) |
+| `\|` | Move to column [count] |
 | `+` / `Enter` | Move to first non-blank of next line |
 | `-` | Move to first non-blank of previous line |
 | `gj` | Move down by display line when wrap is enabled |
@@ -219,6 +221,8 @@ When specifying keys, use these formats:
 | `g^` | Move to first non-blank of display line when wrap is enabled |
 | `{` | Move to previous blank line (paragraph) |
 | `}` | Move to next blank line (paragraph) |
+| `[[` | Move to previous section start (`{` in column 0) |
+| `]]` | Move to next section start (`{` in column 0) |
 | `(` | Move to previous sentence |
 | `)` | Move to next sentence |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 316 keybinds implemented, 52 planned Vim/Neovim parity defaults.**
+**Status: 320 keybinds implemented, 48 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -39,13 +39,9 @@ mode parity.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `\|` | Go to a screen column |
-| `g_` | Go to the last non-blank character of the line |
 | `gm` | Go to the middle of the screen line |
 | `gM` | Go to the middle of the text line |
 | `go` | Go to a byte offset |
-| `[[` | Go to previous section start |
-| `]]` | Go to next section start |
 | `[]` | Go to previous section end |
 | `][` | Go to next section end |
 | `[{` | Go to previous unmatched `{` |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -10994,6 +10994,7 @@ impl Editor {
             Motion::WordEnd
                 | Motion::BigWordEnd
                 | Motion::LineEnd
+                | Motion::LastNonBlank
                 | Motion::FindChar(_)
                 | Motion::FindCharBack(_)
                 | Motion::MatchingBracket

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -936,6 +936,7 @@ impl InputState {
             }
             (_, KeyCode::Char('^')) => self.motion_or_operator(Motion::FirstNonBlank, count),
             (_, KeyCode::Char('$')) => self.motion_or_operator(Motion::LineEnd, count),
+            (_, KeyCode::Char('|')) => self.motion_or_operator(Motion::ToColumn, count),
             (_, KeyCode::Char('+')) | (KeyModifiers::NONE, KeyCode::Enter) => {
                 self.motion_or_operator(Motion::NextLineFirstNonBlank, count)
             }
@@ -1426,6 +1427,13 @@ impl InputState {
                 self.reset();
                 action
             }
+            // g_ - move to last non-blank character of the line
+            ('g', KeyModifiers::NONE, KeyCode::Char('_'))
+            | ('g', KeyModifiers::SHIFT, KeyCode::Char('_')) => {
+                let action = self.motion_or_operator(Motion::LastNonBlank, count);
+                self.reset();
+                action
+            }
             // gJ - join lines without space
             ('g', KeyModifiers::SHIFT, KeyCode::Char('J')) => {
                 self.reset();
@@ -1470,6 +1478,18 @@ impl InputState {
             ('[', KeyModifiers::NONE, KeyCode::Char('d')) => {
                 self.reset();
                 KeyAction::PrevDiagnostic
+            }
+            // ]] - go to next section start
+            (']', KeyModifiers::NONE, KeyCode::Char(']')) => {
+                let action = self.motion_or_operator(Motion::SectionForward, count);
+                self.reset();
+                action
+            }
+            // [[ - go to previous section start
+            ('[', KeyModifiers::NONE, KeyCode::Char('[')) => {
+                let action = self.motion_or_operator(Motion::SectionBackward, count);
+                self.reset();
+                action
             }
             // ]h - go to next harpoon file
             (']', KeyModifiers::NONE, KeyCode::Char('h')) => {
@@ -2145,6 +2165,13 @@ mod tests {
         assert_motion(&[key('0')], Motion::LineStart, 1);
         assert_motion(&[key('^')], Motion::FirstNonBlank, 1);
         assert_motion(&[key('$')], Motion::LineEnd, 1);
+        assert_motion(&[key('g'), key('_')], Motion::LastNonBlank, 1);
+        assert_motion(&[key('3'), key('g'), key('_')], Motion::LastNonBlank, 3);
+        assert_motion(&[key('|')], Motion::ToColumn, 1);
+        assert_motion(&[key('5'), key('|')], Motion::ToColumn, 5);
+        assert_motion(&[key(']'), key(']')], Motion::SectionForward, 1);
+        assert_motion(&[key('['), key('[')], Motion::SectionBackward, 1);
+        assert_motion(&[key('2'), key(']'), key(']')], Motion::SectionForward, 2);
         assert_motion(&[key('+')], Motion::NextLineFirstNonBlank, 1);
         assert_motion(&[enter()], Motion::NextLineFirstNonBlank, 1);
         assert_motion(&[key('-')], Motion::PrevLineFirstNonBlank, 1);

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -28,6 +28,8 @@ pub enum Motion {
     LineStart,             // 0
     FirstNonBlank,         // ^
     LineEnd,               // $
+    LastNonBlank,          // g_ - last non-blank, [count-1] lines downward
+    ToColumn,              // | - to column [count]
     NextLineFirstNonBlank, // +
     PrevLineFirstNonBlank, // -
 
@@ -61,6 +63,10 @@ pub enum Motion {
 
     // Bracket matching
     MatchingBracket, // %
+
+    // Section motions (Vim sections: a '{' in the first column starts a section)
+    SectionForward,  // ]]
+    SectionBackward, // [[
 }
 
 /// Check if a character is a "word" character (alphanumeric or underscore)
@@ -267,6 +273,60 @@ pub fn apply_motion(
             }
             let line_len = buffer.line_len(target_line);
             Some((target_line, line_len.saturating_sub(1)))
+        }
+
+        Motion::LastNonBlank => {
+            // Like $, a count moves [count-1] lines downward first (Vim g_).
+            let target_line = line.checked_add(count.max(1).saturating_sub(1))?;
+            if target_line > last_addressable_line(buffer) {
+                return None;
+            }
+            Some((target_line, find_last_non_blank(buffer, target_line)))
+        }
+
+        Motion::ToColumn => {
+            // Vim | uses screen columns; we use char columns, which differs on tabs.
+            let line_len = buffer.line_len(line);
+            Some((
+                line,
+                count.saturating_sub(1).min(line_len.saturating_sub(1)),
+            ))
+        }
+
+        Motion::SectionForward => {
+            // Vim ]]: to the [count]'th next '{' in column 0, or end of file.
+            let last_line = last_addressable_line(buffer);
+            let mut current = line;
+            for _ in 0..count {
+                match ((current + 1)..=last_line)
+                    .find(|&candidate| buffer.char_at(candidate, 0) == Some('{'))
+                {
+                    Some(section) => current = section,
+                    None => {
+                        current = last_line;
+                        break;
+                    }
+                }
+            }
+            Some((current, 0))
+        }
+
+        Motion::SectionBackward => {
+            // Vim [[: to the [count]'th previous '{' in column 0, or start of file.
+            let mut current = line;
+            for _ in 0..count {
+                match (0..current)
+                    .rev()
+                    .find(|&candidate| buffer.char_at(candidate, 0) == Some('{'))
+                {
+                    Some(section) => current = section,
+                    None => {
+                        current = 0;
+                        break;
+                    }
+                }
+            }
+            Some((current, 0))
         }
 
         Motion::NextLineFirstNonBlank => {
@@ -915,6 +975,18 @@ fn find_word_end(
 fn find_first_non_blank(buffer: &Buffer, line: usize) -> usize {
     let line_len = buffer.line_len(line);
     for c in 0..line_len {
+        if let Some(ch) = buffer.char_at(line, c) {
+            if !ch.is_whitespace() {
+                return c;
+            }
+        }
+    }
+    0
+}
+
+fn find_last_non_blank(buffer: &Buffer, line: usize) -> usize {
+    let line_len = buffer.line_len(line);
+    for c in (0..line_len).rev() {
         if let Some(ch) = buffer.char_at(line, c) {
             if !ch.is_whitespace() {
                 return c;

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -51,6 +51,10 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("0", "Move to start of line", "line start"),
     vim_oracle("^", "Move to first non-blank character", "first nonblank"),
     vim_oracle("$", "Move to end of line", "line end"),
+    vim_oracle("g_", "Move to last non-blank character", "last non blank"),
+    vim_oracle("|", "Move to column [count]", "to column"),
+    vim_oracle("]]", "Move to next section start", "section forward"),
+    vim_oracle("[[", "Move to previous section start", "section backward"),
     vim_oracle(
         "<CR>",
         "Move to first non-blank of next line",

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -439,6 +439,76 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "alpha beta gamma\n",
         keys: "2w",
     },
+    OracleCase {
+        name: "last non blank",
+        initial_text: "  alpha beta   \n",
+        keys: "g_",
+    },
+    OracleCase {
+        name: "counted last non blank",
+        initial_text: "alpha  \nbeta   \ngamma  \n",
+        keys: "2g_",
+    },
+    OracleCase {
+        name: "last non blank on blank line",
+        initial_text: "alpha\n     \ngamma\n",
+        keys: "jg_",
+    },
+    OracleCase {
+        name: "delete to last non blank",
+        initial_text: "alpha beta   \n",
+        keys: "dg_",
+    },
+    OracleCase {
+        name: "to column",
+        initial_text: "abcdef\n",
+        keys: "4|",
+    },
+    OracleCase {
+        name: "to column default",
+        initial_text: "abcdef\n",
+        keys: "$|",
+    },
+    OracleCase {
+        name: "to column past line end",
+        initial_text: "abc\n",
+        keys: "9|",
+    },
+    OracleCase {
+        name: "delete to column",
+        initial_text: "abcdef\n",
+        keys: "$d3|",
+    },
+    OracleCase {
+        name: "section forward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "]]",
+    },
+    OracleCase {
+        name: "counted section forward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "2]]",
+    },
+    OracleCase {
+        name: "section forward without sections",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "]]",
+    },
+    OracleCase {
+        name: "section backward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "G[[",
+    },
+    OracleCase {
+        name: "counted section backward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "G2[[",
+    },
+    OracleCase {
+        name: "section backward without sections",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "G[[",
+    },
 ];
 
 const SHORT_VIEWPORT_CASES: &[OracleCase] = &[


### PR DESCRIPTION
PR covers:
Add Vim parity motions: g_ (last non-blank, inclusive), | (go to column), and ]] / [[ (next/previous section start at '{' in column 0). Counts, operators, and visual mode work through the existing motion dispatch. | uses character columns, which differs from Vim's screen columns only on lines with tabs.

Verified with 14 new vim-oracle cases against Neovim 0.11.3, dispatch unit tests, and keybind coverage entries. Keybind docs and roadmap updated (320 implemented, 48 planned).