### PR TITLE
feat: add gM and section-end motions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Nevi 0.3.0 brings further improvements.
 ### Highlights
 
 - `:Format` now runs the external formatter from `languages.toml` when one is configured for the current language, and falls back to LSP otherwise.
+- Added Vim motions `g_`, `|`, `gM`, `[[`, `]]`, `][`, and `[]`.
 
 ## 0.2.0 - 2026-07-07
 

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -212,6 +212,7 @@ When specifying keys, use these formats:
 | `$` | Move to end of line |
 | `g_` | Move to last non-blank character (count moves lines down) |
 | `\|` | Move to column [count] |
+| `gM` | Move to middle of the line's text (count is a percentage) |
 | `+` / `Enter` | Move to first non-blank of next line |
 | `-` | Move to first non-blank of previous line |
 | `gj` | Move down by display line when wrap is enabled |
@@ -223,6 +224,8 @@ When specifying keys, use these formats:
 | `}` | Move to next blank line (paragraph) |
 | `[[` | Move to previous section start (`{` in column 0) |
 | `]]` | Move to next section start (`{` in column 0) |
+| `[]` | Move to previous section end (`}` in column 0) |
+| `][` | Move to next section end (`}` in column 0) |
 | `(` | Move to previous sentence |
 | `)` | Move to next sentence |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 320 keybinds implemented, 48 planned Vim/Neovim parity defaults.**
+**Status: 323 keybinds implemented, 45 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -40,10 +40,7 @@ mode parity.
 | Keybind | Planned behavior |
 |---------|------------------|
 | `gm` | Go to the middle of the screen line |
-| `gM` | Go to the middle of the text line |
 | `go` | Go to a byte offset |
-| `[]` | Go to previous section end |
-| `][` | Go to next section end |
 | `[{` | Go to previous unmatched `{` |
 | `]}` | Go to next unmatched `}` |
 | `[(` | Go to previous unmatched `(` |

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1434,6 +1434,12 @@ impl InputState {
                 self.reset();
                 action
             }
+            // gM - move to middle of the line's text
+            ('g', KeyModifiers::SHIFT, KeyCode::Char('M')) => {
+                let action = self.motion_or_operator(Motion::MiddleOfLine, count);
+                self.reset();
+                action
+            }
             // gJ - join lines without space
             ('g', KeyModifiers::SHIFT, KeyCode::Char('J')) => {
                 self.reset();
@@ -1488,6 +1494,18 @@ impl InputState {
             // [[ - go to previous section start
             ('[', KeyModifiers::NONE, KeyCode::Char('[')) => {
                 let action = self.motion_or_operator(Motion::SectionBackward, count);
+                self.reset();
+                action
+            }
+            // ][ - go to next section end
+            (']', KeyModifiers::NONE, KeyCode::Char('[')) => {
+                let action = self.motion_or_operator(Motion::SectionEndForward, count);
+                self.reset();
+                action
+            }
+            // [] - go to previous section end
+            ('[', KeyModifiers::NONE, KeyCode::Char(']')) => {
+                let action = self.motion_or_operator(Motion::SectionEndBackward, count);
                 self.reset();
                 action
             }
@@ -2169,9 +2187,22 @@ mod tests {
         assert_motion(&[key('3'), key('g'), key('_')], Motion::LastNonBlank, 3);
         assert_motion(&[key('|')], Motion::ToColumn, 1);
         assert_motion(&[key('5'), key('|')], Motion::ToColumn, 5);
+        assert_motion(&[key('g'), shift('M')], Motion::MiddleOfLine, 1);
+        assert_motion(
+            &[key('2'), key('0'), key('g'), shift('M')],
+            Motion::MiddleOfLine,
+            20,
+        );
         assert_motion(&[key(']'), key(']')], Motion::SectionForward, 1);
         assert_motion(&[key('['), key('[')], Motion::SectionBackward, 1);
         assert_motion(&[key('2'), key(']'), key(']')], Motion::SectionForward, 2);
+        assert_motion(&[key(']'), key('[')], Motion::SectionEndForward, 1);
+        assert_motion(&[key('['), key(']')], Motion::SectionEndBackward, 1);
+        assert_motion(
+            &[key('2'), key(']'), key('[')],
+            Motion::SectionEndForward,
+            2,
+        );
         assert_motion(&[key('+')], Motion::NextLineFirstNonBlank, 1);
         assert_motion(&[enter()], Motion::NextLineFirstNonBlank, 1);
         assert_motion(&[key('-')], Motion::PrevLineFirstNonBlank, 1);

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -30,6 +30,7 @@ pub enum Motion {
     LineEnd,               // $
     LastNonBlank,          // g_ - last non-blank, [count-1] lines downward
     ToColumn,              // | - to column [count]
+    MiddleOfLine,          // gM - middle of the line's text
     NextLineFirstNonBlank, // +
     PrevLineFirstNonBlank, // -
 
@@ -64,9 +65,12 @@ pub enum Motion {
     // Bracket matching
     MatchingBracket, // %
 
-    // Section motions (Vim sections: a '{' in the first column starts a section)
-    SectionForward,  // ]]
-    SectionBackward, // [[
+    // Section motions (Vim sections: a '{' in the first column starts a
+    // section, a '}' in the first column ends one)
+    SectionForward,     // ]]
+    SectionBackward,    // [[
+    SectionEndForward,  // ][
+    SectionEndBackward, // []
 }
 
 /// Check if a character is a "word" character (alphanumeric or underscore)
@@ -293,6 +297,20 @@ pub fn apply_motion(
             ))
         }
 
+        Motion::MiddleOfLine => {
+            // Vim gM: halfway the text of the line; a count of 2-100 jumps to
+            // that percentage instead. Vim treats a bare 1 as "no count", which
+            // our dispatcher can't distinguish, so 1gM also means halfway.
+            // Char columns, like |, so tabs differ.
+            let line_len = buffer.line_len(line);
+            let target = if (2..=100).contains(&count) {
+                line_len * count / 100
+            } else {
+                line_len / 2
+            };
+            Some((line, target.min(line_len.saturating_sub(1))))
+        }
+
         Motion::SectionForward => {
             // Vim ]]: to the [count]'th next '{' in column 0, or end of file.
             let last_line = last_addressable_line(buffer);
@@ -318,6 +336,42 @@ pub fn apply_motion(
                 match (0..current)
                     .rev()
                     .find(|&candidate| buffer.char_at(candidate, 0) == Some('{'))
+                {
+                    Some(section) => current = section,
+                    None => {
+                        current = 0;
+                        break;
+                    }
+                }
+            }
+            Some((current, 0))
+        }
+
+        Motion::SectionEndForward => {
+            // Vim ][: to the [count]'th next '}' in column 0, or end of file.
+            let last_line = last_addressable_line(buffer);
+            let mut current = line;
+            for _ in 0..count {
+                match ((current + 1)..=last_line)
+                    .find(|&candidate| buffer.char_at(candidate, 0) == Some('}'))
+                {
+                    Some(section) => current = section,
+                    None => {
+                        current = last_line;
+                        break;
+                    }
+                }
+            }
+            Some((current, 0))
+        }
+
+        Motion::SectionEndBackward => {
+            // Vim []: to the [count]'th previous '}' in column 0, or start of file.
+            let mut current = line;
+            for _ in 0..count {
+                match (0..current)
+                    .rev()
+                    .find(|&candidate| buffer.char_at(candidate, 0) == Some('}'))
                 {
                     Some(section) => current = section,
                     None => {

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -53,8 +53,11 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("$", "Move to end of line", "line end"),
     vim_oracle("g_", "Move to last non-blank character", "last non blank"),
     vim_oracle("|", "Move to column [count]", "to column"),
+    vim_oracle("gM", "Move to middle of the line's text", "middle of line"),
     vim_oracle("]]", "Move to next section start", "section forward"),
     vim_oracle("[[", "Move to previous section start", "section backward"),
+    vim_oracle("][", "Move to next section end", "section end forward"),
+    vim_oracle("[]", "Move to previous section end", "section end backward"),
     vim_oracle(
         "<CR>",
         "Move to first non-blank of next line",

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -509,6 +509,56 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "alpha\nbeta\ngamma\n",
         keys: "G[[",
     },
+    OracleCase {
+        name: "middle of line",
+        initial_text: "abcdefgh\n",
+        keys: "gM",
+    },
+    OracleCase {
+        name: "middle of line odd length",
+        initial_text: "abcdefg\n",
+        keys: "gM",
+    },
+    OracleCase {
+        name: "middle of line percent",
+        initial_text: "abcdefghij\n",
+        keys: "20gM",
+    },
+    OracleCase {
+        name: "delete to middle of line",
+        initial_text: "abcdefgh\n",
+        keys: "dgM",
+    },
+    OracleCase {
+        name: "section end forward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "][",
+    },
+    OracleCase {
+        name: "counted section end forward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "2][",
+    },
+    OracleCase {
+        name: "section end forward without sections",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "][",
+    },
+    OracleCase {
+        name: "section end backward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "G[]",
+    },
+    OracleCase {
+        name: "counted section end backward",
+        initial_text: "fn main()\n{\n    body\n}\nfn other()\n{\n    tail\n}\n",
+        keys: "G2[]",
+    },
+    OracleCase {
+        name: "section end backward without sections",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "G[]",
+    },
 ];
 
 const SHORT_VIEWPORT_CASES: &[OracleCase] = &[


### PR DESCRIPTION
- gM moves to the middle of the line's text; a count of 2-100 jumps to that percentage of the line instead
- ][ and [] move to the next/previous section end ('}' in column 0), falling back to end/start of file like ]] and [[
- Adds the deferred CHANGELOG bullet covering all 0.3.0 motions
- 10 new vim-oracle cases validated against nvim 0.11.3, plus keybind coverage entries, KEYBINDINGS.md rows, and roadmap counts