### PR TITLE
feat: add unmatched-bracket motions [{ ]} [( ])

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Nevi 0.3.0 brings further improvements.
 ### Highlights
 
 - `:Format` now runs the external formatter from `languages.toml` when one is configured for the current language, and falls back to LSP otherwise.
-- Added Vim motions `g_`, `|`, `gM`, `[[`, `]]`, `][`, and `[]`.
+- Added Vim motions `g_`, `|`, `gM`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
 - `j`/`k` now keep the preferred column (Vim `curswant`) when moving across short or blank lines, and `$` makes vertical motion stick to line ends.
 - Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
 - Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -226,6 +226,10 @@ When specifying keys, use these formats:
 | `]]` | Move to next section start (`{` in column 0) |
 | `[]` | Move to previous section end (`}` in column 0) |
 | `][` | Move to next section end (`}` in column 0) |
+| `[{` | Move to previous unmatched `{` (out of the enclosing block) |
+| `]}` | Move to next unmatched `}` (out of the enclosing block) |
+| `[(` | Move to previous unmatched `(` |
+| `])` | Move to next unmatched `)` |
 | `(` | Move to previous sentence |
 | `)` | Move to next sentence |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 323 keybinds implemented, 45 planned Vim/Neovim parity defaults.**
+**Status: 327 keybinds implemented, 41 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -41,10 +41,6 @@ mode parity.
 |---------|------------------|
 | `gm` | Go to the middle of the screen line |
 | `go` | Go to a byte offset |
-| `[{` | Go to previous unmatched `{` |
-| `]}` | Go to next unmatched `}` |
-| `[(` | Go to previous unmatched `(` |
-| `])` | Go to next unmatched `)` |
 | `[m` | Go to previous method/function start |
 | `]m` | Go to next method/function start |
 | `[M` | Go to previous method/function end |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -11144,9 +11144,12 @@ impl Editor {
             if end_line == start_line {
                 end_col = end_col.saturating_sub(1).max(start_col);
             } else if end_col == 0 {
+                // Vim :h exclusive: an exclusive motion ending in column 1
+                // moves its end to the last character of the previous line
+                // and becomes inclusive — the line break survives, so d[{
+                // and d} never join lines.
                 let prev_line = end_line.saturating_sub(1);
-                let prev_len =
-                    self.buffers[self.current_buffer_idx].line_len_including_newline(prev_line);
+                let prev_len = self.buffers[self.current_buffer_idx].line_len(prev_line);
                 end_line = prev_line;
                 end_col = prev_len.saturating_sub(1);
             } else {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1509,6 +1509,30 @@ impl InputState {
                 self.reset();
                 action
             }
+            // [{ - go to previous unmatched { (modifier is `_`: shifted char)
+            ('[', _, KeyCode::Char('{')) => {
+                let action = self.motion_or_operator(Motion::UnmatchedOpenBrace, count);
+                self.reset();
+                action
+            }
+            // ]} - go to next unmatched }
+            (']', _, KeyCode::Char('}')) => {
+                let action = self.motion_or_operator(Motion::UnmatchedCloseBrace, count);
+                self.reset();
+                action
+            }
+            // [( - go to previous unmatched (
+            ('[', _, KeyCode::Char('(')) => {
+                let action = self.motion_or_operator(Motion::UnmatchedOpenParen, count);
+                self.reset();
+                action
+            }
+            // ]) - go to next unmatched )
+            (']', _, KeyCode::Char(')')) => {
+                let action = self.motion_or_operator(Motion::UnmatchedCloseParen, count);
+                self.reset();
+                action
+            }
             // ]h - go to next harpoon file
             (']', KeyModifiers::NONE, KeyCode::Char('h')) => {
                 self.reset();
@@ -2201,6 +2225,18 @@ mod tests {
         assert_motion(
             &[key('2'), key(']'), key('[')],
             Motion::SectionEndForward,
+            2,
+        );
+        // Shifted chars may arrive with or without the SHIFT modifier
+        // depending on the terminal, so both must dispatch.
+        assert_motion(&[key('['), key('{')], Motion::UnmatchedOpenBrace, 1);
+        assert_motion(&[key('['), shift('{')], Motion::UnmatchedOpenBrace, 1);
+        assert_motion(&[key(']'), key('}')], Motion::UnmatchedCloseBrace, 1);
+        assert_motion(&[key('['), key('(')], Motion::UnmatchedOpenParen, 1);
+        assert_motion(&[key(']'), key(')')], Motion::UnmatchedCloseParen, 1);
+        assert_motion(
+            &[key('2'), key('['), key('{')],
+            Motion::UnmatchedOpenBrace,
             2,
         );
         assert_motion(&[key('+')], Motion::NextLineFirstNonBlank, 1);

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -71,6 +71,12 @@ pub enum Motion {
     SectionBackward,    // [[
     SectionEndForward,  // ][
     SectionEndBackward, // []
+
+    // Unmatched-bracket motions (jump out of the enclosing {} or () block)
+    UnmatchedOpenBrace,  // [{
+    UnmatchedCloseBrace, // ]}
+    UnmatchedOpenParen,  // [(
+    UnmatchedCloseParen, // ])
 }
 
 /// Check if a character is a "word" character (alphanumeric or underscore)
@@ -383,6 +389,11 @@ pub fn apply_motion(
             Some((current, 0))
         }
 
+        Motion::UnmatchedOpenBrace => find_unmatched_backward(buffer, line, col, '{', '}', count),
+        Motion::UnmatchedCloseBrace => find_unmatched_forward(buffer, line, col, '{', '}', count),
+        Motion::UnmatchedOpenParen => find_unmatched_backward(buffer, line, col, '(', ')', count),
+        Motion::UnmatchedCloseParen => find_unmatched_forward(buffer, line, col, '(', ')', count),
+
         Motion::NextLineFirstNonBlank => {
             let max_line = last_addressable_line(buffer);
             let target_line = (line + count).min(max_line);
@@ -692,6 +703,84 @@ fn find_matching_bracket(buffer: &Buffer, line: usize, col: usize) -> Option<(us
 /// Check if a character is a bracket
 fn is_bracket(ch: char) -> bool {
     matches!(ch, '(' | ')' | '[' | ']' | '{' | '}' | '<' | '>')
+}
+
+/// Vim [{ / [(: scan backward from before the cursor for the [count]'th
+/// unmatched `open`. Pairs that close between the cursor and the candidate
+/// cancel out; like Vim, the motion fails (None) when nothing encloses the
+/// cursor. Purely textual — strings and comments are not special.
+fn find_unmatched_backward(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    open: char,
+    close: char,
+    count: usize,
+) -> Option<(usize, usize)> {
+    let mut depth = 0usize;
+    let mut remaining = count.max(1);
+    let mut current_line = line;
+    // Exclusive upper bound: the char under the cursor is never a candidate.
+    let mut end_col = col;
+    loop {
+        for c in (0..end_col).rev() {
+            match buffer.char_at(current_line, c) {
+                Some(ch) if ch == close => depth += 1,
+                Some(ch) if ch == open => {
+                    if depth == 0 {
+                        remaining -= 1;
+                        if remaining == 0 {
+                            return Some((current_line, c));
+                        }
+                    } else {
+                        depth -= 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+        if current_line == 0 {
+            return None;
+        }
+        current_line -= 1;
+        end_col = buffer.line_len(current_line);
+    }
+}
+
+/// Vim ]} / ]): scan forward from after the cursor for the [count]'th
+/// unmatched `close`. Mirror of [`find_unmatched_backward`].
+fn find_unmatched_forward(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    open: char,
+    close: char,
+    count: usize,
+) -> Option<(usize, usize)> {
+    let total_lines = buffer.len_lines();
+    let mut depth = 0usize;
+    let mut remaining = count.max(1);
+    for current_line in line..total_lines {
+        // The char under the cursor is never a candidate.
+        let start_col = if current_line == line { col + 1 } else { 0 };
+        for c in start_col..buffer.line_len(current_line) {
+            match buffer.char_at(current_line, c) {
+                Some(ch) if ch == open => depth += 1,
+                Some(ch) if ch == close => {
+                    if depth == 0 {
+                        remaining -= 1;
+                        if remaining == 0 {
+                            return Some((current_line, c));
+                        }
+                    } else {
+                        depth -= 1;
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+    None
 }
 
 /// Search forward for matching bracket

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -58,6 +58,18 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("[[", "Move to previous section start", "section backward"),
     vim_oracle("][", "Move to next section end", "section end forward"),
     vim_oracle("[]", "Move to previous section end", "section end backward"),
+    vim_oracle("[{", "Move to previous unmatched {", "unmatched open brace"),
+    vim_oracle("]}", "Move to next unmatched }", "unmatched close brace"),
+    vim_oracle(
+        "[(",
+        "Move to previous unmatched (",
+        "unmatched open paren skips nested pair",
+    ),
+    vim_oracle(
+        "])",
+        "Move to next unmatched )",
+        "unmatched close paren skips nested pair",
+    ),
     vim_oracle(
         "<CR>",
         "Move to first non-blank of next line",

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -601,6 +601,72 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "abcdef\nab\nabcdef\n",
         keys: "$j",
     },
+    // Unmatched-bracket motions: [{ ]} [( ]) jump out of the enclosing
+    // block; nested pairs between cursor and target must cancel out and the
+    // motion must fail in place when nothing encloses the cursor.
+    OracleCase {
+        name: "unmatched open brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2j[{",
+    },
+    OracleCase {
+        name: "counted unmatched open brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2j2[{",
+    },
+    OracleCase {
+        name: "unmatched close brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2j]}",
+    },
+    OracleCase {
+        name: "counted unmatched close brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2j2]}",
+    },
+    OracleCase {
+        name: "unmatched open brace not found",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "[{",
+    },
+    OracleCase {
+        name: "unmatched open brace from open brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "j$[{",
+    },
+    OracleCase {
+        name: "unmatched open paren skips nested pair",
+        initial_text: "let x = f(a, (b + c), d);\n",
+        keys: "fd[(",
+    },
+    OracleCase {
+        name: "unmatched close paren skips nested pair",
+        initial_text: "let x = f(a, (b + c), d);\n",
+        keys: "fa])",
+    },
+    OracleCase {
+        name: "unmatched close paren from nested pair",
+        initial_text: "let x = f(a, (b + c), d);\n",
+        keys: "fb])",
+    },
+    OracleCase {
+        name: "delete to unmatched close brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2jd]}",
+    },
+    OracleCase {
+        name: "delete to unmatched open brace",
+        initial_text: "fn main() {\n    if x {\n        inner\n    }\n    tail\n}\n",
+        keys: "2jd[{",
+    },
+    // Pre-existing motion_range bug: an exclusive motion ending in column 1
+    // must stop at the last char of the previous line (Vim :h exclusive)
+    // instead of eating the line break — d} was joining lines.
+    OracleCase {
+        name: "delete to next paragraph keeps line break",
+        initial_text: "aaa bbb\nccc\n\nddd\n",
+        keys: "lld}",
+    },
 ];
 
 const SHORT_VIEWPORT_CASES: &[OracleCase] = &[


### PR DESCRIPTION
Vim parity: jump out of the enclosing {} or () block. Nested pairs between the cursor and the target cancel out, counts jump multiple levels, and the motion fails in place when nothing encloses the
cursor.

Also fixes a pre-existing motion_range bug the new oracle casesexposed: an exclusive motion ending in column 1 must stop at the last character of the previous line (Vim :h exclusive) instead of eating the line break — d} was joining lines.

12 vim-oracle cases validated against nvim 0.11.3, keybind coverage entries, and docs updated (327 implemented / 41 planned).