### PR TITLE
feat: add gm and go motions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Nevi 0.3.0 brings further improvements.
 ### Highlights
 
 - `:Format` now runs the external formatter from `languages.toml` when one is configured for the current language, and falls back to LSP otherwise.
-- Added Vim motions `g_`, `|`, `gM`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
+- Added Vim motions `g_`, `|`, `gM`, `gm`, `go`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
 - `j`/`k` now keep the preferred column (Vim `curswant`) when moving across short or blank lines, and `$` makes vertical motion stick to line ends.
 - Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
 - Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -220,6 +220,7 @@ When specifying keys, use these formats:
 | `g0` | Move to start of display line when wrap is enabled |
 | `g$` | Move to end of display line when wrap is enabled |
 | `g^` | Move to first non-blank of display line when wrap is enabled |
+| `gm` | Move to middle of the screen line |
 | `{` | Move to previous blank line (paragraph) |
 | `}` | Move to next blank line (paragraph) |
 | `[[` | Move to previous section start (`{` in column 0) |
@@ -240,6 +241,7 @@ When specifying keys, use these formats:
 | `gg` | Move to start of file |
 | `G` | Move to end of file |
 | `{n}G` | Move to line n (e.g., `50G` goes to line 50) |
+| `{n}go` | Go to byte n of the file |
 | `%` | Jump to matching bracket `()`, `{}`, `[]` |
 
 ### Screen Movement

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 327 keybinds implemented, 41 planned Vim/Neovim parity defaults.**
+**Status: 329 keybinds implemented, 39 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -39,8 +39,6 @@ mode parity.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `gm` | Go to the middle of the screen line |
-| `go` | Go to a byte offset |
 | `[m` | Go to previous method/function start |
 | `]m` | Go to next method/function start |
 | `[M` | Go to previous method/function end |

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,12 +9,12 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **327 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **41 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **71 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 69 verified against real Neovim (v0.11.3) by the Vim oracle
+- **329 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **39 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **73 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 71 verified against real Neovim (v0.11.3) by the Vim oracle
   - 1 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **215 oracle cases**: motions (101), editing (56), insert-entry (11), open-line (18), replace (27), undo-redo (2)
+- **221 oracle cases**: motions (107), editing (56), insert-entry (11), open-line (18), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
 
 ## How the Vim oracle works
@@ -56,6 +56,8 @@ claim protection.
 | `]}` | Move to next unmatched } | `unmatched close brace` |
 | `[(` | Move to previous unmatched ( | `unmatched open paren skips nested pair` |
 | `])` | Move to next unmatched ) | `unmatched close paren skips nested pair` |
+| `gm` | Move to middle of the screen line | `gm on short line` |
+| `go` | Go to [count] byte of the buffer | `go to byte` |
 | `<CR>` | Move to first non-blank of next line | `enter next line first nonblank` |
 | `gg` | Move to start of file | `file top` |
 | `G` | Move to end of file | `file bottom` |

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -399,6 +399,18 @@ impl Buffer {
         }
     }
 
+    /// Convert a 0-based byte offset to (line, col), clamping to the last
+    /// byte. A byte inside a multibyte char resolves to that char (Vim go).
+    pub fn byte_to_line_col(&self, byte: usize) -> (usize, usize) {
+        if self.text.len_bytes() == 0 {
+            return (0, 0);
+        }
+        let byte = byte.min(self.text.len_bytes() - 1);
+        let ch = self.text.byte_to_char(byte);
+        let line = self.text.char_to_line(ch);
+        (line, ch - self.text.line_to_char(line))
+    }
+
     /// Check if buffer is empty
     pub fn is_empty(&self) -> bool {
         self.text.len_chars() == 0
@@ -605,6 +617,22 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn byte_to_line_col_counts_bytes_and_clamps() {
+        let mut buffer = Buffer::new();
+        buffer.set_content("h\u{e9}llo\nworld\n");
+        assert_eq!(buffer.byte_to_line_col(0), (0, 0));
+        // Byte 2 is the second byte of the 2-byte 'é' → resolves to 'é'.
+        assert_eq!(buffer.byte_to_line_col(2), (0, 1));
+        // 'é' shifts bytes vs chars: byte 7 is 'w', char col 0 of line 1.
+        assert_eq!(buffer.byte_to_line_col(7), (1, 0));
+        // Past the end clamps to the last byte (the trailing newline).
+        assert_eq!(buffer.byte_to_line_col(999), (1, 5));
+
+        let empty = Buffer::new();
+        assert_eq!(empty.byte_to_line_col(5), (0, 0));
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -129,6 +129,7 @@ enum DisplayLineTarget {
     Start,
     End,
     FirstNonBlank,
+    Middle,
 }
 
 /// Pending LSP action requested by key handler
@@ -10085,6 +10086,9 @@ impl Editor {
             Motion::DisplayLineFirstNonBlank => {
                 self.move_to_display_line_position(DisplayLineTarget::FirstNonBlank);
             }
+            Motion::DisplayLineMiddle => {
+                self.move_to_display_line_position(DisplayLineTarget::Middle);
+            }
             Motion::PageDown if !self.settings.editor.wrap => {
                 self.scroll_full_page(true, count);
             }
@@ -10498,10 +10502,21 @@ impl Editor {
 
     fn move_to_display_line_position(&mut self, target: DisplayLineTarget) {
         if !self.settings.editor.wrap || self.effective_wrap_width() == 0 {
+            // Vim gm: half a screenwidth right of the screen-line start, or
+            // as much as possible. No pure-motion fallback exists because
+            // the target depends on the pane's text width.
+            if let DisplayLineTarget::Middle = target {
+                self.cursor.col = self.h_offset + self.text_area_width() / 2;
+                self.clamp_cursor();
+                self.scroll_to_cursor();
+                return;
+            }
             let fallback = match target {
                 DisplayLineTarget::Start => Motion::LineStart,
                 DisplayLineTarget::End => Motion::LineEnd,
-                DisplayLineTarget::FirstNonBlank => Motion::FirstNonBlank,
+                DisplayLineTarget::FirstNonBlank | DisplayLineTarget::Middle => {
+                    Motion::FirstNonBlank
+                }
             };
             if let Some((new_line, new_col)) = apply_motion(
                 &self.buffers[self.current_buffer_idx],
@@ -10538,6 +10553,11 @@ impl Editor {
             DisplayLineTarget::End => segment.end_col.saturating_sub(1),
             DisplayLineTarget::FirstNonBlank => {
                 Self::display_line_first_non_blank_col(&current_text, segment, tab_width)
+            }
+            // gm: half a screenwidth right of the display-line start,
+            // clamped to the segment (Vim: "or as much as possible").
+            DisplayLineTarget::Middle => {
+                Self::display_col_to_buffer_col(&current_text, segment, wrap_width / 2, tab_width)
             }
         };
         self.clamp_cursor();
@@ -12392,6 +12412,36 @@ mod tests {
 
         editor.undo();
         assert_eq!(editor.buffer().content(), "abc\n");
+    }
+
+    // gm targets half the pane's text-area width; the oracle only covers
+    // clamped short-line cases because nvim's text width differs, so the
+    // exact midpoint is pinned here with a known editor size.
+    #[test]
+    fn gm_moves_to_middle_of_screen_line() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 24);
+        editor.replace_buffer_content(&"x".repeat(200));
+
+        editor.apply_motion(Motion::DisplayLineMiddle, 1);
+        // 80 wide - sign column (2) - line numbers (3) - gap (1) = 74 → 37
+        assert_eq!(editor.text_area_width(), 74);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 37));
+    }
+
+    #[test]
+    fn gm_targets_current_display_segment_when_wrapped() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 24);
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 9_999;
+        editor.replace_buffer_content(&"x".repeat(200));
+        editor.cursor.set(0, 100);
+
+        // Cursor sits in the second 74-wide segment (cols 74..148); gm goes
+        // to that segment's start + half a screenwidth.
+        editor.apply_motion(Motion::DisplayLineMiddle, 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 74 + 37));
     }
 
     // Issue #227: j/k must keep the preferred column (Vim curswant) when

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1354,6 +1354,18 @@ impl InputState {
                 self.reset();
                 action
             }
+            // gm - move to middle of the screen line
+            ('g', KeyModifiers::NONE, KeyCode::Char('m')) => {
+                let action = self.motion_or_operator(Motion::DisplayLineMiddle, count);
+                self.reset();
+                action
+            }
+            // go - go to [count] byte of the buffer
+            ('g', KeyModifiers::NONE, KeyCode::Char('o')) => {
+                let action = self.motion_or_operator(Motion::GoToByte, count);
+                self.reset();
+                action
+            }
             // gn - search forward and select match
             ('g', KeyModifiers::NONE, KeyCode::Char('n')) => {
                 self.reset();
@@ -2212,6 +2224,13 @@ mod tests {
         assert_motion(&[key('|')], Motion::ToColumn, 1);
         assert_motion(&[key('5'), key('|')], Motion::ToColumn, 5);
         assert_motion(&[key('g'), shift('M')], Motion::MiddleOfLine, 1);
+        assert_motion(&[key('g'), key('m')], Motion::DisplayLineMiddle, 1);
+        assert_motion(&[key('g'), key('o')], Motion::GoToByte, 1);
+        assert_motion(
+            &[key('4'), key('2'), key('g'), key('o')],
+            Motion::GoToByte,
+            42,
+        );
         assert_motion(
             &[key('2'), key('0'), key('g'), shift('M')],
             Motion::MiddleOfLine,

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -77,6 +77,13 @@ pub enum Motion {
     UnmatchedCloseBrace, // ]}
     UnmatchedOpenParen,  // [(
     UnmatchedCloseParen, // ])
+
+    // gm - middle of the screen line (handled in Editor::apply_motion where
+    // pane width is available, like the other display-line motions)
+    DisplayLineMiddle,
+
+    // go - go to the [count]'th byte of the buffer (1-based, default 1)
+    GoToByte,
 }
 
 /// Check if a character is a "word" character (alphanumeric or underscore)
@@ -387,6 +394,19 @@ pub fn apply_motion(
                 }
             }
             Some((current, 0))
+        }
+
+        Motion::DisplayLineMiddle => {
+            // Screen-aware handling lives in Editor::apply_motion; operator
+            // ranges would need the pane width, so the motion fails there
+            // rather than computing a wrong range.
+            None
+        }
+
+        Motion::GoToByte => {
+            // Vim go: cursor to the [count]'th byte, newlines included.
+            let (target_line, target_col) = buffer.byte_to_line_col(count.saturating_sub(1));
+            Some((target_line, target_col))
         }
 
         Motion::UnmatchedOpenBrace => find_unmatched_backward(buffer, line, col, '{', '}', count),

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -71,6 +71,12 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "unmatched close paren skips nested pair",
     ),
     vim_oracle(
+        "gm",
+        "Move to middle of the screen line",
+        "gm on short line",
+    ),
+    vim_oracle("go", "Go to [count] byte of the buffer", "go to byte"),
+    vim_oracle(
         "<CR>",
         "Move to first non-blank of next line",
         "enter next line first nonblank",

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -667,6 +667,41 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "aaa bbb\nccc\n\nddd\n",
         keys: "lld}",
     },
+    // gm: half a screenwidth right of the screen-line start. Only clamped
+    // (short-line) cases run against nvim — the exact midpoint depends on
+    // the text-area width, which differs between Nevi (line-number chrome)
+    // and headless nvim; the midpoint has a native regression test instead.
+    OracleCase {
+        name: "gm on short line",
+        initial_text: "abc\n",
+        keys: "gm",
+    },
+    OracleCase {
+        name: "gm on short line moves back from end",
+        initial_text: "abcd\n",
+        keys: "$gm",
+    },
+    // go: 1-based byte offset, newlines count, bytes not chars.
+    OracleCase {
+        name: "go to byte",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "12go",
+    },
+    OracleCase {
+        name: "go to first byte",
+        initial_text: "alpha\nbeta\ngamma\n",
+        keys: "Ggo",
+    },
+    OracleCase {
+        name: "go to byte counts bytes not chars",
+        initial_text: "h\u{e9}llo\nworld\n",
+        keys: "8go",
+    },
+    OracleCase {
+        name: "go to byte beyond end clamps",
+        initial_text: "alpha\nbeta\n",
+        keys: "99go",
+    },
 ];
 
 const SHORT_VIEWPORT_CASES: &[OracleCase] = &[


### PR DESCRIPTION
gm moves to the middle of the screen line (half the text-area width, clamped like Vim's "or as much as possible"), reusing the display-line machinery shared with g0/g$/g^ for both wrapped and unwrapped panes.

go moves to the [count]'th byte of the buffer, 1-based with newlines counted, via a new Buffer::byte_to_line_col backed by ropey's byte indexing, a byte inside a multibyte char resolves to that char.

6 vim-oracle cases validated against nvim 0.11.3, native regression tests for the width-dependent gm midpoint, PARITY.md regenerated (329 implemented / 39 planned, 221 oracle cases).