### PR TITLE
test: add key-sequence fuzz harness and pane sync guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Nevi 0.3.0 brings further improvements.
 - `j`/`k` now keep the preferred column (Vim `curswant`) when moving across short or blank lines, and `$` makes vertical motion stick to line ends.
 - Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
 - Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).
+- Fixed `J`/`gJ` on the last line silently deleting the file's trailing newline; they are now a no-op like Vim.
 
 ## 0.2.0 - 2026-07-07
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -14,7 +14,7 @@ the test suite enforces, so it cannot drift from what is actually verified.
   - 71 verified against real Neovim (v0.11.3) by the Vim oracle
   - 1 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **221 oracle cases**: motions (107), editing (56), insert-entry (11), open-line (18), replace (27), undo-redo (2)
+- **223 oracle cases**: motions (107), editing (58), insert-entry (11), open-line (18), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
 
 ## How the Vim oracle works

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -8611,7 +8611,11 @@ impl Editor {
 
     /// Join current line with next line (J command)
     pub fn join_lines(&mut self) {
-        let total_lines = self.buffers[self.current_buffer_idx].len_lines();
+        // Use the addressable count: raw addressable_line_count() includes the trailing
+        // rope sentinel, and joining "into" it silently eats the file's
+        // final newline (found by fuzzing; Vim treats J on the last line
+        // as a no-op).
+        let total_lines = self.buffers[self.current_buffer_idx].addressable_line_count();
         if self.cursor.line >= total_lines.saturating_sub(1) {
             // Already on last line, nothing to join
             return;
@@ -8715,7 +8719,8 @@ impl Editor {
 
     /// Join current line with next line without inserting space (gJ command)
     pub fn join_lines_no_space(&mut self) {
-        let total_lines = self.buffers[self.current_buffer_idx].len_lines();
+        // Addressable count, not len_lines(): see join_lines().
+        let total_lines = self.buffers[self.current_buffer_idx].addressable_line_count();
         if self.cursor.line >= total_lines.saturating_sub(1) {
             // Already on last line, nothing to join
             return;
@@ -12412,6 +12417,56 @@ mod tests {
 
         editor.undo();
         assert_eq!(editor.buffer().content(), "abc\n");
+    }
+
+    // Guard for the Pane/Editor mirroring invariant: every per-pane field
+    // the Editor mirrors must survive save_pane_state/load_pane_state. The
+    // exhaustive destructure (no `..`) makes this test stop compiling when
+    // Pane grows a field — decide then whether the Editor mirrors it, update
+    // both sync functions, and extend the assertions here.
+    #[test]
+    fn every_pane_field_survives_save_and_load() {
+        let mut editor = Editor::default();
+        editor.set_size(120, 40);
+        editor.replace_buffer_content("12\n\n1234\n\n123\n");
+        editor.vsplit(None).expect("vsplit");
+
+        // Distinctive state in the active pane, including a sticky column.
+        editor.cursor.set(2, 2);
+        editor.apply_motion(Motion::Up, 1);
+        let saved_cursor = editor.cursor;
+        let saved_desired = editor.desired_col;
+        assert!(saved_desired.is_some(), "Up should record a sticky column");
+
+        // Move around in the other pane so its state differs, then return.
+        editor.next_pane();
+        editor.cursor.set(0, 0);
+        editor.apply_motion(Motion::Down, 1);
+        editor.next_pane();
+
+        assert_eq!(editor.cursor, saved_cursor);
+        assert_eq!(editor.desired_col, saved_desired);
+
+        let pane = &editor.panes[editor.active_pane];
+        let super::Pane {
+            buffer_idx,
+            cursor,
+            desired_col,
+            viewport_offset,
+            h_offset,
+            half_page_scroll_rows,
+            rect: _,
+            size_weight: _,
+        } = pane;
+
+        // Editor-mirrored fields must match the Editor's copies after load.
+        assert_eq!(*buffer_idx, editor.current_buffer_idx);
+        assert_eq!(*cursor, editor.cursor);
+        assert_eq!(*desired_col, editor.desired_col);
+        assert_eq!(*viewport_offset, editor.viewport_offset);
+        assert_eq!(*h_offset, editor.h_offset);
+        // Pane-local by design (counted Ctrl-d/Ctrl-u distance, layout).
+        let _ = half_page_scroll_rows;
     }
 
     // gm targets half the pane's text-area width; the oracle only covers

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -1,0 +1,367 @@
+//! Seeded random-key fuzz: drives the headless editor through random key
+//! sequences and asserts it never panics and core cursor/viewport invariants
+//! hold afterwards. Complements the vim oracle — the oracle proves curated
+//! sequences are *correct*, this proves arbitrary sequences don't *crash*.
+//!
+//! Sequences are fully deterministic per seed (xorshift, no rand crate), so
+//! a failure message names the exact seed and key sequence for replay.
+//!
+//! Deliberately excluded keys: `:` (ex commands can write or open files on
+//! disk), `Z` (`ZZ` writes), `<Space>` leader (pickers/floating terminal),
+//! and any Ctrl chord not listed (e.g. Ctrl-s saves). The fixed buffer texts
+//! must never contain URLs or file paths, since `gx`/`gf` act on them.
+
+use crate::editor::Editor;
+use crate::terminal::handle_key;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+/// xorshift64* — deterministic across platforms.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        // Avoid the all-zero state, which xorshift never leaves.
+        Self(seed.wrapping_add(0x9E37_79B9_7F4A_7C15))
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.0 = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
+        &items[(self.next() % items.len() as u64) as usize]
+    }
+}
+
+#[derive(Clone, Copy)]
+struct FuzzKey {
+    code: KeyCode,
+    modifiers: KeyModifiers,
+    desc: &'static str,
+}
+
+const fn plain(ch: char, desc: &'static str) -> FuzzKey {
+    FuzzKey {
+        code: KeyCode::Char(ch),
+        modifiers: KeyModifiers::NONE,
+        desc,
+    }
+}
+
+const fn shifted(ch: char, desc: &'static str) -> FuzzKey {
+    FuzzKey {
+        code: KeyCode::Char(ch),
+        modifiers: KeyModifiers::SHIFT,
+        desc,
+    }
+}
+
+const fn ctrl(ch: char, desc: &'static str) -> FuzzKey {
+    FuzzKey {
+        code: KeyCode::Char(ch),
+        modifiers: KeyModifiers::CONTROL,
+        desc,
+    }
+}
+
+/// The key alphabet: vim editing keys plus insert-mode text. Escape appears
+/// several times so random walks reliably return to normal mode.
+const ALPHABET: &[FuzzKey] = &[
+    // Motions
+    plain('h', "h"),
+    plain('j', "j"),
+    plain('k', "k"),
+    plain('l', "l"),
+    plain('w', "w"),
+    plain('b', "b"),
+    plain('e', "e"),
+    shifted('W', "W"),
+    shifted('B', "B"),
+    shifted('E', "E"),
+    plain('0', "0"),
+    plain('^', "^"),
+    plain('$', "$"),
+    plain('{', "{"),
+    plain('}', "}"),
+    plain('(', "("),
+    plain(')', ")"),
+    plain('[', "["),
+    plain(']', "]"),
+    plain('%', "%"),
+    plain('|', "|"),
+    plain('+', "+"),
+    plain('-', "-"),
+    plain('_', "_"),
+    plain('g', "g"),
+    shifted('G', "G"),
+    shifted('H', "H"),
+    shifted('M', "M"),
+    shifted('L', "L"),
+    plain('f', "f"),
+    plain('t', "t"),
+    shifted('F', "F"),
+    shifted('T', "T"),
+    plain(';', ";"),
+    plain(',', ","),
+    plain('n', "n"),
+    shifted('N', "N"),
+    plain('*', "*"),
+    plain('#', "#"),
+    // Counts
+    plain('1', "1"),
+    plain('2', "2"),
+    plain('3', "3"),
+    plain('9', "9"),
+    // Operators and edits
+    plain('d', "d"),
+    plain('c', "c"),
+    plain('y', "y"),
+    plain('p', "p"),
+    shifted('P', "P"),
+    plain('x', "x"),
+    plain('s', "s"),
+    plain('r', "r"),
+    plain('~', "~"),
+    shifted('J', "J"),
+    plain('u', "u"),
+    plain('.', "."),
+    plain('<', "<"),
+    plain('>', ">"),
+    shifted('D', "D"),
+    shifted('C', "C"),
+    shifted('Y', "Y"),
+    shifted('S', "S"),
+    shifted('X', "X"),
+    // Insert entry (alphabet chars above double as insert-mode text)
+    plain('i', "i"),
+    plain('a', "a"),
+    plain('o', "o"),
+    shifted('I', "I"),
+    shifted('A', "A"),
+    shifted('O', "O"),
+    // Visual, registers, marks, macros
+    plain('v', "v"),
+    shifted('V', "V"),
+    plain('"', "\""),
+    plain('m', "m"),
+    plain('\'', "'"),
+    plain('`', "`"),
+    plain('q', "q"),
+    plain('@', "@"),
+    // Search (in-memory only)
+    plain('/', "/"),
+    plain('?', "?"),
+    // Scrolling, panes, jumps
+    plain('z', "z"),
+    ctrl('r', "<C-r>"),
+    ctrl('d', "<C-d>"),
+    ctrl('u', "<C-u>"),
+    ctrl('f', "<C-f>"),
+    ctrl('b', "<C-b>"),
+    ctrl('o', "<C-o>"),
+    ctrl('i', "<C-i>"),
+    ctrl('v', "<C-v>"),
+    ctrl('w', "<C-w>"),
+    // Mode exits, weighted so sequences keep returning to normal mode
+    FuzzKey {
+        code: KeyCode::Esc,
+        modifiers: KeyModifiers::NONE,
+        desc: "<Esc>",
+    },
+    FuzzKey {
+        code: KeyCode::Esc,
+        modifiers: KeyModifiers::NONE,
+        desc: "<Esc>",
+    },
+    FuzzKey {
+        code: KeyCode::Esc,
+        modifiers: KeyModifiers::NONE,
+        desc: "<Esc>",
+    },
+    FuzzKey {
+        code: KeyCode::Enter,
+        modifiers: KeyModifiers::NONE,
+        desc: "<CR>",
+    },
+];
+
+/// Plain code-like text and a tricky one (multibyte, tabs, blank and long
+/// lines, trailing spaces) to stress UTF-8 and width paths.
+const TEXTS: &[&str] = &[
+    "fn main() {\n    let total = 1;\n\n    if total > 0 {\n        println(total);\n    }\n}\n",
+    "h\u{e9}llo w\u{f6}rld \u{3b1}\u{3b2}\u{3b3}\n\n\tindented\ttabs\t\ntrailing   \nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n\nshort\n",
+];
+
+const SEQUENCE_LEN: usize = 32;
+
+fn run_sequence(seed: u64) -> Result<(), String> {
+    let mut rng = Rng::new(seed);
+    let text = TEXTS[(seed % TEXTS.len() as u64) as usize];
+
+    let mut keys = Vec::with_capacity(SEQUENCE_LEN);
+    for _ in 0..SEQUENCE_LEN {
+        keys.push(*rng.pick(ALPHABET));
+    }
+    let desc: String = keys.iter().map(|k| k.desc).collect();
+
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        let mut editor = Editor::default();
+        editor.set_size(80, 24);
+        editor.replace_buffer_content(text);
+        for key in &keys {
+            handle_key(&mut editor, KeyEvent::new(key.code, key.modifiers));
+        }
+        editor
+    }));
+
+    let editor = match outcome {
+        Ok(editor) => editor,
+        Err(_) => return Err(format!("panicked (seed {seed}): {desc}")),
+    };
+
+    let buffer = editor.buffer();
+    let max_line = buffer.addressable_line_count().saturating_sub(1);
+    if editor.cursor.line > max_line {
+        return Err(format!(
+            "cursor line {} > last line {max_line} (seed {seed}): {desc}",
+            editor.cursor.line
+        ));
+    }
+    let line_len = buffer.line_len(editor.cursor.line);
+    if editor.cursor.col > line_len {
+        return Err(format!(
+            "cursor col {} > line len {line_len} (seed {seed}): {desc}",
+            editor.cursor.col
+        ));
+    }
+    if editor.viewport_offset > max_line {
+        return Err(format!(
+            "viewport {} > last line {max_line} (seed {seed}): {desc}",
+            editor.viewport_offset
+        ));
+    }
+    Ok(())
+}
+
+fn run_seeds(range: std::ops::Range<u64>) {
+    let failures: Vec<String> = range.filter_map(|seed| run_sequence(seed).err()).collect();
+    assert!(
+        failures.is_empty(),
+        "{} fuzz failure(s):\n{}",
+        failures.len(),
+        failures.join("\n")
+    );
+}
+
+/// Replay an explicit key list against a text; Err = invariant violated.
+fn run_keys(text: &str, keys: &[FuzzKey]) -> Result<(), String> {
+    let outcome = catch_unwind(AssertUnwindSafe(|| {
+        let mut editor = Editor::default();
+        editor.set_size(80, 24);
+        editor.replace_buffer_content(text);
+        for key in keys {
+            handle_key(&mut editor, KeyEvent::new(key.code, key.modifiers));
+        }
+        editor
+    }));
+    let desc: String = keys.iter().map(|k| k.desc).collect();
+    let editor = match outcome {
+        Ok(editor) => editor,
+        Err(_) => return Err(format!("panicked: {desc}")),
+    };
+    let buffer = editor.buffer();
+    let max_line = buffer.addressable_line_count().saturating_sub(1);
+    if editor.cursor.line > max_line {
+        return Err(format!(
+            "cursor line {} > {max_line}: {desc}",
+            editor.cursor.line
+        ));
+    }
+    let line_len = buffer.line_len(editor.cursor.line);
+    if editor.cursor.col > line_len {
+        return Err(format!(
+            "cursor col {} > {line_len}: {desc}",
+            editor.cursor.col
+        ));
+    }
+    if editor.viewport_offset > max_line {
+        return Err(format!(
+            "viewport {} > {max_line}: {desc}",
+            editor.viewport_offset
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ALPHABET, Rng, SEQUENCE_LEN, TEXTS, run_keys, run_seeds};
+
+    /// Greedy delta-debugging for failing seeds. Usage:
+    /// `NEVI_FUZZ_MINIMIZE=2230,11672 cargo test fuzz_minimize -- --ignored --nocapture`
+    /// Note: greedy single-key removal can stop at a local minimum when a
+    /// prefix key changes how later keys parse (e.g. a pending register).
+    #[test]
+    #[ignore = "run with NEVI_FUZZ_MINIMIZE=<seed,...>"]
+    fn fuzz_minimize() {
+        let seeds = std::env::var("NEVI_FUZZ_MINIMIZE").unwrap_or_default();
+        for seed in seeds
+            .split(',')
+            .filter_map(|s| s.trim().parse::<u64>().ok())
+        {
+            let mut rng = Rng::new(seed);
+            let text = TEXTS[(seed % TEXTS.len() as u64) as usize];
+            let mut keys = Vec::with_capacity(SEQUENCE_LEN);
+            for _ in 0..SEQUENCE_LEN {
+                keys.push(*rng.pick(ALPHABET));
+            }
+            if run_keys(text, &keys).is_ok() {
+                println!("seed {seed}: does not fail, nothing to minimize");
+                continue;
+            }
+            // Greedy removal until no single key can be dropped.
+            loop {
+                let mut shrunk = false;
+                let mut i = 0;
+                while i < keys.len() {
+                    let mut candidate = keys.clone();
+                    candidate.remove(i);
+                    if run_keys(text, &candidate).is_err() {
+                        keys = candidate;
+                        shrunk = true;
+                    } else {
+                        i += 1;
+                    }
+                }
+                if !shrunk {
+                    break;
+                }
+            }
+            println!(
+                "seed {seed}: minimal = {}",
+                run_keys(text, &keys).unwrap_err()
+            );
+        }
+    }
+
+    /// Fast deterministic slice that runs in the normal suite (~2s; editor
+    /// construction dominates, so keep the seed count modest here).
+    #[test]
+    fn fuzz_key_sequences_smoke() {
+        run_seeds(0..128);
+    }
+
+    /// Extended run for CI nightly / manual use:
+    /// `cargo test fuzz_key_sequences_extended -- --ignored`
+    #[test]
+    #[ignore = "extended fuzz; run explicitly"]
+    fn fuzz_key_sequences_extended() {
+        run_seeds(128..20_000);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod finder;
 pub mod floating_terminal;
 pub mod formatter;
 pub mod frecency;
+#[cfg(test)]
+mod fuzz;
 pub mod git;
 pub mod harpoon;
 pub mod health;

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -283,4 +283,17 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "abcd\n",
         keys: "x2gP",
     },
+    // Fuzz-found: J/gJ on the last line must be a no-op. The old guard
+    // counted the trailing rope sentinel as a joinable line and silently
+    // deleted the file's final newline.
+    OracleCase {
+        name: "join on last line is a no-op",
+        initial_text: "alpha\nbeta\n",
+        keys: "GJ",
+    },
+    OracleCase {
+        name: "join without space on last line is a no-op",
+        initial_text: "alpha\nbeta\n",
+        keys: "GgJ",
+    },
 ];


### PR DESCRIPTION
Two new regression layers now that real users depend on Nevi. A seeded
deterministic fuzz (no new deps) drives the headless editor through
random key sequences asserting no panics and cursor/viewport bounds:
128-seed smoke in the normal suite, 20k-seed extended tier and a
seed minimizer behind --ignored. A compile-time guard exhaustively
destructures Pane so new fields cannot skip save/load_pane_state.

The first extended run caught a real bug, fixed here: J/gJ on the
last line counted the trailing rope sentinel as joinable and silently
deleted the file's final newline. Both now use addressable_line_count
and no-op like Vim, pinned by oracle cases against nvim 0.11.3.