### PR TITLE
fix: normalize missing final newline on buffer load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Nevi 0.3.0 brings further improvements.
 - Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
 - Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).
 - Fixed `J`/`gJ` on the last line silently deleting the file's trailing newline; they are now a no-op like Vim.
+- Files without a final newline now gain one on load and save (Neovim's `fixendofline` default), fixing the cursor landing on a phantom line when opening a line at end of file.
 
 ## 0.2.0 - 2026-07-07
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -14,7 +14,7 @@ the test suite enforces, so it cannot drift from what is actually verified.
   - 71 verified against real Neovim (v0.11.3) by the Vim oracle
   - 1 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **223 oracle cases**: motions (107), editing (58), insert-entry (11), open-line (18), replace (27), undo-redo (2)
+- **227 oracle cases**: motions (107), editing (60), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
 
 ## How the Vim oracle works

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -64,7 +64,8 @@ impl Buffer {
     fn from_file_with_read_only(path: PathBuf, read_only: bool) -> anyhow::Result<Self> {
         let (text, last_mtime) = if path.exists() {
             let mtime = std::fs::metadata(&path)?.modified().ok();
-            let rope = Rope::from_reader(std::fs::File::open(&path)?)?;
+            let mut rope = Rope::from_reader(std::fs::File::open(&path)?)?;
+            Self::fix_missing_final_newline(&mut rope);
             (rope, mtime)
         } else {
             // New file that doesn't exist yet
@@ -194,11 +195,25 @@ impl Buffer {
 
         if path.exists() {
             self.text = Rope::from_reader(std::fs::File::open(path)?)?;
+            Self::fix_missing_final_newline(&mut self.text);
             self.last_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
             self.dirty = false;
             self.version = self.version.wrapping_add(1);
         }
         Ok(())
+    }
+
+    /// Neovim parity ('fixendofline' default): a non-empty buffer whose text
+    /// does not end in a newline gets one appended, so the missing-final-
+    /// newline state is unrepresentable while editing. Without this, opening
+    /// a line at end of file parks the cursor on the rope's trailing
+    /// sentinel line (fuzz-found), and saving writes the newline exactly
+    /// like Neovim does.
+    fn fix_missing_final_newline(text: &mut Rope) {
+        let len = text.len_chars();
+        if len > 0 && text.char(len - 1) != '\n' {
+            text.insert(len, "\n");
+        }
     }
 
     /// Get total number of lines
@@ -273,6 +288,7 @@ impl Buffer {
             return;
         }
         self.text = Rope::from_str(content);
+        Self::fix_missing_final_newline(&mut self.text);
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -617,6 +633,29 @@ mod tests {
             .expect("system time")
             .as_nanos();
         std::env::temp_dir().join(format!("{}_{}_{}", prefix, std::process::id(), nanos))
+    }
+
+    #[test]
+    fn missing_final_newline_is_fixed_on_load_and_set_content() {
+        let mut buffer = Buffer::new();
+        buffer.set_content("abc");
+        assert_eq!(buffer.content(), "abc\n");
+        assert_eq!(buffer.addressable_line_count(), 1);
+
+        buffer.set_content("abc\n");
+        assert_eq!(buffer.content(), "abc\n", "already terminated: unchanged");
+
+        buffer.set_content("");
+        assert_eq!(buffer.content(), "", "empty buffer stays empty");
+
+        let dir = unique_temp_dir("nevi_noeol");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+        let path = dir.join("noeol.txt");
+        std::fs::write(&path, "alpha\nbeta").expect("write file");
+        let from_disk = Buffer::from_file(path).expect("load");
+        assert_eq!(from_disk.content(), "alpha\nbeta\n");
+        assert!(!from_disk.dirty, "normalization must not mark dirty");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2916,10 +2916,13 @@ impl Editor {
         let cursor_col = self.cursor.col;
         self.undo_stack.end_undo_group(cursor_line, cursor_col);
         self.undo_stack.begin_undo_group(cursor_line, cursor_col);
-        self.undo_stack
-            .record_change(Change::new(0, 0, old_content, content.to_string()));
 
+        // Record what actually lands in the buffer: set_content may append
+        // a missing final newline, and the redo string must match it.
         self.buffer_mut().set_content(content);
+        let new_content = self.buffer().content();
+        self.undo_stack
+            .record_change(Change::new(0, 0, old_content, new_content));
 
         let max_line = self.buffer().addressable_line_count().saturating_sub(1);
         self.cursor.line = cursor_line.min(max_line);
@@ -12615,7 +12618,9 @@ mod tests {
         editor.apply_motion(Motion::LineEnd, 1);
         editor.visual_delete();
 
-        assert_eq!(editor.buffer().content(), "");
+        // Normalized on load (fixendofline): deleting all text leaves the
+        // single empty line, like Vim's always-at-least-one-line buffer.
+        assert_eq!(editor.buffer().content(), "\n");
         assert_eq!(editor.mode, Mode::Normal);
         assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
     }

--- a/src/editor/tests/editing_operators.rs
+++ b/src/editor/tests/editing_operators.rs
@@ -173,8 +173,10 @@ fn linewise_paste_after_unterminated_last_line_remains_undoable() {
     editor.yank_line(1, Some('a'));
     editor.paste_after(Some('a'));
 
+    // The no-EOL source text is normalized on load (fixendofline), so undo
+    // restores the terminated form.
     editor.undo();
-    assert_eq!(editor.buffer().content(), "abc");
+    assert_eq!(editor.buffer().content(), "abc\n");
 
     editor.redo();
     assert_eq!(editor.buffer().content(), "abc\nabc\n");

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -15857,7 +15857,8 @@ mod tests {
         handle_key(&mut editor, key('c'));
         handle_key(&mut editor, key('$'));
 
-        assert_eq!(editor.buffer().content(), "ab");
+        // The no-EOL source text is normalized on load (fixendofline).
+        assert_eq!(editor.buffer().content(), "ab\n");
         assert_eq!(editor.mode, Mode::Insert);
         assert_eq!(editor.cursor.col, 2);
 

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -296,4 +296,16 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "alpha\nbeta\n",
         keys: "GgJ",
     },
+    // No-EOL buffers must behave like Neovim ('fixendofline' default):
+    // the buffer gains the missing final newline on load.
+    OracleCase {
+        name: "enter in insert at eof without trailing newline",
+        initial_text: "abc",
+        keys: "A<CR><Esc>",
+    },
+    OracleCase {
+        name: "join on last line without trailing newline",
+        initial_text: "alpha\nbeta",
+        keys: "GJ",
+    },
 ];

--- a/src/vim_oracle/open_line_cases.rs
+++ b/src/vim_oracle/open_line_cases.rs
@@ -93,4 +93,17 @@ pub(super) const OPEN_LINE_CASES: &[OracleCase] = &[
         initial_text: "alpha\nomega\n",
         keys: "j$Oabove<Esc>u<C-r>",
     },
+    // Fuzz-found class: without the missing-final-newline fix, opening a
+    // line at the end of a no-EOL buffer parked the cursor on the rope's
+    // trailing sentinel line.
+    OracleCase {
+        name: "open below at eof without trailing newline",
+        initial_text: "abc",
+        keys: "o<Esc>",
+    },
+    OracleCase {
+        name: "open below and type at eof without trailing newline",
+        initial_text: "abc",
+        keys: "oend<Esc>",
+    },
 ];


### PR DESCRIPTION
Files without a trailing final newline now gain one on load and save,
matching Neovim's 'fixendofline' default. This makes the no-EOL state
unrepresentable while editing and fixes the fuzz-found class where
opening a line at end of file parked the cursor on the rope's trailing
sentinel line.

The undo path records post-normalization content so redo cannot
resurrect the unterminated state. Three older tests that patched
individual symptoms of this class (linewise paste, visual delete to
EOF, c$ on no-EOL buffers) are updated to the normalized model.