### PR TITLE
feat: add macro lens (:Macros view, :MacroEdit editing)

### DIFF
--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -458,6 +458,17 @@ Record and replay sequences of commands.
 
 > **Example:** `qa` starts recording into register `a`. Make your edits, press `q` to stop. Then `@a` replays it. `5@a` replays it 5 times.
 
+### Macro Lens
+
+View and edit recorded macros as readable key notation instead of re-recording.
+
+| Command | Action |
+|---------|--------|
+| `:Macros` | Open all recorded macros as notation in a read-only `[macros]` buffer |
+| `:MacroEdit {a-z}` | Edit one register's notation in a `[macro-{register}]` scratch buffer; `:w` applies it back to the register (empty content clears it) |
+
+> **Example:** after recording `qa`…`q`, run `:Macros` to see `@a  0f,ci"hello<Esc>j`. Typo in the macro? `:MacroEdit a`, fix the notation like any text, `:w`, and `@a` replays the corrected version. Newlines in the edit buffer are ignored, so long macros can be wrapped; a literal Enter is written as `<CR>`.
+
 ---
 
 ## Insert Mode

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ nevi file1.rs file2.rs
 - `:checkhealth` / `:Health` - Open editor health report in a read-only `[health]` buffer
 - `:ToolInstall` / `:LspInstall` - Open missing LSP/tool install guidance in a read-only `[tool-installer]` buffer
 - `:FlightRecorder` / `:WhySlow` - Open recent in-memory timing report in a read-only `[flight-recorder]` buffer
+- `:Macros` / `:MacroEdit {a-z}` - View recorded macros as readable notation, or edit one as text and `:w` it back into its register
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -167,6 +167,10 @@ pub enum Command {
     ConfigOpen,
     /// :ConfigDefaults - Open the latest default config template
     ConfigDefaults,
+    /// :Macros - Open recorded macros as readable notation
+    Macros,
+    /// :MacroEdit {register} - Edit a macro's notation in a scratch buffer
+    MacroEdit(char),
     /// :marks - Show all marks
     Marks,
     /// :delmarks {marks} - Delete specified marks
@@ -682,6 +686,18 @@ const COMMAND_SPECS: &[CommandSpec] = &[
         takes_args: false,
     },
     CommandSpec {
+        command: "Macros",
+        aliases: &["macros"],
+        description: "Open recorded macros as readable notation",
+        takes_args: false,
+    },
+    CommandSpec {
+        command: "MacroEdit",
+        aliases: &["macroedit"],
+        description: "Edit a macro register's notation (:MacroEdit a)",
+        takes_args: true,
+    },
+    CommandSpec {
         command: "marks",
         aliases: &[],
         description: "Show all marks",
@@ -1123,6 +1139,20 @@ pub fn parse_command(input: &str) -> Command {
         "Jump" | "jump" => Command::Jump,
         "ConfigOpen" | "configopen" | "config" | "ConfigEdit" | "configedit" => Command::ConfigOpen,
         "ConfigDefaults" | "configdefaults" | "defaults" => Command::ConfigDefaults,
+
+        // Macro lens commands
+        "Macros" | "macros" => Command::Macros,
+        "MacroEdit" | "macroedit" => {
+            if let Some(arg) = args.filter(|s| !s.is_empty()) {
+                let mut chars = arg.chars();
+                match (chars.next(), chars.next()) {
+                    (Some(register), None) => Command::MacroEdit(register),
+                    _ => Command::Unknown("MacroEdit: register must be one letter a-z".to_string()),
+                }
+            } else {
+                Command::Unknown("MacroEdit: missing register (a-z)".to_string())
+            }
+        }
 
         // Marks commands
         "marks" => Command::Marks,
@@ -1914,6 +1944,22 @@ mod tests {
         assert!(matches!(parse_command("GitChanges"), Command::GitChanges));
         assert!(matches!(parse_command("changes"), Command::GitChanges));
         assert!(matches!(parse_command("gc"), Command::GitChanges));
+    }
+
+    #[test]
+    fn parses_macro_lens_commands() {
+        assert!(matches!(parse_command("Macros"), Command::Macros));
+        assert!(matches!(parse_command("macros"), Command::Macros));
+        assert!(matches!(
+            parse_command("MacroEdit a"),
+            Command::MacroEdit('a')
+        ));
+        assert!(matches!(
+            parse_command("macroedit q"),
+            Command::MacroEdit('q')
+        ));
+        assert!(matches!(parse_command("MacroEdit"), Command::Unknown(_)));
+        assert!(matches!(parse_command("MacroEdit ab"), Command::Unknown(_)));
     }
 
     #[test]

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -101,6 +101,26 @@ impl Buffer {
         }
     }
 
+    /// Create a named editable virtual buffer (e.g. the macro-lens edit view).
+    pub fn virtual_writable(
+        name: impl Into<String>,
+        content: &str,
+        syntax_hint_path: Option<PathBuf>,
+    ) -> Self {
+        Self {
+            text: Rope::from_str(content),
+            path: None,
+            dirty: false,
+            version: 0,
+            last_mtime: None,
+            kind: BufferKind::Virtual {
+                name: name.into(),
+                read_only: false,
+                syntax_hint_path,
+            },
+        }
+    }
+
     /// Whether this buffer should reject direct content changes.
     pub fn is_read_only(&self) -> bool {
         matches!(

--- a/src/editor/macros.rs
+++ b/src/editor/macros.rs
@@ -58,6 +58,26 @@ impl MacroState {
         self.macros.get(&register)
     }
 
+    /// Replace a macro's keys directly (macro-lens editing); empty clears it.
+    pub fn set_macro(&mut self, register: char, keys: Vec<KeyEvent>) {
+        if keys.is_empty() {
+            self.macros.remove(&register);
+        } else {
+            self.macros.insert(register, keys);
+        }
+    }
+
+    /// All recorded macros, sorted by register for stable display.
+    pub fn recorded(&self) -> Vec<(char, &[KeyEvent])> {
+        let mut entries: Vec<(char, &[KeyEvent])> = self
+            .macros
+            .iter()
+            .map(|(register, keys)| (*register, keys.as_slice()))
+            .collect();
+        entries.sort_by_key(|(register, _)| *register);
+        entries
+    }
+
     /// Get the last executed macro register
     pub fn last_executed(&self) -> Option<char> {
         self.last_executed

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1861,6 +1861,72 @@ impl Editor {
         );
     }
 
+    /// Open the macro-lens overview: every recorded register as vim notation.
+    pub fn open_macros_view(&mut self) {
+        let entries: Vec<(char, Result<String, String>)> = self
+            .macros
+            .recorded()
+            .into_iter()
+            .map(|(register, keys)| {
+                (
+                    register,
+                    crate::input::key_notation::encode_key_sequence(keys),
+                )
+            })
+            .collect();
+        let content = crate::macro_lens::render_macros_view(&entries);
+        self.open_virtual_read_only_buffer(
+            crate::macro_lens::MACROS_VIEW_BUFFER_NAME,
+            &content,
+            Some("macros.md"),
+        );
+    }
+
+    /// Open one macro register for editing as notation in a scratch buffer.
+    /// An empty register opens empty, so new macros can be written from scratch.
+    pub fn open_macro_edit_buffer(&mut self, register: char) -> Result<(), String> {
+        if !MacroState::is_valid_register(register) {
+            return Err(format!("Invalid macro register `{register}` (use a-z)"));
+        }
+        if self.macros.is_recording() {
+            return Err("Cannot edit a macro while recording".to_string());
+        }
+        let notation = match self.macros.get_macro(register) {
+            Some(keys) => crate::input::key_notation::encode_key_sequence(keys)
+                .map_err(|reason| format!("Macro @{register} cannot be edited: {reason}"))?,
+            None => String::new(),
+        };
+        self.open_virtual_writable_buffer(
+            crate::macro_lens::edit_buffer_name(register),
+            &notation,
+            None,
+        );
+        Ok(())
+    }
+
+    /// Register behind the current buffer if it is a macro-edit buffer.
+    pub fn macro_edit_register(&self) -> Option<char> {
+        crate::macro_lens::register_from_edit_buffer_name(&self.buffer().display_name())
+    }
+
+    /// `:w` in a macro-edit buffer: parse the notation back into the register.
+    /// The buffer stays dirty on parse errors so unsaved work isn't misreported.
+    pub fn save_macro_edit_buffer(&mut self) -> Result<String, String> {
+        let register = self
+            .macro_edit_register()
+            .ok_or_else(|| "Not a macro edit buffer".to_string())?;
+        let notation = crate::macro_lens::notation_from_edit_content(&self.buffer().content());
+        let keys = crate::input::key_notation::parse_key_sequence(&notation)?;
+        let message = if keys.is_empty() {
+            format!("Macro @{register} cleared")
+        } else {
+            format!("Macro @{register} updated ({} keys)", keys.len())
+        };
+        self.macros.set_macro(register, keys);
+        self.buffer_mut().dirty = false;
+        Ok(message)
+    }
+
     /// Build a project-wide replace preview and open it as a read-only buffer.
     pub fn preview_project_replace(
         &mut self,
@@ -1985,6 +2051,24 @@ impl Editor {
             content,
             syntax_hint_path.map(std::path::PathBuf::from),
         );
+        self.open_virtual_buffer(new_buffer);
+    }
+
+    pub fn open_virtual_writable_buffer(
+        &mut self,
+        name: impl Into<String>,
+        content: &str,
+        syntax_hint_path: Option<&str>,
+    ) {
+        let new_buffer = Buffer::virtual_writable(
+            name,
+            content,
+            syntax_hint_path.map(std::path::PathBuf::from),
+        );
+        self.open_virtual_buffer(new_buffer);
+    }
+
+    fn open_virtual_buffer(&mut self, new_buffer: Buffer) {
         self.markdown_preview = None;
 
         if self.buffers[self.current_buffer_idx].is_empty()
@@ -11308,6 +11392,7 @@ mod tests {
     mod editing_operators;
     mod file_lifecycle;
     mod insert_entry;
+    mod macro_lens;
     mod open_line;
     mod replace;
     mod screen_position;

--- a/src/editor/tests/macro_lens.rs
+++ b/src/editor/tests/macro_lens.rs
@@ -1,0 +1,163 @@
+use crate::editor::Editor;
+use crate::input::key_notation::parse_key_sequence;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+fn editor_with_macro(register: char, notation: &str) -> Editor {
+    let mut editor = Editor::default();
+    editor
+        .macros
+        .set_macro(register, parse_key_sequence(notation).expect(notation));
+    editor
+}
+
+#[test]
+fn macros_view_lists_recorded_macros_as_notation() {
+    let mut editor = editor_with_macro('a', "0f,ci\"hi<Esc>j");
+    editor
+        .macros
+        .set_macro('b', parse_key_sequence("dw").unwrap());
+
+    editor.open_macros_view();
+
+    assert_eq!(editor.buffer().display_name(), "[macros]");
+    assert!(editor.buffer().is_read_only());
+    let content = editor.buffer().content();
+    assert!(content.contains("@a  0f,ci\"hi<Esc>j"));
+    assert!(content.contains("@b  dw"));
+}
+
+#[test]
+fn macros_view_without_recordings_explains_how_to_record() {
+    let mut editor = Editor::default();
+
+    editor.open_macros_view();
+
+    assert!(editor.buffer().content().contains("No macros recorded yet"));
+}
+
+#[test]
+fn macros_view_marks_unencodable_macros_instead_of_failing() {
+    let mut editor = Editor::default();
+    editor
+        .macros
+        .set_macro('q', vec![KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE)]);
+
+    editor.open_macros_view();
+
+    assert!(editor.buffer().content().contains("@q  (not editable:"));
+}
+
+#[test]
+fn macro_edit_buffer_shows_notation_and_saves_back_to_register() {
+    let mut editor = editor_with_macro('a', "ciw<Esc>");
+
+    editor
+        .open_macro_edit_buffer('a')
+        .expect("open edit buffer");
+
+    assert_eq!(editor.buffer().display_name(), "[macro-a]");
+    assert!(!editor.buffer().is_read_only());
+    assert_eq!(editor.buffer().content(), "ciw<Esc>");
+
+    editor.replace_buffer_content("2ciw<Esc>");
+    editor.buffer_mut().dirty = true;
+    let message = editor.save_macro_edit_buffer().expect("save");
+
+    assert!(message.contains("Macro @a updated"));
+    assert_eq!(
+        editor.macros.get_macro('a'),
+        Some(&parse_key_sequence("2ciw<Esc>").unwrap())
+    );
+    assert!(!editor.buffer().dirty, "successful save clears dirty");
+}
+
+#[test]
+fn macro_edit_of_empty_register_creates_a_new_macro() {
+    let mut editor = Editor::default();
+
+    editor
+        .open_macro_edit_buffer('z')
+        .expect("open edit buffer");
+    assert_eq!(editor.buffer().content(), "");
+
+    editor.replace_buffer_content("ggVG");
+    editor.save_macro_edit_buffer().expect("save");
+
+    assert_eq!(
+        editor.macros.get_macro('z'),
+        Some(&parse_key_sequence("ggVG").unwrap())
+    );
+}
+
+#[test]
+fn macro_edit_save_rejects_bad_notation_and_preserves_register() {
+    let mut editor = editor_with_macro('a', "x");
+    editor
+        .open_macro_edit_buffer('a')
+        .expect("open edit buffer");
+
+    editor.replace_buffer_content("d<Esc");
+    editor.buffer_mut().dirty = true;
+    let error = editor.save_macro_edit_buffer().expect_err("bad notation");
+
+    assert!(error.contains("unterminated"));
+    assert_eq!(
+        editor.macros.get_macro('a'),
+        Some(&parse_key_sequence("x").unwrap()),
+        "register must be untouched on parse errors"
+    );
+    assert!(editor.buffer().dirty, "failed save must not clear dirty");
+}
+
+#[test]
+fn macro_edit_saving_empty_content_clears_the_register() {
+    let mut editor = editor_with_macro('a', "x");
+    editor
+        .open_macro_edit_buffer('a')
+        .expect("open edit buffer");
+
+    editor.replace_buffer_content("");
+    let message = editor.save_macro_edit_buffer().expect("save");
+
+    assert!(message.contains("cleared"));
+    assert_eq!(editor.macros.get_macro('a'), None);
+}
+
+#[test]
+fn macro_edit_is_blocked_while_recording() {
+    let mut editor = Editor::default();
+    editor.macros.start_recording('q');
+
+    let error = editor.open_macro_edit_buffer('a').expect_err("recording");
+
+    assert!(error.contains("recording"));
+}
+
+#[test]
+fn macro_edit_rejects_invalid_registers_and_unencodable_macros() {
+    let mut editor = Editor::default();
+    assert!(editor.open_macro_edit_buffer('A').is_err());
+    assert!(editor.open_macro_edit_buffer('1').is_err());
+
+    editor
+        .macros
+        .set_macro('q', vec![KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE)]);
+    let error = editor.open_macro_edit_buffer('q').expect_err("unencodable");
+    assert!(error.contains("cannot be edited"));
+}
+
+#[test]
+fn wrapped_edit_content_joins_lines_before_parsing() {
+    let mut editor = Editor::default();
+    editor
+        .open_macro_edit_buffer('a')
+        .expect("open edit buffer");
+
+    editor.replace_buffer_content("gg\nVG\n");
+    editor.save_macro_edit_buffer().expect("save");
+
+    assert_eq!(
+        editor.macros.get_macro('a'),
+        Some(&parse_key_sequence("ggVG").unwrap())
+    );
+}

--- a/src/input/key_notation.rs
+++ b/src/input/key_notation.rs
@@ -1,0 +1,218 @@
+//! Vim-style key notation ↔ `KeyEvent` codec.
+//!
+//! One grammar shared by the vim-oracle test harness (notation → events for
+//! replay) and the macro lens (recorded events → notation for viewing and
+//! editing). Keeping both directions in one module is what guarantees an
+//! edited macro parses back to exactly the events the encoder was shown.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Parse a vim-notation key string (`ciw<Esc><C-r>`) into key events.
+pub fn parse_key_sequence(input: &str) -> Result<Vec<KeyEvent>, String> {
+    let mut keys = Vec::new();
+    let mut chars = input.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '<' {
+            let mut token = String::new();
+            let mut closed = false;
+            for token_ch in chars.by_ref() {
+                if token_ch == '>' {
+                    closed = true;
+                    break;
+                }
+                token.push(token_ch);
+            }
+
+            if !closed {
+                return Err(format!("unterminated key token in `{input}`"));
+            }
+
+            keys.push(parse_key_token(&token)?);
+        } else {
+            keys.push(char_key(ch));
+        }
+    }
+
+    Ok(keys)
+}
+
+fn parse_key_token(token: &str) -> Result<KeyEvent, String> {
+    let lower = token.to_ascii_lowercase();
+    match lower.as_str() {
+        "esc" => Ok(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
+        "cr" | "enter" | "return" => Ok(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
+        "tab" => Ok(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
+        "bs" | "backspace" => Ok(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
+        "left" => Ok(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)),
+        "right" => Ok(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
+        "up" => Ok(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
+        "down" => Ok(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
+        "del" | "delete" => Ok(KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE)),
+        "home" => Ok(KeyEvent::new(KeyCode::Home, KeyModifiers::NONE)),
+        "end" => Ok(KeyEvent::new(KeyCode::End, KeyModifiers::NONE)),
+        "pageup" => Ok(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE)),
+        "pagedown" => Ok(KeyEvent::new(KeyCode::PageDown, KeyModifiers::NONE)),
+        "space" => Ok(char_key(' ')),
+        "lt" => Ok(char_key('<')),
+        _ => {
+            if let Some(control) = lower
+                .strip_prefix("c-")
+                .or_else(|| lower.strip_prefix("ctrl-"))
+            {
+                let mut chars = control.chars();
+                if let (Some(ch), None) = (chars.next(), chars.next()) {
+                    return Ok(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL));
+                }
+            }
+            Err(format!("unsupported key token `<{token}>`"))
+        }
+    }
+}
+
+fn char_key(ch: char) -> KeyEvent {
+    if ch.is_ascii_uppercase() {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::SHIFT)
+    } else {
+        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE)
+    }
+}
+
+/// Encode key events as vim notation, or explain which key can't be written.
+pub fn encode_key_sequence(keys: &[KeyEvent]) -> Result<String, String> {
+    let mut out = String::new();
+    for key in keys {
+        out.push_str(&encode_key_event(key)?);
+    }
+    Ok(out)
+}
+
+fn encode_key_event(key: &KeyEvent) -> Result<String, String> {
+    match key.code {
+        KeyCode::Char(ch) => {
+            if key.modifiers.contains(KeyModifiers::CONTROL) {
+                // Parsing lowercases the token, so normalize here for roundtrips.
+                return Ok(format!("<C-{}>", ch.to_ascii_lowercase()));
+            }
+            // SHIFT is implied by the character itself ('A', '$'); other
+            // modifiers (Alt, Super) have no notation.
+            if key.modifiers.difference(KeyModifiers::SHIFT) != KeyModifiers::NONE {
+                return Err(format!(
+                    "key `{ch}` with modifiers {:?} has no notation",
+                    key.modifiers
+                ));
+            }
+            if ch == '<' {
+                return Ok("<lt>".to_string());
+            }
+            Ok(ch.to_string())
+        }
+        code => {
+            if key.modifiers != KeyModifiers::NONE {
+                return Err(format!(
+                    "key {code:?} with modifiers {:?} has no notation",
+                    key.modifiers
+                ));
+            }
+            let token = match code {
+                KeyCode::Esc => "Esc",
+                KeyCode::Enter => "CR",
+                KeyCode::Tab => "Tab",
+                KeyCode::Backspace => "BS",
+                KeyCode::Left => "Left",
+                KeyCode::Right => "Right",
+                KeyCode::Up => "Up",
+                KeyCode::Down => "Down",
+                KeyCode::Delete => "Del",
+                KeyCode::Home => "Home",
+                KeyCode::End => "End",
+                KeyCode::PageUp => "PageUp",
+                KeyCode::PageDown => "PageDown",
+                other => return Err(format!("key {other:?} has no notation")),
+            };
+            Ok(format!("<{token}>"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_key_sequence, parse_key_sequence};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    #[test]
+    fn notation_roundtrips_through_events_and_back() {
+        let samples = [
+            "ciw<Esc>",
+            "0f,ci\"hello<Esc>j",
+            "2dd@aP",
+            "<C-r><C-d>",
+            "<CR><Tab><BS><Esc>",
+            "<Left><Right><Up><Down>",
+            "<Del><Home><End><PageUp><PageDown>",
+            "i<lt>div><CR><Esc>",
+            "f x",
+            "A;<Esc>",
+        ];
+
+        for sample in samples {
+            let events = parse_key_sequence(sample).expect(sample);
+            let encoded = encode_key_sequence(&events).expect(sample);
+            assert_eq!(encoded, sample, "notation should roundtrip unchanged");
+        }
+    }
+
+    #[test]
+    fn events_roundtrip_through_notation_and_back() {
+        let events = vec![
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            KeyEvent::new(KeyCode::Char('r'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('<'), KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE),
+            KeyEvent::new(KeyCode::Delete, KeyModifiers::NONE),
+        ];
+
+        let notation = encode_key_sequence(&events).expect("encode");
+        assert_eq!(notation, "dG<C-r><lt><Esc><Del>");
+        assert_eq!(parse_key_sequence(&notation).expect("parse"), events);
+    }
+
+    #[test]
+    fn uppercase_and_symbol_chars_encode_without_modifier_tokens() {
+        // Terminals disagree on whether shifted characters carry SHIFT; the
+        // character itself is the source of truth either way.
+        let with_shift = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::SHIFT);
+        let without = KeyEvent::new(KeyCode::Char('$'), KeyModifiers::NONE);
+
+        assert_eq!(encode_key_sequence(&[with_shift]).unwrap(), "$");
+        assert_eq!(encode_key_sequence(&[without]).unwrap(), "$");
+    }
+
+    #[test]
+    fn control_uppercase_normalizes_to_parseable_lowercase() {
+        let event = KeyEvent::new(
+            KeyCode::Char('R'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        );
+
+        let notation = encode_key_sequence(&[event]).expect("encode");
+        assert_eq!(notation, "<C-r>");
+        assert!(parse_key_sequence(&notation).is_ok());
+    }
+
+    #[test]
+    fn unrepresentable_keys_report_an_error_instead_of_lossy_output() {
+        let alt_char = KeyEvent::new(KeyCode::Char('x'), KeyModifiers::ALT);
+        assert!(encode_key_sequence(&[alt_char]).is_err());
+
+        let function_key = KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE);
+        assert!(encode_key_sequence(&[function_key]).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_unterminated_and_unknown_tokens() {
+        assert!(parse_key_sequence("d<Esc").is_err());
+        assert!(parse_key_sequence("<F5>").is_err());
+    }
+}

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,3 +1,4 @@
+pub mod key_notation;
 pub mod motion;
 
 pub use motion::{Motion, apply_motion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod input;
 mod keybind_coverage;
 pub mod labeled_jump;
 pub mod lsp;
+pub mod macro_lens;
 pub mod markdown_preview;
 #[cfg(test)]
 mod parity_report;

--- a/src/macro_lens.rs
+++ b/src/macro_lens.rs
@@ -1,0 +1,109 @@
+//! Macro Lens — view and edit recorded macros as readable vim notation.
+//!
+//! `:Macros` renders every recorded register through the key-notation encoder;
+//! `:MacroEdit {register}` opens one in an editable scratch buffer whose `:w`
+//! parses the notation back into the register. The pure text logic lives here;
+//! buffer plumbing stays on `Editor`.
+
+/// Name of the read-only `:Macros` overview buffer.
+pub const MACROS_VIEW_BUFFER_NAME: &str = "[macros]";
+
+const EDIT_BUFFER_PREFIX: &str = "[macro-";
+const EDIT_BUFFER_SUFFIX: &str = "]";
+
+/// Buffer name for editing one register, e.g. `[macro-a]`.
+pub fn edit_buffer_name(register: char) -> String {
+    format!("{EDIT_BUFFER_PREFIX}{register}{EDIT_BUFFER_SUFFIX}")
+}
+
+/// Recover the register from an edit-buffer name. Deriving it from the name
+/// keeps `Editor` free of extra state that buffer closes could orphan.
+pub fn register_from_edit_buffer_name(name: &str) -> Option<char> {
+    let register = name
+        .strip_prefix(EDIT_BUFFER_PREFIX)?
+        .strip_suffix(EDIT_BUFFER_SUFFIX)?;
+    let mut chars = register.chars();
+    match (chars.next(), chars.next()) {
+        (Some(ch), None) if ch.is_ascii_lowercase() => Some(ch),
+        _ => None,
+    }
+}
+
+/// Notation from an edit buffer's content. Newlines are dropped (never part of
+/// notation — `<CR>` is a token) so long macros may be wrapped for readability.
+pub fn notation_from_edit_content(content: &str) -> String {
+    content.chars().filter(|ch| *ch != '\n').collect()
+}
+
+/// Render the `:Macros` overview from (register, encoded-or-error) pairs.
+pub fn render_macros_view(entries: &[(char, Result<String, String>)]) -> String {
+    let mut out = String::from("# Macros\n\n");
+
+    if entries.is_empty() {
+        out.push_str("No macros recorded yet. Record one with `q{a-z}...q`.\n");
+        return out;
+    }
+
+    out.push_str("Replay with `@{register}`. Edit with `:MacroEdit {register}`.\n\n");
+    for (register, notation) in entries {
+        match notation {
+            Ok(notation) => {
+                out.push_str(&format!("@{register}  {notation}\n"));
+            }
+            Err(reason) => {
+                out.push_str(&format!("@{register}  (not editable: {reason})\n"));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        edit_buffer_name, notation_from_edit_content, register_from_edit_buffer_name,
+        render_macros_view,
+    };
+
+    #[test]
+    fn edit_buffer_names_roundtrip_to_registers() {
+        for register in 'a'..='z' {
+            let name = edit_buffer_name(register);
+            assert_eq!(register_from_edit_buffer_name(&name), Some(register));
+        }
+    }
+
+    #[test]
+    fn non_macro_buffer_names_are_rejected() {
+        for name in ["[macros]", "[macro-A]", "[macro-ab]", "[macro-]", "main.rs"] {
+            assert_eq!(register_from_edit_buffer_name(name), None, "{name}");
+        }
+    }
+
+    #[test]
+    fn edit_content_drops_newlines_but_keeps_meaningful_spaces() {
+        assert_eq!(notation_from_edit_content("ciw<Esc>\n"), "ciw<Esc>");
+        assert_eq!(notation_from_edit_content("f x\ndd\n"), "f xdd");
+        // A trailing space is a real key (e.g. `f<space>`), not stray whitespace.
+        assert_eq!(notation_from_edit_content("f \n"), "f ");
+    }
+
+    #[test]
+    fn view_lists_macros_and_marks_unencodable_ones() {
+        let entries = vec![
+            ('a', Ok("0f,ci\"hi<Esc>".to_string())),
+            ('q', Err("key F(5) has no notation".to_string())),
+        ];
+
+        let view = render_macros_view(&entries);
+
+        assert!(view.contains("@a  0f,ci\"hi<Esc>"));
+        assert!(view.contains("@q  (not editable: key F(5) has no notation)"));
+    }
+
+    #[test]
+    fn empty_view_explains_how_to_record() {
+        let view = render_macros_view(&[]);
+        assert!(view.contains("No macros recorded yet"));
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9967,7 +9967,14 @@ fn rename_file_impl(
 fn execute_command(editor: &mut Editor, cmd: Command) {
     let result = match cmd {
         Command::Write(path) => {
-            if let Some(p) = path {
+            // A macro-edit buffer's `:w` applies the notation to the register
+            // instead of writing a file (it has no path to write to anyway).
+            if path.is_none() && editor.macro_edit_register().is_some() {
+                match editor.save_macro_edit_buffer() {
+                    Ok(message) => CommandResult::Message(message),
+                    Err(error) => CommandResult::Error(error),
+                }
+            } else if let Some(p) = path {
                 // Save as: skip format_on_save for explicit path
                 match editor.save_as(p) {
                     Ok(()) => CommandResult::Ok,
@@ -10030,7 +10037,14 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
         }
 
         Command::ForceWrite(path) => {
-            if let Some(p) = path {
+            // `:w!` in a macro-edit buffer applies the notation, same as `:w` —
+            // force has nothing extra to override for a register.
+            if path.is_none() && editor.macro_edit_register().is_some() {
+                match editor.save_macro_edit_buffer() {
+                    Ok(message) => CommandResult::Message(message),
+                    Err(error) => CommandResult::Error(error),
+                }
+            } else if let Some(p) = path {
                 match editor.save_as_force(p) {
                     Ok(()) => CommandResult::Ok,
                     Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
@@ -10617,6 +10631,18 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             editor.open_config_defaults_preview();
             CommandResult::Ok
         }
+
+        Command::Macros => {
+            editor.open_macros_view();
+            CommandResult::Ok
+        }
+
+        Command::MacroEdit(register) => match editor.open_macro_edit_buffer(register) {
+            Ok(()) => CommandResult::Message(format!(
+                "Editing macro @{register} (:w applies the notation)"
+            )),
+            Err(message) => CommandResult::Error(message),
+        },
 
         Command::Marks => {
             editor.open_finder_marks();
@@ -14118,6 +14144,136 @@ mod tests {
         assert!(text.contains("Nevi Flight Recorder"));
         assert!(text.contains("handle_key"));
         assert!(text.contains("slow"));
+    }
+
+    #[test]
+    fn macro_edit_write_command_applies_notation_to_register() {
+        use crate::input::key_notation::parse_key_sequence;
+
+        let mut editor = Editor::default();
+
+        execute_command(&mut editor, crate::commands::parse_command("MacroEdit a"));
+        assert_eq!(editor.buffer().display_name(), "[macro-a]");
+        assert!(!editor.buffer().is_read_only());
+
+        editor.replace_buffer_content("0dw<Esc>");
+        editor.buffer_mut().dirty = true;
+        execute_command(&mut editor, Command::Write(None));
+
+        assert_eq!(
+            editor.macros.get_macro('a'),
+            Some(&parse_key_sequence("0dw<Esc>").unwrap())
+        );
+        assert!(!editor.buffer().dirty, ":w must apply and mark clean");
+    }
+
+    #[test]
+    fn macros_command_opens_read_only_overview() {
+        use crate::input::key_notation::parse_key_sequence;
+
+        let mut editor = Editor::default();
+        editor
+            .macros
+            .set_macro('a', parse_key_sequence("ciw<Esc>").unwrap());
+
+        execute_command(&mut editor, crate::commands::parse_command("Macros"));
+
+        assert_eq!(editor.buffer().display_name(), "[macros]");
+        assert!(editor.buffer().is_read_only());
+        assert!(editor.buffer().content().contains("@a  ciw<Esc>"));
+    }
+
+    #[test]
+    fn recorded_macro_shows_in_view_with_real_key_events() {
+        // Record through handle_key so the encoder sees genuine recorded
+        // events (q/register markers excluded), not string-parsed ones.
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha beta\n");
+
+        for k in [key('q'), key('a'), key('d'), key('w'), key('q')] {
+            handle_key(&mut editor, k);
+        }
+        assert_eq!(editor.buffer().content(), "beta\n");
+
+        execute_command(&mut editor, crate::commands::parse_command("Macros"));
+
+        assert!(
+            editor.buffer().content().contains("@a  dw"),
+            "recording markers must not leak into the notation: {}",
+            editor.buffer().content()
+        );
+    }
+
+    #[test]
+    fn edited_macro_replays_through_the_key_pipeline() {
+        use crate::commands::parse_command;
+
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha one\nbeta two\ngamma three\n");
+
+        // Author a macro purely through the lens: edit buffer, :w, back.
+        execute_command(&mut editor, parse_command("MacroEdit a"));
+        editor.replace_buffer_content("0dwj");
+        execute_command(&mut editor, Command::Write(None));
+        execute_command(&mut editor, Command::Prev);
+        assert_eq!(
+            editor.buffer().content(),
+            "alpha one\nbeta two\ngamma three\n"
+        );
+
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('g'));
+        handle_key(&mut editor, key('@'));
+        handle_key(&mut editor, key('a'));
+        assert_eq!(editor.buffer().content(), "one\nbeta two\ngamma three\n");
+
+        // `@@` must replay the lens-authored macro as the last executed one.
+        handle_key(&mut editor, key('@'));
+        handle_key(&mut editor, key('@'));
+        assert_eq!(editor.buffer().content(), "one\ntwo\ngamma three\n");
+    }
+
+    #[test]
+    fn force_write_applies_macro_notation_like_write() {
+        use crate::input::key_notation::parse_key_sequence;
+
+        let mut editor = Editor::default();
+        execute_command(&mut editor, crate::commands::parse_command("MacroEdit a"));
+        editor.replace_buffer_content("x");
+        editor.buffer_mut().dirty = true;
+
+        execute_command(&mut editor, Command::ForceWrite(None));
+
+        assert_eq!(
+            editor.macros.get_macro('a'),
+            Some(&parse_key_sequence("x").unwrap())
+        );
+        assert!(!editor.buffer().dirty);
+    }
+
+    #[test]
+    fn write_with_explicit_path_in_macro_buffer_writes_a_file_not_the_register() {
+        let mut editor = Editor::default();
+        execute_command(&mut editor, crate::commands::parse_command("MacroEdit a"));
+        editor.replace_buffer_content("dw");
+
+        let path = std::env::temp_dir().join(format!(
+            "nevi_macro_lens_save_as_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        execute_command(&mut editor, Command::Write(Some(path.clone())));
+
+        assert_eq!(
+            editor.macros.get_macro('a'),
+            None,
+            ":w {{path}} must not touch the register"
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "dw");
+        let _ = std::fs::remove_file(&path);
     }
 
     #[test]

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -1,6 +1,7 @@
 use crate::editor::{Editor, Mode};
+use crate::input::key_notation::parse_key_sequence;
 use crate::terminal::handle_key;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::KeyEvent;
 use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -817,71 +818,6 @@ pub(crate) fn has_oracle_case(name: &str) -> bool {
         .iter()
         .flat_map(|category| category.cases)
         .any(|case| case.name == name)
-}
-
-fn parse_key_sequence(input: &str) -> Result<Vec<KeyEvent>, String> {
-    let mut keys = Vec::new();
-    let mut chars = input.chars().peekable();
-
-    while let Some(ch) = chars.next() {
-        if ch == '<' {
-            let mut token = String::new();
-            let mut closed = false;
-            for token_ch in chars.by_ref() {
-                if token_ch == '>' {
-                    closed = true;
-                    break;
-                }
-                token.push(token_ch);
-            }
-
-            if !closed {
-                return Err(format!("unterminated key token in `{input}`"));
-            }
-
-            keys.push(parse_key_token(&token)?);
-        } else {
-            keys.push(char_key(ch));
-        }
-    }
-
-    Ok(keys)
-}
-
-fn parse_key_token(token: &str) -> Result<KeyEvent, String> {
-    let lower = token.to_ascii_lowercase();
-    match lower.as_str() {
-        "esc" => Ok(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)),
-        "cr" | "enter" | "return" => Ok(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE)),
-        "tab" => Ok(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)),
-        "bs" | "backspace" => Ok(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE)),
-        "left" => Ok(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)),
-        "right" => Ok(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE)),
-        "up" => Ok(KeyEvent::new(KeyCode::Up, KeyModifiers::NONE)),
-        "down" => Ok(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE)),
-        "space" => Ok(char_key(' ')),
-        "lt" => Ok(char_key('<')),
-        _ => {
-            if let Some(control) = lower
-                .strip_prefix("c-")
-                .or_else(|| lower.strip_prefix("ctrl-"))
-            {
-                let mut chars = control.chars();
-                if let (Some(ch), None) = (chars.next(), chars.next()) {
-                    return Ok(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL));
-                }
-            }
-            Err(format!("unsupported key token `<{token}>`"))
-        }
-    }
-}
-
-fn char_key(ch: char) -> KeyEvent {
-    if ch.is_ascii_uppercase() {
-        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::SHIFT)
-    } else {
-        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE)
-    }
 }
 
 fn run_nevi_case(case: &OracleCase) -> Result<EditorSnapshot, String> {


### PR DESCRIPTION
View and edit recorded macros as readable vim notation instead of re-recording them from scratch.

- :Macros opens a read-only [macros] buffer listing every recorded register as notation, e.g.   0f,ci\"hello<Esc>j; macros containing keys with no notation are shown as not editable instead of failing
- :MacroEdit {a-z} opens the register's notation in an editable [macro-x] scratch buffer; :w (and :w!) parses it back into the
  register, empty content clears it, and a parse error reports the problem while leaving the register and dirty flag untouched; editing an empty register authors a new macro without recording
- extract the vim-oracle notation parser into a shared src/input/key_notation.rs and add the inverse encoder, so the same grammar drives oracle replay, the lens view, and edit save-back; both directions gain <Del>/<Home>/<End>/<PageUp>/<PageDown>
- pure lens logic lives in src/macro_lens.rs; the register is derived from the buffer name so no editor state can desync on buffer closes
- :w {path} in a macro buffer still writes a file and never touches the register

Covered by codec roundtrip tests, editor flow tests (save, clear, errors, recording guard), and end-to-end tests that record via q and replay a lens-authored macro through the real key pipeline (`@a`, @@)."