### PR TITLE
test: expect final newline in macro save-as file

### DIFF
--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -14272,7 +14272,9 @@ mod tests {
             None,
             ":w {{path}} must not touch the register"
         );
-        assert_eq!(std::fs::read_to_string(&path).unwrap(), "dw");
+        // The buffer normalizes a missing final newline ('fixendofline'
+        // parity), so the written file ends with one.
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "dw\n");
         let _ = std::fs::remove_file(&path);
     }
 


### PR DESCRIPTION
PRs #262 and #263 were green independently but collided on master: #262 normalizes a missing final newline on any buffer edit ('fixendofline' parity), so the macro-lens save-as test's file is now written as "dw\n". The assertion pinned the pre-#262 behavior; macro lens behavior itself is unaffected since notation parsing strips newlines.