### PR TITLE
Feat/UI finder polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Nevi 0.3.0 brings further improvements.
 ### Highlights
 
 - New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
+- The finder gets the rich treatment too: rounded corners, icon border titles, per-filetype devicons in results and the preview title, and a selection accent bar. `[ui] style = "minimal"` keeps the previous finder look (square corners, two-letter file chips) unchanged.
 - `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).
 - Statusline width math is now Unicode-aware, fixing right-side misalignment with double-width (e.g. CJK) filenames.
 - Themes gain an optional `[ui.statusline] section_bg` key for the mid statusline segments; it falls back to `cursor_line`, so existing themes need no changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Nevi 0.3.0 brings further improvements.
 
 ### Highlights
 
+- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] basic = true` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
+- `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).
+- Statusline width math is now Unicode-aware, fixing right-side misalignment with double-width (e.g. CJK) filenames.
+- Themes gain an optional `[ui.statusline] section_bg` key for the mid statusline segments; it falls back to `cursor_line`, so existing themes need no changes.
 - `:Format` now runs the external formatter from `languages.toml` when one is configured for the current language, and falls back to LSP otherwise.
 - Added Vim motions `g_`, `|`, `gM`, `gm`, `go`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
 - `j`/`k` now keep the preferred column (Vim `curswant`) when moving across short or blank lines, and `$` makes vertical motion stick to line ends.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Nevi 0.3.0 brings further improvements.
 
 ### Highlights
 
-- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] basic = true` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
+- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
 - `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).
 - Statusline width math is now Unicode-aware, fixing right-side misalignment with double-width (e.g. CJK) filenames.
 - Themes gain an optional `[ui.statusline] section_bg` key for the mid statusline segments; it falls back to `cursor_line`, so existing themes need no changes.

--- a/README.md
+++ b/README.md
@@ -275,6 +275,9 @@ scroll_off = 8
 [theme]
 colorscheme = "onedark"
 
+[ui]
+basic = false
+
 [terminal]
 popup_width_ratio = 0.9
 popup_height_ratio = 0.9
@@ -294,6 +297,22 @@ defaults are added.
 
 See the generated config file at `~/.config/nevi/config.toml` for all available
 options with documentation.
+
+### UI style
+
+The default UI is "rich": Nerd Font icons, a segmented powerline statusline,
+and glyph-based signs. It expects a [Nerd Font](https://www.nerdfonts.com) in
+your terminal — if you see boxes instead of icons, either install one or set:
+
+```toml
+[ui]
+basic = true
+```
+
+for a plain-ASCII UI with the same layout. If you already had
+`use_nerd_font_icons = false` under `[editor]`, Nevi keeps respecting it and
+defaults to the ASCII UI automatically. `:checkhealth` reports the active UI
+mode and includes a glyph probe.
 
 ## Custom Themes
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ scroll_off = 8
 colorscheme = "onedark"
 
 [ui]
-basic = false
+style = "rich"
 
 [terminal]
 popup_width_ratio = 0.9
@@ -306,7 +306,7 @@ your terminal — if you see boxes instead of icons, either install one or set:
 
 ```toml
 [ui]
-basic = true
+style = "minimal"
 ```
 
 for a plain-ASCII UI with the same layout. If you already had

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -46,11 +46,15 @@ impl Default for Settings {
 }
 
 impl Settings {
-    /// Resolve the UI chrome style. Unset `[ui] basic` falls back to the
+    /// Resolve the UI chrome style. Unset `[ui] style` falls back to the
     /// legacy `editor.use_nerd_font_icons` flag so users who already opted
     /// out of Nerd Fonts keep a glyph-free UI without editing their config.
-    pub fn resolved_basic_ui(&self) -> bool {
-        self.ui.basic.unwrap_or(!self.editor.use_nerd_font_icons)
+    pub fn resolved_ui_style(&self) -> UiStyle {
+        self.ui.style.unwrap_or(if self.editor.use_nerd_font_icons {
+            UiStyle::Rich
+        } else {
+            UiStyle::Minimal
+        })
     }
 }
 
@@ -58,9 +62,24 @@ impl Settings {
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(default)]
 pub struct UiSettings {
-    /// true = minimal ASCII chrome; false = rich (Nerd Font icons, powerline
-    /// statusline segments). Default (unset) = rich.
-    pub basic: Option<bool>,
+    /// "rich" (Nerd Font icons, powerline statusline segments) or "minimal"
+    /// (plain ASCII, flat statusline). Default (unset) = rich.
+    pub style: Option<UiStyle>,
+}
+
+/// UI chrome style — an enum rather than a bool so future styles can be
+/// added without a second flag.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum UiStyle {
+    Rich,
+    Minimal,
+}
+
+impl UiStyle {
+    pub fn is_minimal(self) -> bool {
+        self == UiStyle::Minimal
+    }
 }
 
 /// Autosave mode configuration
@@ -1025,8 +1044,8 @@ fn default_config_template() -> &'static str {
 # UI CHROME
 # ============================================================================
 # [ui]
-# basic = false              # true = plain ASCII UI (no Nerd Font required);
-#                            # false = rich icons + powerline statusline (default)
+# style = "rich"             # "rich" = icons + powerline statusline (default);
+#                            # "minimal" = plain ASCII UI (no Nerd Font required)
 
 # ============================================================================
 # FLOATING TERMINAL
@@ -1745,27 +1764,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn ui_basic_resolution_combinations() {
+    fn ui_style_resolution_combinations() {
         let mut s = Settings::default();
         // nothing set → rich
-        assert!(!s.resolved_basic_ui());
+        assert_eq!(s.resolved_ui_style(), UiStyle::Rich);
         // legacy nerd-font opt-out implies minimal
         s.editor.use_nerd_font_icons = false;
-        assert!(s.resolved_basic_ui());
-        // explicit [ui] basic wins over legacy flag
-        s.ui.basic = Some(false);
-        assert!(!s.resolved_basic_ui());
-        s.ui.basic = Some(true);
+        assert_eq!(s.resolved_ui_style(), UiStyle::Minimal);
+        // explicit [ui] style wins over legacy flag
+        s.ui.style = Some(UiStyle::Rich);
+        assert_eq!(s.resolved_ui_style(), UiStyle::Rich);
+        s.ui.style = Some(UiStyle::Minimal);
         s.editor.use_nerd_font_icons = true;
-        assert!(s.resolved_basic_ui());
+        assert_eq!(s.resolved_ui_style(), UiStyle::Minimal);
     }
 
     #[test]
     fn ui_section_parses_and_is_optional() {
-        let s: Settings = toml::from_str("[ui]\nbasic = true\n").expect("parse [ui]");
-        assert_eq!(s.ui.basic, Some(true));
+        let s: Settings = toml::from_str("[ui]\nstyle = \"minimal\"\n").expect("parse [ui]");
+        assert_eq!(s.ui.style, Some(UiStyle::Minimal));
+        let s: Settings = toml::from_str("[ui]\nstyle = \"rich\"\n").expect("parse [ui]");
+        assert_eq!(s.ui.style, Some(UiStyle::Rich));
         let s: Settings = toml::from_str("").expect("parse empty config");
-        assert_eq!(s.ui.basic, None);
+        assert_eq!(s.ui.style, None);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -26,6 +26,7 @@ pub struct Settings {
     pub finder: FinderSettings,
     pub lsp: LspSettings,
     pub copilot: CopilotSettings,
+    pub ui: UiSettings,
 }
 
 impl Default for Settings {
@@ -39,8 +40,27 @@ impl Default for Settings {
             finder: FinderSettings::default(),
             lsp: LspSettings::default(),
             copilot: CopilotSettings::default(),
+            ui: UiSettings::default(),
         }
     }
+}
+
+impl Settings {
+    /// Resolve the UI chrome style. Unset `[ui] basic` falls back to the
+    /// legacy `editor.use_nerd_font_icons` flag so users who already opted
+    /// out of Nerd Fonts keep a glyph-free UI without editing their config.
+    pub fn resolved_basic_ui(&self) -> bool {
+        self.ui.basic.unwrap_or(!self.editor.use_nerd_font_icons)
+    }
+}
+
+/// UI chrome settings
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(default)]
+pub struct UiSettings {
+    /// true = minimal ASCII chrome; false = rich (Nerd Font icons, powerline
+    /// statusline segments). Default (unset) = rich.
+    pub basic: Option<bool>,
 }
 
 /// Autosave mode configuration
@@ -1002,6 +1022,13 @@ fn default_config_template() -> &'static str {
 # colorscheme = "onedark"    # Color scheme name
 
 # ============================================================================
+# UI CHROME
+# ============================================================================
+# [ui]
+# basic = false              # true = plain ASCII UI (no Nerd Font required);
+#                            # false = rich icons + powerline statusline (default)
+
+# ============================================================================
 # FLOATING TERMINAL
 # ============================================================================
 # [terminal]
@@ -1716,6 +1743,30 @@ fn merge_explorer_mappings(user_mappings: &[ExplorerModeMapping]) -> Vec<Explore
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ui_basic_resolution_combinations() {
+        let mut s = Settings::default();
+        // nothing set → rich
+        assert!(!s.resolved_basic_ui());
+        // legacy nerd-font opt-out implies minimal
+        s.editor.use_nerd_font_icons = false;
+        assert!(s.resolved_basic_ui());
+        // explicit [ui] basic wins over legacy flag
+        s.ui.basic = Some(false);
+        assert!(!s.resolved_basic_ui());
+        s.ui.basic = Some(true);
+        s.editor.use_nerd_font_icons = true;
+        assert!(s.resolved_basic_ui());
+    }
+
+    #[test]
+    fn ui_section_parses_and_is_optional() {
+        let s: Settings = toml::from_str("[ui]\nbasic = true\n").expect("parse [ui]");
+        assert_eq!(s.ui.basic, Some(true));
+        let s: Settings = toml::from_str("").expect("parse empty config");
+        assert_eq!(s.ui.basic, None);
+    }
 
     #[test]
     fn lsp_server_partial_config_keeps_default_command_and_args() {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1030,6 +1030,10 @@ pub struct Editor {
     pub finder: FuzzyFinder,
     /// LSP status message (persistent, shown in status bar)
     pub lsp_status: Option<String>,
+    /// Whether the LSP looks busy (indexing/loading), from the status text
+    pub lsp_busy: bool,
+    /// Spinner position; advances per LSP notification, never on a timer
+    lsp_spinner_idx: usize,
     /// LSP diagnostics per file URI
     diagnostics: HashMap<String, Vec<Diagnostic>>,
     /// Autocomplete state
@@ -1080,6 +1084,9 @@ pub struct Editor {
     git_diffs: HashMap<String, crate::git::GitDiff>,
     /// Cached git repository (if project is in git)
     git_repo: Option<crate::git::GitRepo>,
+    /// Cached branch short name; refreshed with git state, read by the
+    /// statusline (render must never call into git2 directly)
+    pub git_branch: Option<String>,
     /// Theme manager for colors and themes
     pub theme_manager: ThemeManager,
     /// Theme picker state (Some if picker is open)
@@ -1568,6 +1575,8 @@ impl Editor {
             pending_external_command: None,
             finder,
             lsp_status: None,
+            lsp_busy: false,
+            lsp_spinner_idx: 0,
             diagnostics: HashMap::new(),
             completion: CompletionState::default(),
             pending_lsp_action: None,
@@ -1593,6 +1602,7 @@ impl Editor {
             copilot_ghost: None,
             git_diffs: HashMap::new(),
             git_repo: None,
+            git_branch: None,
             theme_manager,
             theme_picker: None,
             markdown_preview: None,
@@ -1836,6 +1846,7 @@ impl Editor {
             &self.settings,
             &self.languages_config,
             Some(self.current_large_file_health()),
+            self.lsp_status.clone(),
         );
         self.open_virtual_read_only_buffer("[health]", &report, Some("health.md"));
     }
@@ -2360,10 +2371,33 @@ impl Editor {
         }
     }
 
+    /// Glyph table for the resolved UI chrome style. A method rather than a
+    /// stored field: resolution is two bool reads, and duplicated state on
+    /// Editor has a history of desyncing (see the pane-mirroring invariant).
+    pub fn ui_glyphs(&self) -> &'static crate::ui_glyphs::UiGlyphs {
+        crate::ui_glyphs::UiGlyphs::for_basic(self.settings.resolved_basic_ui())
+    }
+
     /// Set the LSP status (persistent, shown in status bar)
     pub fn set_lsp_status<S: Into<String>>(&mut self, msg: S) {
-        self.lsp_status = Some(msg.into());
+        let msg = msg.into();
+        // Busy heuristic over the free-form status strings main.rs emits.
+        // The spinner advances only here — event-driven, never on a timer.
+        let lower = msg.to_lowercase();
+        self.lsp_busy = ["indexing", "loading", "starting", "%"]
+            .iter()
+            .any(|needle| lower.contains(needle));
+        if self.lsp_busy {
+            self.lsp_spinner_idx = self.lsp_spinner_idx.wrapping_add(1);
+        }
+        self.lsp_status = Some(msg);
         self.render_damage.mark_statusline();
+    }
+
+    /// Current spinner frame for the statusline's LSP busy indicator
+    pub fn lsp_spinner_frame(&self) -> &'static str {
+        let frames = self.ui_glyphs().lsp_busy_frames;
+        frames[self.lsp_spinner_idx % frames.len()]
     }
 
     /// Update diagnostics for a file URI
@@ -2677,6 +2711,21 @@ impl Editor {
         }
     }
 
+    /// (errors, warnings) counts for the current buffer — statusline data.
+    /// Information/Hint severities are excluded on purpose.
+    pub fn current_diagnostic_counts(&self) -> (usize, usize) {
+        let mut errors = 0;
+        let mut warnings = 0;
+        for d in self.current_diagnostics() {
+            match d.severity {
+                crate::lsp::DiagnosticSeverity::Error => errors += 1,
+                crate::lsp::DiagnosticSeverity::Warning => warnings += 1,
+                _ => {}
+            }
+        }
+        (errors, warnings)
+    }
+
     /// Get diagnostics for the current buffer using a pre-computed URI (avoids repeated allocations)
     pub fn current_diagnostics_cached(&self, uri: &str) -> &[Diagnostic] {
         self.diagnostics
@@ -2797,6 +2846,7 @@ impl Editor {
         if let Some(root) = &self.project_root {
             self.git_repo = crate::git::GitRepo::open(root);
         }
+        self.git_branch = self.git_repo.as_ref().and_then(|r| r.branch_name());
         self.refresh_explorer_git_statuses();
     }
 
@@ -2810,6 +2860,13 @@ impl Editor {
         let path = self.buffer().path.as_ref()?.to_string_lossy().to_string();
         let diff = self.git_diffs.get(&path)?;
         diff.status_for_line(line)
+    }
+
+    /// (added, modified) line counts for the current buffer's cached git
+    /// diff — statusline data, derived from the same diff the gutter uses
+    pub fn current_git_diff_totals(&self) -> Option<(usize, usize)> {
+        let path = self.buffer().path.as_ref()?.to_string_lossy().to_string();
+        self.git_diffs.get(&path).map(|d| d.totals())
     }
 
     /// Get git status for a specific line given a file path
@@ -2865,6 +2922,7 @@ impl Editor {
     /// Refresh all git-derived editor state.
     pub fn refresh_git_state(&mut self) {
         self.update_all_git_diffs();
+        self.git_branch = self.git_repo.as_ref().and_then(|r| r.branch_name());
         self.refresh_explorer_git_statuses();
     }
 
@@ -13200,6 +13258,63 @@ mod tests {
         let _ = editor.apply_selected_code_action();
 
         assert_eq!(editor.buffer().content(), "abc\n");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn lsp_status_drives_busy_flag_and_spinner_frame() {
+        let mut editor = Editor::default();
+        editor.set_lsp_status("LSP: indexing 40%");
+        assert!(editor.lsp_busy);
+        let f1 = editor.lsp_spinner_frame();
+        editor.set_lsp_status("LSP: indexing 60%");
+        let f2 = editor.lsp_spinner_frame();
+        assert_ne!(
+            f1, f2,
+            "spinner advances per notification (event-driven, no timer)"
+        );
+        editor.set_lsp_status("rust-analyzer: idle");
+        assert!(!editor.lsp_busy);
+    }
+
+    #[test]
+    fn current_diagnostic_counts_split_by_severity() {
+        let tmp = unique_temp_dir("nevi_diag_counts");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("counts.rs");
+        std::fs::write(&path, "one\ntwo\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        let uri = crate::lsp::path_to_uri(&path);
+        editor.set_diagnostics(
+            uri,
+            vec![
+                Diagnostic {
+                    line: 0,
+                    end_line: 0,
+                    col_start: 0,
+                    col_end: 1,
+                    severity: DiagnosticSeverity::Error,
+                    message: "e".to_string(),
+                    source: None,
+                    code: None,
+                },
+                Diagnostic {
+                    line: 1,
+                    end_line: 1,
+                    col_start: 0,
+                    col_end: 1,
+                    severity: DiagnosticSeverity::Warning,
+                    message: "w".to_string(),
+                    source: None,
+                    code: None,
+                },
+            ],
+        );
+
+        assert_eq!(editor.current_diagnostic_counts(), (1, 1));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2375,7 +2375,7 @@ impl Editor {
     /// stored field: resolution is two bool reads, and duplicated state on
     /// Editor has a history of desyncing (see the pane-mirroring invariant).
     pub fn ui_glyphs(&self) -> &'static crate::ui_glyphs::UiGlyphs {
-        crate::ui_glyphs::UiGlyphs::for_basic(self.settings.resolved_basic_ui())
+        crate::ui_glyphs::UiGlyphs::for_minimal(self.settings.resolved_ui_style().is_minimal())
     }
 
     /// Set the LSP status (persistent, shown in status bar)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -99,6 +99,22 @@ impl GitDiff {
     pub fn status_for_line(&self, line: usize) -> Option<GitLineStatus> {
         self.hunks.iter().find(|h| h.line == line).map(|h| h.status)
     }
+
+    /// (added, modified) line counts for the statusline. Deleted hunks are
+    /// excluded on purpose — the statusline shows "+n ~n" only.
+    pub fn totals(&self) -> (usize, usize) {
+        let added = self
+            .hunks
+            .iter()
+            .filter(|h| h.status == GitLineStatus::Added)
+            .count();
+        let modified = self
+            .hunks
+            .iter()
+            .filter(|h| h.status == GitLineStatus::Modified)
+            .count();
+        (added, modified)
+    }
 }
 
 /// Wrapper around git2::Repository for git operations
@@ -118,6 +134,11 @@ impl GitRepo {
     /// Get the working directory of the repository
     pub fn workdir(&self) -> Option<&Path> {
         self.repo.workdir()
+    }
+
+    /// Current branch short name (e.g. "master"), or None when detached/unborn.
+    pub fn branch_name(&self) -> Option<String> {
+        self.repo.head().ok()?.shorthand().map(str::to_string)
     }
 
     /// Get the content of a file at HEAD
@@ -1096,6 +1117,14 @@ mod tests {
                 .iter()
                 .any(|h| h.status == GitLineStatus::Deleted)
         );
+    }
+
+    #[test]
+    fn diff_totals_count_added_and_modified_lines() {
+        let diff = compute_diff("a\nb\n", "a\nX\nc\n");
+        let (added, modified) = diff.totals();
+        assert_eq!(modified, 1); // b → X
+        assert_eq!(added, 1); // c
     }
 
     #[test]

--- a/src/health.rs
+++ b/src/health.rs
@@ -44,6 +44,10 @@ pub struct HealthReportInput {
     pub profile_log_status: ProfileLogStatus,
     pub lsp_enabled: bool,
     pub lsp_servers: Vec<LspServerHealth>,
+    /// Resolved `[ui] basic` setting (rich vs minimal chrome).
+    pub ui_basic: bool,
+    /// Raw LSP status string (the statusline only shows an indicator).
+    pub lsp_status_raw: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -177,6 +181,22 @@ pub fn build_health_report(input: &HealthReportInput) -> String {
     ));
     report.push_str("- Open user config: `:ConfigOpen`\n");
     report.push_str("- View latest default config: `:ConfigDefaults`\n\n");
+
+    report.push_str("## UI\n");
+    if input.ui_basic {
+        report.push_str("- UI mode: minimal (`[ui] basic = true`)\n");
+    } else {
+        report
+            .push_str("- UI mode: rich (set `[ui] basic = true` in config.toml for plain ASCII)\n");
+        report.push_str(
+            "- Glyph probe: \u{e0b0} \u{e0a0} \u{f057} \u{f071} — if these are boxes, \
+             install a Nerd Font or set `[ui] basic = true`\n",
+        );
+    }
+    if let Some(status) = &input.lsp_status_raw {
+        report.push_str(&format!("- LSP status: {}\n", status));
+    }
+    report.push('\n');
 
     report.push_str("## Keymaps\n");
     report.push_str(&format!(
@@ -357,6 +377,7 @@ pub fn collect_health_report(
     settings: &crate::config::Settings,
     languages_config: &crate::config::LanguagesConfig,
     large_file: Option<LargeFileHealth>,
+    lsp_status_raw: Option<String>,
 ) -> String {
     let config_path = crate::config::config_path();
     let languages_path = crate::config::languages::languages_config_path();
@@ -381,6 +402,8 @@ pub fn collect_health_report(
         profile_log_path,
         lsp_enabled: settings.lsp.enabled,
         lsp_servers: lsp_server_health(settings),
+        ui_basic: settings.resolved_basic_ui(),
+        lsp_status_raw,
     })
 }
 
@@ -765,6 +788,8 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
+            ui_basic: false,
+            lsp_status_raw: None,
             lsp_servers: vec![LspServerHealth {
                 language: "rust",
                 enabled: true,
@@ -782,6 +807,43 @@ mod tests {
         assert!(report.contains("/tmp/nevi_profile.log"));
         assert!(report.contains("NEVI_PROFILE=1"));
         assert!(report.contains("rust: enabled (rust-analyzer)"));
+    }
+
+    #[test]
+    fn health_report_shows_ui_mode_and_glyph_probe() {
+        let mut input = HealthReportInput {
+            config_path: None,
+            config_status: FileCheckStatus::Unavailable,
+            languages_path: None,
+            languages_status: FileCheckStatus::Unavailable,
+            keymap: default_keymap_health(),
+            external_tools: default_external_tools_health(),
+            large_file: None,
+            profile_enabled: false,
+            profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
+            profile_log_status: ProfileLogStatus::Missing,
+            lsp_enabled: false,
+            lsp_servers: vec![],
+            ui_basic: false,
+            lsp_status_raw: Some("rust-analyzer: idle".to_string()),
+        };
+
+        let report = build_health_report(&input);
+        assert!(report.contains("UI mode: rich"));
+        assert!(
+            report.contains("basic = true"),
+            "rich mode should mention the opt-out"
+        );
+        assert!(report.contains("\u{e0b0}"), "rich mode shows a glyph probe");
+        assert!(report.contains("rust-analyzer: idle"));
+
+        input.ui_basic = true;
+        let report = build_health_report(&input);
+        assert!(report.contains("UI mode: minimal"));
+        assert!(
+            !report.contains("\u{e0b0}"),
+            "minimal mode needs no glyph probe"
+        );
     }
 
     #[test]
@@ -808,6 +870,8 @@ mod tests {
             }]),
             lsp_enabled: false,
             lsp_servers: Vec::new(),
+            ui_basic: false,
+            lsp_status_raw: None,
         });
 
         assert!(report.contains("Profiling: enabled"));
@@ -838,6 +902,8 @@ mod tests {
                 max_us: 42,
             }]),
             lsp_enabled: true,
+            ui_basic: false,
+            lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
 
@@ -859,6 +925,8 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
+            ui_basic: false,
+            lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
 
@@ -896,6 +964,8 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
+            ui_basic: false,
+            lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
 
@@ -925,6 +995,8 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
+            ui_basic: false,
+            lsp_status_raw: None,
             lsp_servers: Vec::new(),
             external_tools: ExternalToolsHealth {
                 built_in_notes: vec![

--- a/src/health.rs
+++ b/src/health.rs
@@ -44,8 +44,8 @@ pub struct HealthReportInput {
     pub profile_log_status: ProfileLogStatus,
     pub lsp_enabled: bool,
     pub lsp_servers: Vec<LspServerHealth>,
-    /// Resolved `[ui] basic` setting (rich vs minimal chrome).
-    pub ui_basic: bool,
+    /// Resolved `[ui] style` setting (rich vs minimal chrome).
+    pub ui_minimal: bool,
     /// Raw LSP status string (the statusline only shows an indicator).
     pub lsp_status_raw: Option<String>,
 }
@@ -183,14 +183,15 @@ pub fn build_health_report(input: &HealthReportInput) -> String {
     report.push_str("- View latest default config: `:ConfigDefaults`\n\n");
 
     report.push_str("## UI\n");
-    if input.ui_basic {
-        report.push_str("- UI mode: minimal (`[ui] basic = true`)\n");
+    if input.ui_minimal {
+        report.push_str("- UI mode: minimal (`[ui] style = \"minimal\"`)\n");
     } else {
-        report
-            .push_str("- UI mode: rich (set `[ui] basic = true` in config.toml for plain ASCII)\n");
+        report.push_str(
+            "- UI mode: rich (set `[ui] style = \"minimal\"` in config.toml for plain ASCII)\n",
+        );
         report.push_str(
             "- Glyph probe: \u{e0b0} \u{e0a0} \u{f057} \u{f071} — if these are boxes, \
-             install a Nerd Font or set `[ui] basic = true`\n",
+             install a Nerd Font or set `[ui] style = \"minimal\"`\n",
         );
     }
     if let Some(status) = &input.lsp_status_raw {
@@ -402,7 +403,7 @@ pub fn collect_health_report(
         profile_log_path,
         lsp_enabled: settings.lsp.enabled,
         lsp_servers: lsp_server_health(settings),
-        ui_basic: settings.resolved_basic_ui(),
+        ui_minimal: settings.resolved_ui_style().is_minimal(),
         lsp_status_raw,
     })
 }
@@ -788,7 +789,7 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
             lsp_servers: vec![LspServerHealth {
                 language: "rust",
@@ -824,20 +825,20 @@ mod tests {
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: false,
             lsp_servers: vec![],
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: Some("rust-analyzer: idle".to_string()),
         };
 
         let report = build_health_report(&input);
         assert!(report.contains("UI mode: rich"));
         assert!(
-            report.contains("basic = true"),
+            report.contains("style = \"minimal\""),
             "rich mode should mention the opt-out"
         );
         assert!(report.contains("\u{e0b0}"), "rich mode shows a glyph probe");
         assert!(report.contains("rust-analyzer: idle"));
 
-        input.ui_basic = true;
+        input.ui_minimal = true;
         let report = build_health_report(&input);
         assert!(report.contains("UI mode: minimal"));
         assert!(
@@ -870,7 +871,7 @@ mod tests {
             }]),
             lsp_enabled: false,
             lsp_servers: Vec::new(),
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
         });
 
@@ -902,7 +903,7 @@ mod tests {
                 max_us: 42,
             }]),
             lsp_enabled: true,
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
@@ -925,7 +926,7 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
@@ -964,7 +965,7 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
             lsp_servers: Vec::new(),
         });
@@ -995,7 +996,7 @@ mod tests {
             profile_log_path: PathBuf::from(PROFILE_LOG_PATH),
             profile_log_status: ProfileLogStatus::Missing,
             lsp_enabled: true,
-            ui_basic: false,
+            ui_minimal: false,
             lsp_status_raw: None,
             lsp_servers: Vec::new(),
             external_tools: ExternalToolsHealth {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,12 @@ mod parity_report;
 pub mod perf;
 pub mod project_replace;
 pub mod render_damage;
+pub mod statusline;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;
 pub mod tool_installer;
+pub mod ui_glyphs;
 #[cfg(test)]
 mod vim_oracle;
 

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -101,7 +101,7 @@ fn push_file_markers(
     glyphs: &UiGlyphs,
     theme: &Theme,
     bg: Color,
-    basic: bool,
+    minimal: bool,
 ) {
     let fg = theme.ui.statusline_fg;
     if ctx.modified {
@@ -118,7 +118,7 @@ fn push_file_markers(
     }
     if let Some(register) = ctx.recording {
         // Minimal's prefix opens a bracket that needs closing; rich is a glyph.
-        let close = if basic { "]" } else { "" };
+        let close = if minimal { "]" } else { "" };
         out.push(seg(
             format!(" {}{}{}", glyphs.recording, register, close),
             theme.diagnostic.error,
@@ -131,9 +131,9 @@ pub fn build_status_segments(
     ctx: &StatusContext,
     glyphs: &UiGlyphs,
     theme: &Theme,
-    basic: bool,
+    minimal: bool,
 ) -> StatusLineContent {
-    if basic {
+    if minimal {
         build_minimal(ctx, glyphs, theme)
     } else {
         build_rich(ctx, glyphs, theme)
@@ -369,8 +369,9 @@ mod tests {
     fn zero_diagnostics_are_hidden() {
         let mut ctx = ctx_base();
         ctx.diag = (0, 0);
-        for basic in [false, true] {
-            let content = build_status_segments(&ctx, UiGlyphs::for_basic(basic), &theme(), basic);
+        for minimal in [false, true] {
+            let content =
+                build_status_segments(&ctx, UiGlyphs::for_minimal(minimal), &theme(), minimal);
             let all = all_text(&content);
             assert!(!all.contains("E:0"));
             assert!(!all.contains('\u{f057}'));

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -1,0 +1,416 @@
+//! Pure statusline segment builder.
+//!
+//! Turns cached editor state (`StatusContext`) into colored segments for the
+//! rich (powerline) or minimal (flat) layout. No I/O, no `Editor`, no
+//! terminal — `render_status_line` in `terminal/mod.rs` is the only consumer
+//! and does nothing but gather state, call this, and emit ANSI. That keeps
+//! both visual modes testable without a terminal.
+
+use crossterm::style::Color;
+
+use crate::editor::Mode;
+use crate::theme::Theme;
+use crate::ui_glyphs::UiGlyphs;
+
+pub struct StatusSegment {
+    pub text: String,
+    pub fg: Color,
+    pub bg: Color,
+    pub bold: bool,
+}
+
+/// Segments in draw order. The renderer paints `left`, pads with the
+/// statusline background to the terminal width, then paints `right`.
+pub struct StatusLineContent {
+    pub left: Vec<StatusSegment>,
+    pub right: Vec<StatusSegment>,
+}
+
+/// Everything the statusline shows, pre-gathered from cached editor state.
+/// Render-reads-cache-only rule: callers must not compute git/LSP data here.
+pub struct StatusContext<'a> {
+    pub mode: Mode,
+    /// Preformatted pending count/operator, e.g. "3d" ("" when none).
+    pub pending: &'a str,
+    /// Macro register currently recording.
+    pub recording: Option<char>,
+    pub project: Option<&'a str>,
+    pub filename: &'a str,
+    pub modified: bool,
+    pub readonly: bool,
+    pub large_file: bool,
+    pub branch: Option<&'a str>,
+    /// (added, modified) line counts from the cached git diff.
+    pub diff: Option<(usize, usize)>,
+    /// (errors, warnings) for the current buffer.
+    pub diag: (usize, usize),
+    pub lang: &'a str,
+    pub lsp_attached: bool,
+    pub lsp_busy: bool,
+    /// Current spinner frame (advanced per LSP notification, never a timer).
+    pub lsp_spinner: &'a str,
+    /// 1-based for display.
+    pub line: usize,
+    pub col: usize,
+    /// 0..=100 scroll position.
+    pub percent: usize,
+}
+
+fn mode_color(mode: Mode, theme: &Theme) -> Color {
+    match mode {
+        Mode::Normal | Mode::Command => theme.ui.statusline_mode_normal,
+        Mode::Insert => theme.ui.statusline_mode_insert,
+        Mode::Visual | Mode::VisualLine | Mode::VisualBlock => theme.ui.statusline_mode_visual,
+        Mode::Replace => theme.ui.statusline_mode_replace,
+        _ => theme.ui.statusline_mode_normal,
+    }
+}
+
+/// Vim parity: command mode keeps showing NORMAL in the statusline.
+fn mode_label(mode: Mode) -> &'static str {
+    if mode == Mode::Command {
+        "NORMAL"
+    } else {
+        mode.as_str()
+    }
+}
+
+fn seg(text: String, fg: Color, bg: Color) -> StatusSegment {
+    StatusSegment {
+        text,
+        fg,
+        bg,
+        bold: false,
+    }
+}
+
+fn seg_bold(text: String, fg: Color, bg: Color) -> StatusSegment {
+    StatusSegment {
+        text,
+        fg,
+        bg,
+        bold: true,
+    }
+}
+
+/// Trailing file-state markers shared by both layouts: modified dot,
+/// read-only, large-file, pending operator, macro recording.
+fn push_file_markers(
+    out: &mut Vec<StatusSegment>,
+    ctx: &StatusContext,
+    glyphs: &UiGlyphs,
+    theme: &Theme,
+    bg: Color,
+    basic: bool,
+) {
+    let fg = theme.ui.statusline_fg;
+    if ctx.modified {
+        out.push(seg(format!(" {}", glyphs.modified), theme.git.modified, bg));
+    }
+    if ctx.readonly {
+        out.push(seg(format!(" {}", glyphs.readonly.trim_end()), fg, bg));
+    }
+    if ctx.large_file {
+        out.push(seg(" [large]".to_string(), fg, bg));
+    }
+    if !ctx.pending.is_empty() {
+        out.push(seg(format!(" [{}]", ctx.pending), fg, bg));
+    }
+    if let Some(register) = ctx.recording {
+        // Minimal's prefix opens a bracket that needs closing; rich is a glyph.
+        let close = if basic { "]" } else { "" };
+        out.push(seg(
+            format!(" {}{}{}", glyphs.recording, register, close),
+            theme.diagnostic.error,
+            bg,
+        ));
+    }
+}
+
+pub fn build_status_segments(
+    ctx: &StatusContext,
+    glyphs: &UiGlyphs,
+    theme: &Theme,
+    basic: bool,
+) -> StatusLineContent {
+    if basic {
+        build_minimal(ctx, glyphs, theme)
+    } else {
+        build_rich(ctx, glyphs, theme)
+    }
+}
+
+fn build_rich(ctx: &StatusContext, glyphs: &UiGlyphs, theme: &Theme) -> StatusLineContent {
+    let mode_bg = mode_color(ctx.mode, theme);
+    let base_bg = theme.ui.statusline_bg;
+    let base_fg = theme.ui.statusline_fg;
+    let section_bg = theme.ui.statusline_section_bg;
+
+    let mut left = Vec::new();
+    left.push(seg_bold(
+        format!(" {} ", mode_label(ctx.mode)),
+        base_bg,
+        mode_bg,
+    ));
+
+    // Mode → git (or file) powerline transition.
+    let after_mode_bg = if ctx.branch.is_some() {
+        section_bg
+    } else {
+        base_bg
+    };
+    left.push(seg(glyphs.sep_left.to_string(), mode_bg, after_mode_bg));
+
+    if let Some(branch) = ctx.branch {
+        left.push(seg(
+            format!(" {}{}", glyphs.branch, branch),
+            base_fg,
+            section_bg,
+        ));
+        if let Some((added, modified)) = ctx.diff {
+            if added > 0 {
+                left.push(seg(format!(" +{}", added), theme.git.added, section_bg));
+            }
+            if modified > 0 {
+                left.push(seg(
+                    format!(" ~{}", modified),
+                    theme.git.modified,
+                    section_bg,
+                ));
+            }
+        }
+        left.push(seg(" ".to_string(), base_fg, section_bg));
+        left.push(seg(glyphs.sep_left.to_string(), section_bg, base_bg));
+    }
+
+    let project = ctx.project.map(|p| format!("[{}] ", p)).unwrap_or_default();
+    left.push(seg(
+        format!(" {}{}", project, ctx.filename),
+        base_fg,
+        base_bg,
+    ));
+    push_file_markers(&mut left, ctx, glyphs, theme, base_bg, false);
+
+    let mut right = Vec::new();
+    let (errors, warnings) = ctx.diag;
+    if errors > 0 {
+        right.push(seg(
+            format!("{}{} ", glyphs.diag_error, errors),
+            theme.diagnostic.error,
+            base_bg,
+        ));
+    }
+    if warnings > 0 {
+        right.push(seg(
+            format!("{}{} ", glyphs.diag_warn, warnings),
+            theme.diagnostic.warning,
+            base_bg,
+        ));
+    }
+    right.push(seg(glyphs.sep_right.to_string(), section_bg, base_bg));
+    let lsp = if !ctx.lsp_attached {
+        String::new()
+    } else if ctx.lsp_busy {
+        format!(" {}", ctx.lsp_spinner)
+    } else {
+        format!(" {}", glyphs.lsp_ok)
+    };
+    right.push(seg(format!(" {}{} ", ctx.lang, lsp), base_fg, section_bg));
+    right.push(seg(glyphs.sep_right.to_string(), mode_bg, section_bg));
+    right.push(seg_bold(
+        format!(" {}:{}  {}% ", ctx.line, ctx.col, ctx.percent),
+        base_bg,
+        mode_bg,
+    ));
+
+    StatusLineContent { left, right }
+}
+
+fn build_minimal(ctx: &StatusContext, glyphs: &UiGlyphs, theme: &Theme) -> StatusLineContent {
+    let bg = theme.ui.statusline_bg;
+    let fg = theme.ui.statusline_fg;
+
+    let mut left = Vec::new();
+    left.push(seg_bold(
+        format!(" {}", mode_label(ctx.mode)),
+        mode_color(ctx.mode, theme),
+        bg,
+    ));
+    if let Some(branch) = ctx.branch {
+        left.push(seg(format!("{}{}", glyphs.item_sep, branch), fg, bg));
+        if let Some((added, modified)) = ctx.diff {
+            if added > 0 {
+                left.push(seg(format!(" +{}", added), theme.git.added, bg));
+            }
+            if modified > 0 {
+                left.push(seg(format!(" ~{}", modified), theme.git.modified, bg));
+            }
+        }
+    }
+    let project = ctx.project.map(|p| format!("[{}] ", p)).unwrap_or_default();
+    left.push(seg(
+        format!("{}{}{}", glyphs.item_sep, project, ctx.filename),
+        fg,
+        bg,
+    ));
+    push_file_markers(&mut left, ctx, glyphs, theme, bg, true);
+
+    let mut right = Vec::new();
+    let (errors, warnings) = ctx.diag;
+    if errors > 0 {
+        right.push(seg(
+            format!("{}{} ", glyphs.diag_error, errors),
+            theme.diagnostic.error,
+            bg,
+        ));
+    }
+    if warnings > 0 {
+        right.push(seg(
+            format!("{}{} ", glyphs.diag_warn, warnings),
+            theme.diagnostic.warning,
+            bg,
+        ));
+    }
+    right.push(seg(format!(" {}", ctx.lang), fg, bg));
+    if ctx.lsp_attached {
+        let indicator = if ctx.lsp_busy {
+            ctx.lsp_spinner
+        } else {
+            glyphs.lsp_ok
+        };
+        right.push(seg(format!(" {}", indicator), fg, bg));
+    }
+    right.push(seg(format!(" {}:{} ", ctx.line, ctx.col), fg, bg));
+
+    StatusLineContent { left, right }
+}
+
+/// Terminal columns occupied by the segments — unicode-width, never `.len()`.
+/// Icons are multi-byte and CJK filenames are double-width; byte math
+/// misaligns the right side.
+pub fn display_width(segments: &[StatusSegment]) -> usize {
+    use unicode_width::UnicodeWidthStr;
+    segments
+        .iter()
+        .map(|s| UnicodeWidthStr::width(s.text.as_str()))
+        .sum()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ui_glyphs::{MINIMAL, RICH};
+
+    fn theme() -> Theme {
+        Theme::default()
+    }
+
+    fn ctx_base<'a>() -> StatusContext<'a> {
+        StatusContext {
+            mode: Mode::Normal,
+            pending: "",
+            recording: None,
+            project: Some("rvim"),
+            filename: "mod.rs",
+            modified: true,
+            readonly: false,
+            large_file: false,
+            branch: Some("master"),
+            diff: Some((12, 3)),
+            diag: (2, 1),
+            lang: "rust",
+            lsp_attached: true,
+            lsp_busy: false,
+            lsp_spinner: "",
+            line: 128,
+            col: 14,
+            percent: 93,
+        }
+    }
+
+    fn all_text(content: &StatusLineContent) -> String {
+        content
+            .left
+            .iter()
+            .chain(content.right.iter())
+            .map(|s| s.text.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn rich_layout_has_mode_block_and_powerline_transitions() {
+        let content = build_status_segments(&ctx_base(), &RICH, &theme(), false);
+        assert!(content.left[0].text.contains("NORMAL"));
+        assert!(content.left[0].bold);
+        let all = all_text(&content);
+        assert!(all.contains("\u{e0b0}"), "left powerline separator present");
+        assert!(all.contains("master"), "branch renders");
+        assert!(all.contains("●"), "modified dot renders");
+        assert!(
+            all.contains("+12") && all.contains("~3"),
+            "diff stats render"
+        );
+    }
+
+    #[test]
+    fn minimal_layout_is_flat_and_ascii_prefixed() {
+        let theme = theme();
+        let content = build_status_segments(&ctx_base(), &MINIMAL, &theme, true);
+        for s in content.left.iter().chain(content.right.iter()) {
+            assert_eq!(s.bg, theme.ui.statusline_bg, "minimal = one background");
+        }
+        let all = all_text(&content);
+        assert!(all.contains("E:2"));
+        assert!(all.contains("W:1"));
+        assert!(!all.contains("\u{e0b0}"));
+    }
+
+    #[test]
+    fn zero_diagnostics_are_hidden() {
+        let mut ctx = ctx_base();
+        ctx.diag = (0, 0);
+        for basic in [false, true] {
+            let content = build_status_segments(&ctx, UiGlyphs::for_basic(basic), &theme(), basic);
+            let all = all_text(&content);
+            assert!(!all.contains("E:0"));
+            assert!(!all.contains('\u{f057}'));
+            assert!(!all.contains('\u{f071}'));
+        }
+    }
+
+    #[test]
+    fn recording_and_pending_are_preserved() {
+        let mut ctx = ctx_base();
+        ctx.pending = "3d";
+        ctx.recording = Some('q');
+        let content = build_status_segments(&ctx, &MINIMAL, &theme(), true);
+        let all = all_text(&content);
+        assert!(all.contains("[3d]"));
+        assert!(all.contains("[recording @q]"));
+
+        let content = build_status_segments(&ctx, &RICH, &theme(), false);
+        let all = all_text(&content);
+        assert!(all.contains("[3d]"));
+        assert!(all.contains("@q"));
+    }
+
+    #[test]
+    fn command_mode_displays_normal_badge() {
+        let mut ctx = ctx_base();
+        ctx.mode = Mode::Command;
+        let content = build_status_segments(&ctx, &RICH, &theme(), false);
+        assert!(content.left[0].text.contains("NORMAL"));
+    }
+
+    #[test]
+    fn display_width_counts_columns_not_bytes() {
+        let segs = vec![StatusSegment {
+            text: "日本".into(),
+            fg: Color::Reset,
+            bg: Color::Reset,
+            bold: false,
+        }];
+        // 2 double-width chars = 4 columns (6 bytes).
+        assert_eq!(display_width(&segs), 4);
+    }
+}

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3100,134 +3100,98 @@ impl Terminal {
 
         let width = editor.term_width as usize;
         let theme = editor.theme();
+        let glyphs = editor.ui_glyphs();
+        let basic = editor.settings.resolved_basic_ui();
 
-        // Left side: mode and filename
-        let mode_str = if editor.mode == Mode::Command {
-            "NORMAL" // Show NORMAL in status while in command mode (like vim)
-        } else {
-            editor.mode.as_str()
-        };
-
-        // Get mode color from theme
-        let mode_color = match editor.mode {
-            Mode::Normal | Mode::Command => theme.ui.statusline_mode_normal,
-            Mode::Insert => theme.ui.statusline_mode_insert,
-            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => theme.ui.statusline_mode_visual,
-            Mode::Replace => theme.ui.statusline_mode_replace,
-            _ => theme.ui.statusline_mode_normal,
-        };
-
-        // Show pending operator if any
-        let pending = if editor.input_state.pending_operator.is_some()
-            || editor.input_state.count.is_some()
-        {
-            let mut s = String::new();
-            if let Some(count) = editor.input_state.count {
-                s.push_str(&count.to_string());
-            }
-            if let Some(op) = editor.input_state.pending_operator {
-                s.push(match op {
-                    Operator::Delete => 'd',
-                    Operator::Change => 'c',
-                    Operator::Yank => 'y',
-                    Operator::Indent => '>',
-                    Operator::Dedent => '<',
-                    Operator::AutoIndent => '=',
-                });
-            }
-            if !s.is_empty() {
-                format!(" [{}]", s)
-            } else {
-                String::new()
-            }
-        } else {
-            String::new()
-        };
+        // Pending operator/count, preformatted ("3d") — vim-parity state.
+        let mut pending = String::new();
+        if let Some(count) = editor.input_state.count {
+            pending.push_str(&count.to_string());
+        }
+        if let Some(op) = editor.input_state.pending_operator {
+            pending.push(match op {
+                Operator::Delete => 'd',
+                Operator::Change => 'c',
+                Operator::Yank => 'y',
+                Operator::Indent => '>',
+                Operator::Dedent => '<',
+                Operator::AutoIndent => '=',
+            });
+        }
 
         let filename = editor.buffer().display_name();
-        let read_only = if editor.buffer().is_read_only() {
-            " [RO]"
-        } else {
-            ""
-        };
-        let large_file = if editor.current_buffer_large_file_mode_active() {
-            " [large]"
-        } else {
-            ""
-        };
-        let modified = if editor.buffer().dirty { " [+]" } else { "" };
-
-        // Show macro recording indicator
-        let recording = if let Some(register) = editor.macros.recording_register() {
-            format!(" [recording @{}]", register)
-        } else {
-            String::new()
-        };
-
-        // Get project name (last component of project_root)
         let project_name = editor
             .project_root
             .as_ref()
             .and_then(|p| p.file_name())
-            .and_then(|n| n.to_str())
-            .map(|s| format!("[{}] ", s))
-            .unwrap_or_default();
+            .and_then(|n| n.to_str());
+        let total_lines = editor.buffer().len_lines().max(1);
 
-        let mode_display = format!(" {} ", mode_str);
-        let rest_left = format!(
-            "{}{} | {}{}{}{}{} ",
-            pending, recording, project_name, filename, large_file, read_only, modified
-        );
-
-        // Right side: LSP status, language and position
-        let lsp_status = editor.lsp_status.as_deref().unwrap_or("");
-        let lang = editor.syntax.language_name().unwrap_or("plain");
-        let right = if lsp_status.is_empty() {
-            format!(
-                " {} | {}:{} ",
-                lang,
-                editor.cursor.line + 1,
-                editor.cursor.col + 1
-            )
-        } else {
-            format!(
-                " {} | {} | {}:{} ",
-                lsp_status,
-                lang,
-                editor.cursor.line + 1,
-                editor.cursor.col + 1
-            )
+        // Render-reads-cache-only rule: everything below is cached editor
+        // state — no git2, LSP, or filesystem calls on this path.
+        let ctx = crate::statusline::StatusContext {
+            mode: editor.mode,
+            pending: &pending,
+            recording: editor.macros.recording_register(),
+            project: project_name,
+            filename: &filename,
+            modified: editor.buffer().dirty,
+            readonly: editor.buffer().is_read_only(),
+            large_file: editor.current_buffer_large_file_mode_active(),
+            branch: editor.git_branch.as_deref(),
+            diff: editor.current_git_diff_totals(),
+            diag: editor.current_diagnostic_counts(),
+            lang: editor.syntax.language_name().unwrap_or("plain"),
+            lsp_attached: editor.lsp_status.is_some(),
+            lsp_busy: editor.lsp_busy,
+            lsp_spinner: editor.lsp_spinner_frame(),
+            line: editor.cursor.line + 1,
+            col: editor.cursor.col + 1,
+            percent: ((editor.cursor.line + 1) * 100 / total_lines).min(100),
         };
+        let content = crate::statusline::build_status_segments(&ctx, glyphs, theme, basic);
 
-        // Calculate padding
-        let left_len = mode_display.len() + rest_left.len();
-        let padding = width.saturating_sub(left_len + right.len());
+        // No truncation on overflow — matches the pre-segment behavior (the
+        // terminal clips); padding saturates to zero. Width math must stay
+        // unicode-width based: icons and CJK filenames are not 1 byte = 1 col.
+        let used = crate::statusline::display_width(&content.left)
+            + crate::statusline::display_width(&content.right);
+        let padding = width.saturating_sub(used);
 
-        // Render status line: mode badge (colored) + rest (status bar colors)
-        // Mode badge with mode-specific color
-        execute!(
-            self.stdout,
-            SetBackgroundColor(mode_color),
-            SetForegroundColor(theme.ui.statusline_bg)
-        )?;
-        terminal_print!(self, "{}", mode_display);
-
-        // Rest of status line with standard colors
+        for seg in &content.left {
+            self.emit_status_segment(seg)?;
+        }
         execute!(
             self.stdout,
             SetBackgroundColor(theme.ui.statusline_bg),
             SetForegroundColor(theme.ui.statusline_fg)
         )?;
-        terminal_print!(
-            self,
-            "{}{:padding$}{}",
-            rest_left,
-            "",
-            right,
-            padding = padding
-        );
+        terminal_print!(self, "{:padding$}", "", padding = padding);
+        for seg in &content.right {
+            self.emit_status_segment(seg)?;
+        }
         execute!(self.stdout, ResetColor)?;
 
+        Ok(())
+    }
+
+    fn emit_status_segment(
+        &mut self,
+        seg: &crate::statusline::StatusSegment,
+    ) -> anyhow::Result<()> {
+        execute!(
+            self.stdout,
+            SetBackgroundColor(seg.bg),
+            SetForegroundColor(seg.fg)
+        )?;
+        if seg.bold {
+            execute!(self.stdout, SetAttribute(Attribute::Bold))?;
+        }
+        terminal_print!(self, "{}", seg.text);
+        if seg.bold {
+            // NormalIntensity clears bold without resetting colors (SGR 22).
+            execute!(self.stdout, SetAttribute(Attribute::NormalIntensity))?;
+        }
         Ok(())
     }
 
@@ -11658,8 +11622,57 @@ mod tests {
             "insert workflow render should show insert mode in statusline; output={rendered:?}"
         );
         assert!(
-            rendered.contains("[+]"),
+            rendered.contains('●'),
             "insert workflow render should show dirty marker in statusline; output={rendered:?}"
+        );
+    }
+
+    #[test]
+    fn statusline_rich_renders_powerline_segments() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.replace_buffer_content("alpha\n");
+
+        let rendered = render_editor_to_string(&editor);
+
+        assert!(
+            rendered.contains("\u{e0b0}"),
+            "rich statusline should use powerline separators; output={rendered:?}"
+        );
+        assert!(
+            !rendered.contains(" | "),
+            "legacy pipe separators should be gone in rich mode; output={rendered:?}"
+        );
+    }
+
+    #[test]
+    fn statusline_minimal_renders_flat_ascii() {
+        let mut editor = Editor::default();
+        editor.settings.ui.basic = Some(true);
+        editor.set_size(80, 12);
+        editor.replace_buffer_content("alpha\n");
+
+        let rendered = render_editor_to_string(&editor);
+
+        assert!(
+            !rendered.contains("\u{e0b0}"),
+            "minimal statusline must not use powerline glyphs; output={rendered:?}"
+        );
+        assert!(rendered.contains("NORMAL"));
+    }
+
+    #[test]
+    fn statusline_renders_wide_filename_without_panic() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.replace_buffer_content("alpha\n");
+        editor.buffer_mut().path = Some(std::path::PathBuf::from("日本語ファイル.rs"));
+
+        let rendered = render_editor_to_string(&editor);
+
+        assert!(
+            rendered.contains("日本語ファイル.rs"),
+            "double-width filename should render; output={rendered:?}"
         );
     }
 
@@ -11829,8 +11842,9 @@ mod tests {
             "statusline-only render should not repaint buffer text; output={rendered:?}"
         );
         assert!(
-            rendered.contains("LSP: ready"),
-            "statusline update render should include updated LSP status; output={rendered:?}"
+            rendered.contains('✓'),
+            "statusline update render should show the LSP idle indicator (raw \
+             status text moved to :checkhealth); output={rendered:?}"
         );
     }
 
@@ -12894,8 +12908,9 @@ mod tests {
             "combined editor/status render should include the marked row; output={rendered:?}"
         );
         assert!(
-            rendered.contains("LSP: ready"),
-            "combined editor/status render should include the statusline; output={rendered:?}"
+            rendered.contains('✓'),
+            "combined editor/status render should include the statusline's LSP \
+             indicator; output={rendered:?}"
         );
         assert!(
             !rendered.contains("alpha target") && !rendered.contains("gamma target"),

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -5507,6 +5507,14 @@ impl Terminal {
 
         // Use theme colors for finder
         let theme = editor.theme();
+        let glyphs = editor.ui_glyphs();
+        let minimal = editor.settings.resolved_ui_style().is_minimal();
+        // Rich mode reserves one column per result row for the selection bar.
+        let bar_col = if glyphs.finder_selection_bar.is_empty() {
+            0
+        } else {
+            1
+        };
         let border_color = theme.ui.finder_border;
         let title_color = theme.ui.finder_prompt;
         let selected_bg = theme.ui.finder_selected;
@@ -5540,7 +5548,7 @@ impl Terminal {
             SetForegroundColor(border_color),
             SetBackgroundColor(finder_bg)
         )?;
-        write!(self.stdout, "\u{250c}")?; // ┌
+        write!(self.stdout, "{}", glyphs.corner_tl)?;
         let title = match editor.finder.mode {
             crate::finder::FinderMode::Files => " Find Files ",
             crate::finder::FinderMode::Grep => " Live Grep ",
@@ -5553,16 +5561,24 @@ impl Terminal {
             crate::finder::FinderMode::Terminals => " Terminals ",
             crate::finder::FinderMode::Keymaps => " Key Maps ",
         };
+        // Rich mode prefixes an icon inside the border title; centering must
+        // count chars (columns), not bytes — the icon glyph is multi-byte.
+        let title = if glyphs.finder_title_icon.is_empty() {
+            title.to_string()
+        } else {
+            format!(" {}{}", glyphs.finder_title_icon, &title[1..])
+        };
+        let title_cols = title.chars().count();
 
         if preview_enabled {
             // Title centered over results panel
-            let title_start = (results_width.saturating_sub(title.len())) / 2;
+            let title_start = (results_width.saturating_sub(title_cols)) / 2;
             for i in 1..=results_width {
                 if i == title_start + 1 {
                     queue!(self.stdout, SetForegroundColor(title_color))?;
                     write!(self.stdout, "{}", title)?;
                     queue!(self.stdout, SetForegroundColor(border_color))?;
-                } else if i > title_start && i <= title_start + title.len() {
+                } else if i > title_start && i <= title_start + title_cols {
                     // Skip - already printed title
                 } else {
                     write!(self.stdout, "\u{2500}")?; // ─
@@ -5571,44 +5587,56 @@ impl Terminal {
             // Separator junction
             write!(self.stdout, "\u{252c}")?; // ┬
 
-            // Preview header with filename
+            // Preview header with filename (rich prefixes the file's devicon)
             let preview_title = if let Some(item) = editor.finder.selected_item() {
                 let filename = item
                     .path
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or("Preview");
-                format!(" {} ", filename)
+                if minimal {
+                    format!(" {} ", filename)
+                } else {
+                    let chip = item
+                        .icon
+                        .unwrap_or_else(|| FuzzyFinder::get_file_icon(&item.path));
+                    format!(
+                        " {} {} ",
+                        crate::ui_glyphs::devicon_for_chip(chip),
+                        filename
+                    )
+                }
             } else {
                 " Preview ".to_string()
             };
-            let preview_title_start = (preview_width.saturating_sub(preview_title.len())) / 2;
+            let preview_title_cols = preview_title.chars().count();
+            let preview_title_start = (preview_width.saturating_sub(preview_title_cols)) / 2;
             for i in 0..preview_width {
                 if i == preview_title_start {
                     queue!(self.stdout, SetForegroundColor(title_color))?;
                     write!(self.stdout, "{}", preview_title)?;
                     queue!(self.stdout, SetForegroundColor(border_color))?;
-                } else if i > preview_title_start && i < preview_title_start + preview_title.len() {
+                } else if i > preview_title_start && i < preview_title_start + preview_title_cols {
                     // Skip - already printed title
                 } else {
                     write!(self.stdout, "\u{2500}")?; // ─
                 }
             }
         } else {
-            let title_start = (win.width as usize - title.len()) / 2;
+            let title_start = (win.width as usize - title_cols) / 2;
             for i in 1..(win.width - 1) {
                 if i as usize == title_start {
                     queue!(self.stdout, SetForegroundColor(title_color))?;
                     write!(self.stdout, "{}", title)?;
                     queue!(self.stdout, SetForegroundColor(border_color))?;
-                } else if i as usize >= title_start && (i as usize) < title_start + title.len() {
+                } else if i as usize >= title_start && (i as usize) < title_start + title_cols {
                     // Skip - already printed title
                 } else {
                     write!(self.stdout, "\u{2500}")?; // ─
                 }
             }
         }
-        write!(self.stdout, "\u{2510}")?; // ┐
+        write!(self.stdout, "{}", glyphs.corner_tr)?;
 
         // Layout: top border, items list, separator, input line, bottom border
         // Height calculation: total height - 4 (top border, separator, input, bottom border)
@@ -5652,99 +5680,43 @@ impl Terminal {
                     queue!(self.stdout, SetBackgroundColor(selected_bg))?;
                 }
 
-                // Get file type indicator (2 chars + space)
+                // Selection accent bar column (rich only; reserved on every
+                // item row so columns stay aligned)
+                if bar_col == 1 {
+                    if is_selected {
+                        queue!(self.stdout, SetForegroundColor(title_color))?;
+                        write!(self.stdout, "{}", glyphs.finder_selection_bar)?;
+                    } else {
+                        write!(self.stdout, " ")?;
+                    }
+                }
+
+                // File type indicator: two-char chip (minimal) or devicon (rich),
+                // both 3 columns wide and tinted by the shared chip color table
                 let icon = item
                     .icon
                     .unwrap_or_else(|| FuzzyFinder::get_file_icon(&item.path));
-                let icon_color = match icon {
-                    "TR" => Color::Rgb {
-                        r: 90,
-                        g: 210,
-                        b: 120,
-                    }, // Terminal - green
-                    "RS" => Color::Rgb {
-                        r: 255,
-                        g: 100,
-                        b: 50,
-                    }, // Rust - orange
-                    "TS" | "TX" => Color::Rgb {
-                        r: 50,
-                        g: 150,
-                        b: 255,
-                    }, // TypeScript - blue
-                    "JS" | "JX" => Color::Rgb {
-                        r: 255,
-                        g: 220,
-                        b: 50,
-                    }, // JavaScript - yellow
-                    "PY" => Color::Rgb {
-                        r: 80,
-                        g: 180,
-                        b: 80,
-                    }, // Python - green
-                    "GO" => Color::Rgb {
-                        r: 100,
-                        g: 200,
-                        b: 220,
-                    }, // Go - cyan
-                    "RB" => Color::Rgb {
-                        r: 220,
-                        g: 50,
-                        b: 50,
-                    }, // Ruby - red
-                    "HT" => Color::Rgb {
-                        r: 230,
-                        g: 100,
-                        b: 50,
-                    }, // HTML - orange
-                    "CS" | "SC" => Color::Rgb {
-                        r: 100,
-                        g: 150,
-                        b: 255,
-                    }, // CSS - blue
-                    "MD" => Color::Rgb {
-                        r: 150,
-                        g: 150,
-                        b: 150,
-                    }, // Markdown - gray
-                    "YM" | "TM" | "CF" => Color::Rgb {
-                        r: 180,
-                        g: 140,
-                        b: 100,
-                    }, // Config - tan
-                    "GT" => Color::Rgb {
-                        r: 240,
-                        g: 80,
-                        b: 50,
-                    }, // Git - red-orange
-                    "EN" => Color::Rgb {
-                        r: 255,
-                        g: 200,
-                        b: 50,
-                    }, // Env - yellow
-                    "SH" | "ZS" | "FS" => Color::Rgb {
-                        r: 100,
-                        g: 200,
-                        b: 100,
-                    }, // Shell - green
-                    _ => Color::Rgb {
-                        r: 120,
-                        g: 120,
-                        b: 120,
-                    }, // Default - gray
-                };
+                let icon_color = crate::ui_glyphs::file_chip_color(icon);
                 queue!(self.stdout, SetForegroundColor(icon_color))?;
-                write!(self.stdout, "{} ", icon)?;
+                if minimal {
+                    write!(self.stdout, "{} ", icon)?;
+                } else {
+                    write!(
+                        self.stdout,
+                        "{}  ",
+                        crate::ui_glyphs::devicon_for_chip(icon)
+                    )?;
+                }
 
                 // Truncate display to fit and highlight matches
-                // Leave space for icon (3 chars) and scroll indicator if needed
-                let icon_width = 3; // icon + space
+                // Leave space for the icon cell and scroll indicator if needed
+                let icon_width = 3; // icon cell
                 let base_width = if show_scroll_indicator {
                     results_width.saturating_sub(2) // -1 for scroll indicator, -1 for spacing
                 } else {
                     results_width.saturating_sub(1) // -1 for spacing
                 };
-                let max_len = base_width.saturating_sub(icon_width);
+                let max_len = base_width.saturating_sub(icon_width + bar_col);
                 let display_chars: Vec<char> = item.display.chars().take(max_len).collect();
 
                 // Reset foreground color for text
@@ -5994,10 +5966,10 @@ impl Terminal {
         queue!(self.stdout, SetForegroundColor(mode_color))?;
         write!(self.stdout, "[{}]", mode_str)?;
         queue!(self.stdout, SetForegroundColor(finder_fg))?;
-        write!(self.stdout, " > ")?;
+        write!(self.stdout, "{}", glyphs.finder_prompt)?;
 
-        // Query text
-        let prefix_len = 6; // "[N] > " or "[I] > "
+        // Query text; both prompt variants occupy 3 columns after "[N]"/"[I]"
+        let prefix_len = 6; // "[N] > " or "[N] <icon> "
         let query_display: String = editor
             .finder
             .query
@@ -6025,7 +5997,7 @@ impl Terminal {
             cursor::MoveTo(win.x, win.y + win.height - 1),
             SetForegroundColor(border_color)
         )?;
-        write!(self.stdout, "\u{2514}")?; // └
+        write!(self.stdout, "{}", glyphs.corner_bl)?;
 
         if preview_enabled {
             // Status centered over results panel, preview indicator shown
@@ -6069,7 +6041,7 @@ impl Terminal {
                 }
             }
         }
-        write!(self.stdout, "\u{2518}")?; // ┘
+        write!(self.stdout, "{}", glyphs.corner_br)?;
 
         queue!(
             self.stdout,
@@ -11437,10 +11409,11 @@ mod tests {
             );
             let rendered = render_finder_to_string(&editor, inherited_background);
             let expected_top_border = format!(
-                "{}{}{}┌",
+                "{}{}{}{}",
                 cursor_position_sequence(win.x, win.y),
                 foreground_sequence(theme.ui.finder_border),
                 background_sequence(theme.ui.finder_bg),
+                editor.ui_glyphs().corner_tl,
             );
             let rendered_prefix: String = rendered.chars().take(80).collect();
 
@@ -11449,6 +11422,72 @@ mod tests {
                 "finder top border should establish {theme_name} background on its first frame; expected={expected_top_border:?}, actual prefix={rendered_prefix:?}"
             );
         }
+    }
+
+    #[test]
+    fn finder_rich_renders_rounded_corners_and_devicons() {
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor
+            .finder
+            .open_harpoon(vec![PathBuf::from("alpha.rs"), PathBuf::from("beta.ts")]);
+        editor.mode = Mode::Finder;
+
+        let rendered = render_finder_to_string(&editor, Color::Black);
+
+        assert!(
+            rendered.contains('╭') && rendered.contains('╯'),
+            "rich finder should use rounded corners"
+        );
+        assert!(!rendered.contains('┌') && !rendered.contains('┘'));
+        assert!(
+            rendered.contains('\u{e7a8}'),
+            "rust devicon should replace the RS chip; output={rendered:?}"
+        );
+        assert!(!rendered.contains("RS "));
+    }
+
+    #[test]
+    fn finder_minimal_matches_legacy_chrome() {
+        let mut editor = Editor::default();
+        editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
+        editor.set_size(120, 30);
+        editor.finder.open_harpoon(vec![PathBuf::from("alpha.rs")]);
+        editor.mode = Mode::Finder;
+
+        let rendered = render_finder_to_string(&editor, Color::Black);
+
+        assert!(rendered.contains('┌'), "minimal keeps square corners");
+        // A color sequence sits between the mode indicator and the arrow
+        // (same as the legacy renderer), so assert the pieces separately.
+        assert!(
+            rendered.contains("[I]") || rendered.contains("[N]"),
+            "minimal keeps the mode indicator; output={rendered:?}"
+        );
+        assert!(
+            rendered.contains(" > "),
+            "minimal keeps the legacy arrow prompt; output={rendered:?}"
+        );
+        assert!(rendered.contains("RS "), "minimal keeps two-char chips");
+        assert!(!rendered.contains('╭') && !rendered.contains('▌'));
+    }
+
+    #[test]
+    fn finder_rich_marks_selected_row_with_accent_bar() {
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor
+            .finder
+            .open_harpoon(vec![PathBuf::from("alpha.rs"), PathBuf::from("beta.ts")]);
+        editor.mode = Mode::Finder;
+
+        let rendered = render_finder_to_string(&editor, Color::Black);
+
+        assert_eq!(
+            rendered.matches('▌').count(),
+            1,
+            "exactly one selected-row accent bar; output={rendered:?}"
+        );
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3101,7 +3101,7 @@ impl Terminal {
         let width = editor.term_width as usize;
         let theme = editor.theme();
         let glyphs = editor.ui_glyphs();
-        let basic = editor.settings.resolved_basic_ui();
+        let minimal = editor.settings.resolved_ui_style().is_minimal();
 
         // Pending operator/count, preformatted ("3d") — vim-parity state.
         let mut pending = String::new();
@@ -3149,7 +3149,7 @@ impl Terminal {
             col: editor.cursor.col + 1,
             percent: ((editor.cursor.line + 1) * 100 / total_lines).min(100),
         };
-        let content = crate::statusline::build_status_segments(&ctx, glyphs, theme, basic);
+        let content = crate::statusline::build_status_segments(&ctx, glyphs, theme, minimal);
 
         // No truncation on overflow — matches the pre-segment behavior (the
         // terminal clips); padding saturates to zero. Width math must stay
@@ -11648,7 +11648,7 @@ mod tests {
     #[test]
     fn statusline_minimal_renders_flat_ascii() {
         let mut editor = Editor::default();
-        editor.settings.ui.basic = Some(true);
+        editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
         editor.set_size(80, 12);
         editor.replace_buffer_content("alpha\n");
 

--- a/src/theme/bundled.rs
+++ b/src/theme/bundled.rs
@@ -127,8 +127,42 @@ pub fn bundled_theme_names() -> Vec<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    use super::load_theme_from_toml;
     use super::{bundled_theme_names, get_bundled_themes};
     use crossterm::style::Color;
+
+    #[test]
+    fn statusline_section_bg_falls_back_to_cursor_line() {
+        // No bundled theme defines section_bg yet, so every theme must
+        // resolve it to its own cursor_line color.
+        for theme in get_bundled_themes() {
+            assert_eq!(
+                theme.ui.statusline_section_bg, theme.ui.cursor_line,
+                "theme {} should fall back to cursor_line",
+                theme.name
+            );
+        }
+    }
+
+    #[test]
+    fn statusline_section_bg_parses_when_present() {
+        let toml = r##"
+[palette]
+bg = "#101010"
+
+[ui.statusline]
+section_bg = "#24283b"
+"##;
+        let theme = load_theme_from_toml("test-theme", toml).expect("theme should load");
+        assert_eq!(
+            theme.ui.statusline_section_bg,
+            Color::Rgb {
+                r: 0x24,
+                g: 0x28,
+                b: 0x3b
+            }
+        );
+    }
 
     #[test]
     fn github_light_is_a_complete_bundled_theme() {

--- a/src/theme/loader.rs
+++ b/src/theme/loader.rs
@@ -109,6 +109,8 @@ pub struct StatuslineToml {
     pub mode_visual: Option<String>,
     pub mode_command: Option<String>,
     pub mode_replace: Option<String>,
+    /// Optional mid-segment background; falls back to the theme's cursor_line
+    pub section_bg: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -266,6 +268,14 @@ fn load_theme_from_toml_inner(name: &str, toml: &ThemeToml) -> Theme {
     };
 
     // Parse UI colors
+    // Hoisted so statusline_section_bg can fall back to the theme's own
+    // resolved cursor_line rather than the base default.
+    let cursor_line = toml
+        .ui
+        .cursor_line
+        .as_ref()
+        .and_then(|v| resolve_color(v, palette))
+        .unwrap_or(base.ui.cursor_line);
     let ui = UiColors {
         background: toml
             .ui
@@ -279,12 +289,7 @@ fn load_theme_from_toml_inner(name: &str, toml: &ThemeToml) -> Theme {
             .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.foreground),
-        cursor_line: toml
-            .ui
-            .cursor_line
-            .as_ref()
-            .and_then(|v| resolve_color(v, palette))
-            .unwrap_or(base.ui.cursor_line),
+        cursor_line,
         selection: toml
             .ui
             .selection
@@ -353,6 +358,13 @@ fn load_theme_from_toml_inner(name: &str, toml: &ThemeToml) -> Theme {
             .as_ref()
             .and_then(|v| resolve_color(v, palette))
             .unwrap_or(base.ui.statusline_mode_replace),
+        statusline_section_bg: toml
+            .ui
+            .statusline
+            .section_bg
+            .as_ref()
+            .and_then(|v| resolve_color(v, palette))
+            .unwrap_or(cursor_line),
 
         popup_bg: toml
             .ui

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -94,6 +94,9 @@ pub struct UiColors {
     pub statusline_mode_visual: Color,
     pub statusline_mode_command: Color,
     pub statusline_mode_replace: Color,
+    /// Background for the statusline's mid segments (git/lang blocks in rich
+    /// mode). Optional in theme TOML; falls back to cursor_line.
+    pub statusline_section_bg: Color,
 
     // Popups/Floating windows
     pub popup_bg: Color,
@@ -264,6 +267,12 @@ impl Theme {
                 statusline_mode_visual: purple,
                 statusline_mode_command: yellow,
                 statusline_mode_replace: red,
+                // matches cursor_line above (the documented fallback)
+                statusline_section_bg: Color::Rgb {
+                    r: 44,
+                    g: 49,
+                    b: 60,
+                },
 
                 popup_bg: bg_dark,
                 popup_border: Color::Rgb {

--- a/src/ui_glyphs.rs
+++ b/src/ui_glyphs.rs
@@ -27,6 +27,18 @@ pub struct UiGlyphs {
     /// LSP busy indicator frames; advanced per LSP notification
     /// (event-driven — never on a timer).
     pub lsp_busy_frames: &'static [&'static str],
+    /// Floating-window corners (rounded in rich, square in minimal).
+    pub corner_tl: &'static str,
+    pub corner_tr: &'static str,
+    pub corner_bl: &'static str,
+    pub corner_br: &'static str,
+    /// Finder input prompt, rendered after the "[I]"/"[N]" mode indicator.
+    /// Both variants occupy 3 columns so the prompt width math is shared.
+    pub finder_prompt: &'static str,
+    /// Selected-row accent bar; empty = no reserved bar column (legacy look).
+    pub finder_selection_bar: &'static str,
+    /// Prefix inside floating-window border titles.
+    pub finder_title_icon: &'static str,
 }
 
 pub static RICH: UiGlyphs = UiGlyphs {
@@ -41,6 +53,13 @@ pub static RICH: UiGlyphs = UiGlyphs {
     diag_warn: "\u{f071} ",
     lsp_ok: "✓",
     lsp_busy_frames: &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"],
+    corner_tl: "╭",
+    corner_tr: "╮",
+    corner_bl: "╰",
+    corner_br: "╯",
+    finder_prompt: " \u{f002} ",
+    finder_selection_bar: "▌",
+    finder_title_icon: "\u{f002} ",
 };
 
 pub static MINIMAL: UiGlyphs = UiGlyphs {
@@ -55,7 +74,122 @@ pub static MINIMAL: UiGlyphs = UiGlyphs {
     diag_warn: "W:",
     lsp_ok: "✓",
     lsp_busy_frames: &["~"],
+    corner_tl: "┌",
+    corner_tr: "┐",
+    corner_bl: "└",
+    corner_br: "┘",
+    finder_prompt: " > ",
+    finder_selection_bar: "",
+    finder_title_icon: "",
 };
+
+/// Devicon glyph for the finder's two-char file-type chips. The chip
+/// classification (FuzzyFinder::get_file_icon) stays the single source of
+/// file-type truth; rich mode only swaps its visual representation.
+pub fn devicon_for_chip(chip: &str) -> &'static str {
+    match chip {
+        "TR" => "\u{f120}",               // terminal
+        "RS" => "\u{e7a8}",               // rust
+        "TS" => "\u{e628}",               // typescript
+        "TX" => "\u{e7ba}",               // tsx/react
+        "JS" => "\u{e74e}",               // javascript
+        "JX" => "\u{e7ba}",               // jsx/react
+        "PY" => "\u{e73c}",               // python
+        "GO" => "\u{e626}",               // go
+        "RB" => "\u{e739}",               // ruby
+        "HT" => "\u{e736}",               // html
+        "CS" | "SC" => "\u{e749}",        // css/scss
+        "MD" => "\u{e73e}",               // markdown
+        "YM" | "TM" | "CF" => "\u{e615}", // yaml/toml/config
+        "GT" => "\u{e702}",               // git
+        "EN" => "\u{f462}",               // env
+        "SH" | "ZS" | "FS" => "\u{e795}", // shell
+        _ => "\u{f15b}",                  // generic file
+    }
+}
+
+/// File-type tint for chips and devicons — lifted unchanged from the
+/// former inline match in render_finder so both representations share it.
+pub fn file_chip_color(chip: &str) -> crossterm::style::Color {
+    use crossterm::style::Color;
+    match chip {
+        "TR" => Color::Rgb {
+            r: 90,
+            g: 210,
+            b: 120,
+        }, // Terminal - green
+        "RS" => Color::Rgb {
+            r: 255,
+            g: 100,
+            b: 50,
+        }, // Rust - orange
+        "TS" | "TX" => Color::Rgb {
+            r: 50,
+            g: 150,
+            b: 255,
+        }, // TypeScript - blue
+        "JS" | "JX" => Color::Rgb {
+            r: 255,
+            g: 220,
+            b: 50,
+        }, // JavaScript - yellow
+        "PY" => Color::Rgb {
+            r: 80,
+            g: 180,
+            b: 80,
+        }, // Python - green
+        "GO" => Color::Rgb {
+            r: 100,
+            g: 200,
+            b: 220,
+        }, // Go - cyan
+        "RB" => Color::Rgb {
+            r: 220,
+            g: 50,
+            b: 50,
+        }, // Ruby - red
+        "HT" => Color::Rgb {
+            r: 230,
+            g: 100,
+            b: 50,
+        }, // HTML - orange
+        "CS" | "SC" => Color::Rgb {
+            r: 100,
+            g: 150,
+            b: 255,
+        }, // CSS - blue
+        "MD" => Color::Rgb {
+            r: 150,
+            g: 150,
+            b: 150,
+        }, // Markdown - gray
+        "YM" | "TM" | "CF" => Color::Rgb {
+            r: 180,
+            g: 140,
+            b: 100,
+        }, // Config - tan
+        "GT" => Color::Rgb {
+            r: 240,
+            g: 80,
+            b: 50,
+        }, // Git - red-orange
+        "EN" => Color::Rgb {
+            r: 255,
+            g: 200,
+            b: 50,
+        }, // Env - yellow
+        "SH" | "ZS" | "FS" => Color::Rgb {
+            r: 100,
+            g: 200,
+            b: 100,
+        }, // Shell - green
+        _ => Color::Rgb {
+            r: 120,
+            g: 120,
+            b: 120,
+        }, // Default - gray
+    }
+}
 
 impl UiGlyphs {
     pub fn for_minimal(minimal: bool) -> &'static UiGlyphs {
@@ -79,9 +213,38 @@ mod tests {
             g.diag_error,
             g.diag_warn,
             g.lsp_ok,
+            g.corner_tl,
+            g.corner_tr,
+            g.corner_bl,
+            g.corner_br,
+            g.finder_prompt,
+            g.finder_selection_bar,
+            g.finder_title_icon,
         ];
         v.extend(g.lsp_busy_frames);
         v
+    }
+
+    #[test]
+    fn devicon_for_chip_maps_known_types() {
+        let rust = devicon_for_chip("RS");
+        let ts = devicon_for_chip("TS");
+        let md = devicon_for_chip("MD");
+        let unknown = devicon_for_chip("??");
+        assert!(!rust.is_empty() && !ts.is_empty() && !md.is_empty());
+        assert_ne!(rust, ts);
+        assert_ne!(ts, md);
+        assert_eq!(
+            unknown, "\u{f15b}",
+            "unknown chips fall back to a generic file glyph"
+        );
+    }
+
+    #[test]
+    fn minimal_finder_prompt_matches_legacy() {
+        assert_eq!(MINIMAL.finder_prompt, " > ");
+        assert_eq!(MINIMAL.corner_tl, "┌");
+        assert!(MINIMAL.finder_selection_bar.is_empty());
     }
 
     #[test]

--- a/src/ui_glyphs.rs
+++ b/src/ui_glyphs.rs
@@ -1,0 +1,103 @@
+//! Shared glyph tables for rich (Nerd Font) vs minimal (ASCII/basic-Unicode)
+//! UI chrome. One layout code path per surface; only the table differs.
+//! Minimal doubles as the no-Nerd-Font fallback, so it must avoid
+//! private-use-area codepoints entirely (enforced by test below).
+
+pub struct UiGlyphs {
+    /// Powerline transition, left side (rendered with fg = previous segment's
+    /// bg and bg = next segment's bg).
+    pub sep_left: &'static str,
+    /// Powerline transition, right side.
+    pub sep_right: &'static str,
+    /// Item separator inside a flat segment (minimal statusline).
+    pub item_sep: &'static str,
+    /// Git branch prefix.
+    pub branch: &'static str,
+    /// Modified-buffer marker (replaces "[+]").
+    pub modified: &'static str,
+    /// Read-only marker.
+    pub readonly: &'static str,
+    /// Macro-recording marker prefix (register char is appended by caller).
+    pub recording: &'static str,
+    /// Diagnostic count prefixes.
+    pub diag_error: &'static str,
+    pub diag_warn: &'static str,
+    /// LSP idle indicator.
+    pub lsp_ok: &'static str,
+    /// LSP busy indicator frames; advanced per LSP notification
+    /// (event-driven — never on a timer).
+    pub lsp_busy_frames: &'static [&'static str],
+}
+
+pub static RICH: UiGlyphs = UiGlyphs {
+    sep_left: "\u{e0b0}",
+    sep_right: "\u{e0b2}",
+    item_sep: " ",
+    branch: "\u{e0a0} ",
+    modified: "●",
+    readonly: "\u{f023} ",
+    recording: "\u{f111} @",
+    diag_error: "\u{f057} ",
+    diag_warn: "\u{f071} ",
+    lsp_ok: "✓",
+    lsp_busy_frames: &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧"],
+};
+
+pub static MINIMAL: UiGlyphs = UiGlyphs {
+    sep_left: "",
+    sep_right: "",
+    item_sep: " · ",
+    branch: "",
+    modified: "•",
+    readonly: "[RO] ",
+    recording: "[recording @",
+    diag_error: "E:",
+    diag_warn: "W:",
+    lsp_ok: "✓",
+    lsp_busy_frames: &["~"],
+};
+
+impl UiGlyphs {
+    pub fn for_basic(basic: bool) -> &'static UiGlyphs {
+        if basic { &MINIMAL } else { &RICH }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fields(g: &UiGlyphs) -> Vec<&'static str> {
+        let mut v = vec![
+            g.sep_left,
+            g.sep_right,
+            g.item_sep,
+            g.branch,
+            g.modified,
+            g.readonly,
+            g.recording,
+            g.diag_error,
+            g.diag_warn,
+            g.lsp_ok,
+        ];
+        v.extend(g.lsp_busy_frames);
+        v
+    }
+
+    #[test]
+    fn minimal_avoids_nerd_font_private_use_codepoints() {
+        for s in fields(&MINIMAL) {
+            assert!(
+                !s.chars()
+                    .any(|c| matches!(c as u32, 0xE000..=0xF8FF | 0xF0000..=0xFFFFD)),
+                "minimal glyph {s:?} uses a private-use codepoint"
+            );
+        }
+    }
+
+    #[test]
+    fn for_basic_selects_tables() {
+        assert!(std::ptr::eq(UiGlyphs::for_basic(true), &MINIMAL));
+        assert!(std::ptr::eq(UiGlyphs::for_basic(false), &RICH));
+    }
+}

--- a/src/ui_glyphs.rs
+++ b/src/ui_glyphs.rs
@@ -58,8 +58,8 @@ pub static MINIMAL: UiGlyphs = UiGlyphs {
 };
 
 impl UiGlyphs {
-    pub fn for_basic(basic: bool) -> &'static UiGlyphs {
-        if basic { &MINIMAL } else { &RICH }
+    pub fn for_minimal(minimal: bool) -> &'static UiGlyphs {
+        if minimal { &MINIMAL } else { &RICH }
     }
 }
 
@@ -96,8 +96,8 @@ mod tests {
     }
 
     #[test]
-    fn for_basic_selects_tables() {
-        assert!(std::ptr::eq(UiGlyphs::for_basic(true), &MINIMAL));
-        assert!(std::ptr::eq(UiGlyphs::for_basic(false), &RICH));
+    fn for_minimal_selects_tables() {
+        assert!(std::ptr::eq(UiGlyphs::for_minimal(true), &MINIMAL));
+        assert!(std::ptr::eq(UiGlyphs::for_minimal(false), &RICH));
     }
 }


### PR DESCRIPTION
Finder re-skin behind the same [ui] style flag as the statusline. Rich mode gets rounded corners, an icon in the border titles (preview title shows the selected file's devicon + name), per-filetype devicons in place of the two-char chips, a search-icon prompt, and a selected-row accent bar. Minimal mode keeps the previous finder look untouched (pinned by
test). Layout math, bottom-up order, preview split, scrollbar, and the match counter are unchanged in both modes.

- New UiGlyphs fields: corners, finder_prompt, finder_selection_bar, finder_title_icon
- devicon_for_chip + file_chip_color in ui_glyphs.rs (color table lifted unchanged from the former inline match in render_finder)
- Border title centering now counts chars, not bytes (icons are multi-byte)