### PR TITLE
feat: rich explorer chrome and gutter diagnostic glyphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Nevi 0.3.0 brings further improvements.
 
 - New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
 - The finder gets the rich treatment too: rounded corners, icon border titles, per-filetype devicons in results and the preview title, and a selection accent bar. `[ui] style = "minimal"` keeps the previous finder look (square corners, two-letter file chips) unchanged.
+- The explorer follows: selection accent bar, git status tinting file names, dot git markers, a folder icon in the header, and diagnostic rollup badges on files and folders (a folder containing errors shows the count without expanding it). Buffer gutter diagnostic signs use Nerd Font glyphs in rich mode. Minimal mode keeps the previous explorer letters and `● ▲ ■ ○` gutter signs; the explorer's relative-number column is unchanged in both modes.
 - `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).
 - Statusline width math is now Unicode-aware, fixing right-side misalignment with double-width (e.g. CJK) filenames.
 - Themes gain an optional `[ui.statusline] section_bg` key for the mid statusline segments; it falls back to `cursor_line`, so existing themes need no changes.

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1036,6 +1036,9 @@ pub struct Editor {
     lsp_spinner_idx: usize,
     /// LSP diagnostics per file URI
     diagnostics: HashMap<String, Vec<Diagnostic>>,
+    /// (errors, warnings) rolled up per file/directory path for explorer
+    /// badges; rebuilt on diagnostics events, never during render
+    diag_rollup: HashMap<std::path::PathBuf, (usize, usize)>,
     /// Autocomplete state
     pub completion: CompletionState,
     /// Pending LSP action to execute (handled by main loop)
@@ -1578,6 +1581,7 @@ impl Editor {
             lsp_busy: false,
             lsp_spinner_idx: 0,
             diagnostics: HashMap::new(),
+            diag_rollup: HashMap::new(),
             completion: CompletionState::default(),
             pending_lsp_action: None,
             jump_list: JumpList::default(),
@@ -2422,6 +2426,43 @@ impl Editor {
         }
 
         self.diagnostics.insert(uri, diags);
+        self.rebuild_diag_rollup();
+    }
+
+    /// Rebuild the per-path diagnostic rollup used by the explorer's folder
+    /// badges. Event-driven (runs only when diagnostics arrive) so renders
+    /// never aggregate; bounded by files-with-diagnostics × path depth.
+    fn rebuild_diag_rollup(&mut self) {
+        self.diag_rollup.clear();
+        for (uri, diags) in &self.diagnostics {
+            let mut errors = 0usize;
+            let mut warnings = 0usize;
+            for d in diags {
+                match d.severity {
+                    crate::lsp::DiagnosticSeverity::Error => errors += 1,
+                    crate::lsp::DiagnosticSeverity::Warning => warnings += 1,
+                    _ => {}
+                }
+            }
+            if errors == 0 && warnings == 0 {
+                continue;
+            }
+            let Some(path) = crate::lsp::uri_to_path(uri) else {
+                continue;
+            };
+            let mut current = Some(path.as_path());
+            while let Some(p) = current {
+                let entry = self.diag_rollup.entry(p.to_path_buf()).or_insert((0, 0));
+                entry.0 += errors;
+                entry.1 += warnings;
+                current = p.parent();
+            }
+        }
+    }
+
+    /// (errors, warnings) rolled up for a file or directory, if any.
+    pub fn diag_counts_for_path(&self, path: &std::path::Path) -> Option<(usize, usize)> {
+        self.diag_rollup.get(path).copied()
     }
 
     fn diagnostic_render_rows_for_uri(
@@ -13258,6 +13299,54 @@ mod tests {
         let _ = editor.apply_selected_code_action();
 
         assert_eq!(editor.buffer().content(), "abc\n");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn diagnostic_rollup_aggregates_counts_into_ancestor_dirs() {
+        let tmp = unique_temp_dir("nevi_diag_rollup");
+        let sub = tmp.join("src");
+        std::fs::create_dir_all(&sub).expect("create dirs");
+        let path = sub.join("lib.rs");
+        std::fs::write(&path, "one\ntwo\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        let uri = crate::lsp::path_to_uri(&path);
+        editor.set_diagnostics(
+            uri.clone(),
+            vec![
+                Diagnostic {
+                    line: 0,
+                    end_line: 0,
+                    col_start: 0,
+                    col_end: 1,
+                    severity: DiagnosticSeverity::Error,
+                    message: "e".to_string(),
+                    source: None,
+                    code: None,
+                },
+                Diagnostic {
+                    line: 1,
+                    end_line: 1,
+                    col_start: 0,
+                    col_end: 1,
+                    severity: DiagnosticSeverity::Warning,
+                    message: "w".to_string(),
+                    source: None,
+                    code: None,
+                },
+            ],
+        );
+
+        assert_eq!(editor.diag_counts_for_path(&path), Some((1, 1)));
+        assert_eq!(editor.diag_counts_for_path(&sub), Some((1, 1)));
+        assert_eq!(editor.diag_counts_for_path(&tmp), Some((1, 1)));
+
+        editor.set_diagnostics(uri, vec![]);
+        assert_eq!(editor.diag_counts_for_path(&path), None);
+        assert_eq!(editor.diag_counts_for_path(&sub), None);
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1815,7 +1815,7 @@ impl Terminal {
                     // Diagnostic sign (second char) - priority: error > warning > info > hint
                     if has_error {
                         execute!(self.stdout, SetForegroundColor(theme.diagnostic.error))?;
-                        terminal_print!(self, "●");
+                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_error);
                         execute!(
                             self.stdout,
                             SetForegroundColor(editor_fg),
@@ -1823,7 +1823,7 @@ impl Terminal {
                         )?;
                     } else if has_warning {
                         execute!(self.stdout, SetForegroundColor(theme.diagnostic.warning))?;
-                        terminal_print!(self, "▲");
+                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_warn);
                         execute!(
                             self.stdout,
                             SetForegroundColor(editor_fg),
@@ -1831,7 +1831,7 @@ impl Terminal {
                         )?;
                     } else if has_info {
                         execute!(self.stdout, SetForegroundColor(theme.diagnostic.info))?;
-                        terminal_print!(self, "■");
+                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_info);
                         execute!(
                             self.stdout,
                             SetForegroundColor(editor_fg),
@@ -1839,7 +1839,7 @@ impl Terminal {
                         )?;
                     } else if has_hint {
                         execute!(self.stdout, SetForegroundColor(theme.diagnostic.hint))?;
-                        terminal_print!(self, "○");
+                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_hint);
                         execute!(
                             self.stdout,
                             SetForegroundColor(editor_fg),
@@ -2140,7 +2140,7 @@ impl Terminal {
                 // Diagnostic sign (second char) - priority: error > warning > info > hint
                 if has_error {
                     execute!(self.stdout, SetForegroundColor(theme.diagnostic.error))?;
-                    terminal_print!(self, "●");
+                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_error);
                     execute!(
                         self.stdout,
                         SetForegroundColor(editor_fg),
@@ -2148,7 +2148,7 @@ impl Terminal {
                     )?;
                 } else if has_warning {
                     execute!(self.stdout, SetForegroundColor(theme.diagnostic.warning))?;
-                    terminal_print!(self, "▲");
+                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_warn);
                     execute!(
                         self.stdout,
                         SetForegroundColor(editor_fg),
@@ -2156,7 +2156,7 @@ impl Terminal {
                     )?;
                 } else if has_info {
                     execute!(self.stdout, SetForegroundColor(theme.diagnostic.info))?;
-                    terminal_print!(self, "■");
+                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_info);
                     execute!(
                         self.stdout,
                         SetForegroundColor(editor_fg),
@@ -2164,7 +2164,7 @@ impl Terminal {
                     )?;
                 } else if has_hint {
                     execute!(self.stdout, SetForegroundColor(theme.diagnostic.hint))?;
-                    terminal_print!(self, "○");
+                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_hint);
                     execute!(
                         self.stdout,
                         SetForegroundColor(editor_fg),
@@ -2461,6 +2461,8 @@ impl Terminal {
 
         // Use theme colors for explorer
         let theme = editor.theme();
+        let glyphs = editor.ui_glyphs();
+        let minimal = editor.settings.resolved_ui_style().is_minimal();
         let explorer_bg = theme.ui.explorer_bg;
         let explorer_fg = theme.ui.foreground;
         let selected_bg = theme.ui.explorer_selected;
@@ -2492,7 +2494,7 @@ impl Terminal {
             .map(|n| n.to_string_lossy().to_string())
             .unwrap_or_else(|| "Explorer".to_string());
 
-        let header = format!(" {} ", project_name);
+        let header = format!(" {}{} ", glyphs.explorer_header_icon, project_name);
         let header = if header.len() > width {
             format!("{}…", &header[..width.saturating_sub(1)])
         } else {
@@ -2553,15 +2555,25 @@ impl Terminal {
                     selected - idx
                 };
 
-                if is_selected {
+                // Rich mode turns the selected row's leading column into an
+                // accent bar; rel_line is 0 there, so the number still fits.
+                if is_selected && !minimal {
+                    execute!(self.stdout, SetForegroundColor(dir_color))?;
+                    terminal_print!(self, "▌");
                     execute!(self.stdout, SetForegroundColor(current_line_num_color))?;
+                    terminal_print!(self, "{:>2} ", rel_line);
                 } else {
-                    execute!(self.stdout, SetForegroundColor(line_num_color))?;
+                    if is_selected {
+                        execute!(self.stdout, SetForegroundColor(current_line_num_color))?;
+                    } else {
+                        execute!(self.stdout, SetForegroundColor(line_num_color))?;
+                    }
+                    terminal_print!(self, "{:>3} ", rel_line);
                 }
-                terminal_print!(self, "{:>3} ", rel_line);
 
-                // Get icon (use config for Nerd Font vs Unicode fallback)
-                let use_nerd_fonts = editor.settings.editor.use_nerd_font_icons;
+                // Icon set follows the resolved UI style (the legacy
+                // use_nerd_font_icons flag still feeds the resolution)
+                let use_nerd_fonts = !minimal;
                 let icon = editor.explorer.get_icon(node, use_nerd_fonts);
 
                 // Get icon color
@@ -2616,10 +2628,49 @@ impl Terminal {
 
                 let git_status = editor.explorer.git_status_for_path(&node.path);
 
+                // Rich mode tints the file name itself with its git status
+                // (search-match highlight still wins)
+                let name_color = if minimal || is_match {
+                    name_color
+                } else {
+                    match git_status {
+                        Some(crate::git::GitFileStatus::Added)
+                        | Some(crate::git::GitFileStatus::Untracked) => theme.git.added,
+                        Some(crate::git::GitFileStatus::Modified) => theme.git.modified,
+                        Some(crate::git::GitFileStatus::Deleted) => theme.git.deleted,
+                        Some(crate::git::GitFileStatus::Conflicted) => theme.diagnostic.error,
+                        None => name_color,
+                    }
+                };
+
+                // Right-aligned diagnostic rollup badge (folders aggregate
+                // their children); dropped when the row is too narrow
+                let mut badge = editor.diag_counts_for_path(&node.path).map(|(e, w)| {
+                    if e > 0 {
+                        (
+                            format!("{}{}", glyphs.diag_error, e),
+                            theme.diagnostic.error,
+                        )
+                    } else {
+                        (
+                            format!("{}{}", glyphs.diag_warn, w),
+                            theme.diagnostic.warning,
+                        )
+                    }
+                });
+                let mut badge_cols = badge
+                    .as_ref()
+                    .map(|(text, _)| text.chars().count() + 1)
+                    .unwrap_or(0);
+                if remaining_width < badge_cols + 8 {
+                    badge = None;
+                    badge_cols = 0;
+                }
+
                 // Calculate available width for name.
-                // Layout: icon + space + git marker column + space + name
+                // Layout: icon + space + git marker column + space + name [+ badge]
                 let prefix_width = 4;
-                let name_max_width = remaining_width.saturating_sub(prefix_width);
+                let name_max_width = remaining_width.saturating_sub(prefix_width + badge_cols);
 
                 // Truncate name if needed
                 let name_chars: Vec<char> = node.name.chars().collect();
@@ -2639,26 +2690,27 @@ impl Terminal {
 
                 // Print git marker with git-sign colors. Keep the marker column
                 // stable so file names do not shift when status appears.
+                // Rich uses a uniform dot (the color carries the status, and
+                // the name is tinted too); minimal keeps the legacy letters.
                 match git_status {
-                    Some(crate::git::GitFileStatus::Added) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.added))?;
-                        terminal_print!(self, "+ ");
-                    }
-                    Some(crate::git::GitFileStatus::Modified) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.modified))?;
-                        terminal_print!(self, "x ");
-                    }
-                    Some(crate::git::GitFileStatus::Deleted) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.deleted))?;
-                        terminal_print!(self, "- ");
-                    }
-                    Some(crate::git::GitFileStatus::Untracked) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.added))?;
-                        terminal_print!(self, "? ");
-                    }
-                    Some(crate::git::GitFileStatus::Conflicted) => {
-                        execute!(self.stdout, SetForegroundColor(theme.diagnostic.error))?;
-                        terminal_print!(self, "! ");
+                    Some(status) => {
+                        let (marker_color, marker) = match status {
+                            crate::git::GitFileStatus::Added => {
+                                (theme.git.added, if minimal { "+" } else { "●" })
+                            }
+                            crate::git::GitFileStatus::Modified => {
+                                (theme.git.modified, if minimal { "x" } else { "●" })
+                            }
+                            crate::git::GitFileStatus::Deleted => {
+                                (theme.git.deleted, if minimal { "-" } else { "●" })
+                            }
+                            crate::git::GitFileStatus::Untracked => {
+                                (theme.git.added, if minimal { "?" } else { "●" })
+                            }
+                            crate::git::GitFileStatus::Conflicted => (theme.diagnostic.error, "!"),
+                        };
+                        execute!(self.stdout, SetForegroundColor(marker_color))?;
+                        terminal_print!(self, "{} ", marker);
                     }
                     None => {
                         execute!(self.stdout, SetForegroundColor(name_color))?;
@@ -2671,10 +2723,14 @@ impl Terminal {
                 let name_display_len = name_display.chars().count();
                 terminal_print!(self, "{}", name_display);
 
-                // Fill any remaining space with background
-                let used_width = prefix_width + name_display_len;
+                // Fill remaining space, then the right-aligned rollup badge
+                let used_width = prefix_width + name_display_len + badge_cols;
                 if used_width < remaining_width {
                     terminal_print!(self, "{:width$}", "", width = remaining_width - used_width);
+                }
+                if let Some((text, badge_color)) = badge {
+                    execute!(self.stdout, SetForegroundColor(badge_color))?;
+                    terminal_print!(self, "{} ", text);
                 }
             } else {
                 // Empty line - use explorer background
@@ -11073,6 +11129,137 @@ mod tests {
             .render_finder(editor)
             .expect("finder render should succeed");
         output.into_string()
+    }
+
+    fn render_explorer_to_string(editor: &Editor) -> String {
+        crossterm::style::force_color_output(true);
+        let output = SharedOutput::default();
+        let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
+        terminal
+            .render_explorer(editor)
+            .expect("explorer render should succeed");
+        output.into_string()
+    }
+
+    fn explorer_test_editor() -> Editor {
+        let mut editor = Editor::default();
+        editor.set_size(120, 30);
+        editor.explorer.flat_view = vec![
+            crate::explorer::FlatNode {
+                path: PathBuf::from("/proj/src"),
+                name: "src".to_string(),
+                is_dir: true,
+                depth: 1,
+                is_expanded: true,
+            },
+            crate::explorer::FlatNode {
+                path: PathBuf::from("/proj/src/main.rs"),
+                name: "main.rs".to_string(),
+                is_dir: false,
+                depth: 2,
+                is_expanded: false,
+            },
+        ];
+        editor.explorer.selected = 1;
+        // rebuild_git_statuses_from clears everything when no root is set
+        editor.explorer.root = Some(PathBuf::from("/proj"));
+        let mut statuses = std::collections::HashMap::new();
+        statuses.insert(
+            PathBuf::from("/proj/src/main.rs"),
+            crate::git::GitFileStatus::Modified,
+        );
+        editor.explorer.rebuild_git_statuses_from(statuses);
+        editor
+    }
+
+    #[test]
+    fn explorer_rich_renders_bar_dot_marker_and_header_icon() {
+        let editor = explorer_test_editor();
+        let rendered = render_explorer_to_string(&editor);
+        assert!(rendered.contains('▌'), "selected row accent bar");
+        assert!(
+            rendered.contains("● "),
+            "modified file gets a dot marker; output={rendered:?}"
+        );
+        assert!(!rendered.contains("x "), "no legacy letter marker in rich");
+        assert!(
+            rendered.contains('\u{f07b}'),
+            "header shows the folder icon"
+        );
+    }
+
+    #[test]
+    fn explorer_minimal_matches_legacy_chrome() {
+        let mut editor = explorer_test_editor();
+        editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
+        let rendered = render_explorer_to_string(&editor);
+        assert!(rendered.contains("x "), "legacy modified marker");
+        assert!(!rendered.contains('▌'));
+        assert!(!rendered.contains('\u{f07b}'));
+    }
+
+    #[test]
+    fn explorer_shows_folder_diagnostic_rollup_badge() {
+        let mut editor = explorer_test_editor();
+        editor.set_diagnostics(
+            "file:///proj/src/main.rs".to_string(),
+            vec![crate::lsp::Diagnostic {
+                line: 0,
+                end_line: 0,
+                col_start: 0,
+                col_end: 1,
+                severity: crate::lsp::DiagnosticSeverity::Error,
+                message: "boom".to_string(),
+                source: None,
+                code: None,
+            }],
+        );
+        let rendered = render_explorer_to_string(&editor);
+        assert!(
+            rendered.contains("\u{f057} 1"),
+            "dir and file rows show the error rollup badge; output={rendered:?}"
+        );
+    }
+
+    #[test]
+    fn gutter_diagnostic_sign_follows_ui_style() {
+        let tmp = std::env::temp_dir().join(format!("nevi_gutter_style_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("gutter.rs");
+        std::fs::write(&path, "line one\nline two\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.open_file(path.clone()).expect("open file");
+        let uri = crate::lsp::path_to_uri(&path);
+        editor.set_diagnostics(
+            uri,
+            vec![crate::lsp::Diagnostic {
+                line: 0,
+                end_line: 0,
+                col_start: 0,
+                col_end: 4,
+                severity: crate::lsp::DiagnosticSeverity::Error,
+                message: "problem".to_string(),
+                source: None,
+                code: None,
+            }],
+        );
+
+        let rendered = render_editor_to_string(&editor);
+        assert!(
+            rendered.contains('\u{f057}'),
+            "rich gutter uses the NF error glyph; output={rendered:?}"
+        );
+
+        editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
+        let rendered = render_editor_to_string(&editor);
+        assert!(
+            rendered.contains('●'),
+            "minimal gutter keeps the legacy dot; output={rendered:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
     }
 
     fn measure_render(editor: &Editor) -> Duration {

--- a/src/ui_glyphs.rs
+++ b/src/ui_glyphs.rs
@@ -39,6 +39,13 @@ pub struct UiGlyphs {
     pub finder_selection_bar: &'static str,
     /// Prefix inside floating-window border titles.
     pub finder_title_icon: &'static str,
+    /// Buffer gutter diagnostic signs (error/warning/info/hint priority).
+    pub gutter_error: &'static str,
+    pub gutter_warn: &'static str,
+    pub gutter_info: &'static str,
+    pub gutter_hint: &'static str,
+    /// Icon before the project name in the explorer header.
+    pub explorer_header_icon: &'static str,
 }
 
 pub static RICH: UiGlyphs = UiGlyphs {
@@ -60,6 +67,11 @@ pub static RICH: UiGlyphs = UiGlyphs {
     finder_prompt: " \u{f002} ",
     finder_selection_bar: "▌",
     finder_title_icon: "\u{f002} ",
+    gutter_error: "\u{f057}",
+    gutter_warn: "\u{f071}",
+    gutter_info: "\u{f05a}",
+    gutter_hint: "\u{f0eb}",
+    explorer_header_icon: "\u{f07b} ",
 };
 
 pub static MINIMAL: UiGlyphs = UiGlyphs {
@@ -81,6 +93,11 @@ pub static MINIMAL: UiGlyphs = UiGlyphs {
     finder_prompt: " > ",
     finder_selection_bar: "",
     finder_title_icon: "",
+    gutter_error: "●",
+    gutter_warn: "▲",
+    gutter_info: "■",
+    gutter_hint: "○",
+    explorer_header_icon: "",
 };
 
 /// Devicon glyph for the finder's two-char file-type chips. The chip
@@ -220,6 +237,11 @@ mod tests {
             g.finder_prompt,
             g.finder_selection_bar,
             g.finder_title_icon,
+            g.gutter_error,
+            g.gutter_warn,
+            g.gutter_info,
+            g.gutter_hint,
+            g.explorer_header_icon,
         ];
         v.extend(g.lsp_busy_frames);
         v
@@ -238,6 +260,15 @@ mod tests {
             unknown, "\u{f15b}",
             "unknown chips fall back to a generic file glyph"
         );
+    }
+
+    #[test]
+    fn minimal_gutter_signs_match_legacy_chars() {
+        assert_eq!(MINIMAL.gutter_error, "●");
+        assert_eq!(MINIMAL.gutter_warn, "▲");
+        assert_eq!(MINIMAL.gutter_info, "■");
+        assert_eq!(MINIMAL.gutter_hint, "○");
+        assert!(MINIMAL.explorer_header_icon.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Phase 3 of the UI polish work (stacks on the finder PR): the explorer and the buffer gutter follow the `[ui] style` flag.

**Rich (default):**
- `▌` selection accent bar — the relative-number jump column is unchanged and sits right next to it (the selected row's number is always 0, so the bar + 2-digit number fit the same 4 columns)
- Git status tints the filename itself (modified yellow, added/untracked green, deleted red), with a uniform colored `●` marker replacing the `+ x - ?` letters (`!` stays for conflicts)
- Folder icon in the explorer header
- Diagnostic rollup badges: files with LSP errors/warnings show ` N` right-aligned, and every ancestor folder aggregates the counts — a collapsed directory tells you something inside is broken
- Buffer gutter diagnostic signs become ``/``/``/`` (error/warn/info/hint)

**Minimal (`[ui] style = "minimal"`):** today's explorer and gutter,
untouched — letter markers, `● ▲ ■ ○` signs, no bar, no header icon. Pinned by tests. Indent guides already existed and are unchanged.

## Implementation notes

- New `Editor.diag_rollup` map (`path → (errors, warnings)`), rebuilt in `set_diagnostics` — event-driven and bounded by files-with-diagnostics × path depth, so renders never aggregate (render-reads-cache-only rule).
- Explorer icons now route through `resolved_ui_style()` instead of reading `use_nerd_font_icons` directly. The legacy flag still works via the resolution fallback; the one behavior change is that an explicit `style = "rich"` wins over `use_nerd_font_icons = false`.
- Both gutter sign-column render sites (wrapped-segment and plain paths) share the same glyph fields; git bars `▎`/`▁` are untouched.
- Rollup badges are dropped per-row when the panel is too narrow, and the name truncation budget accounts for the badge width.