### PR TITLE
feat: vim-style statusline ruler and distinct SEARCH badge color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Nevi 0.3.0 brings further improvements.
 
 ### Highlights
 
-- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, and an event-driven LSP activity indicator. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
+- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, an event-driven LSP activity indicator, a Vim-style `Top`/`Bot`/percent ruler, and a distinct SEARCH badge color. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
 - The finder gets the rich treatment too: rounded corners, icon border titles, per-filetype devicons in results and the preview title, and a selection accent bar. `[ui] style = "minimal"` keeps the previous finder look (square corners, two-letter file chips) unchanged.
 - The explorer follows: selection accent bar, git status tinting file names, dot git markers, a folder icon in the header, and diagnostic rollup badges on files and folders (a folder containing errors shows the count without expanding it). Buffer gutter diagnostic signs use Nerd Font glyphs in rich mode. Minimal mode keeps the previous explorer letters and `● ▲ ■ ○` gutter signs; the explorer's relative-number column is unchanged in both modes.
 - `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).

--- a/src/statusline.rs
+++ b/src/statusline.rs
@@ -52,8 +52,42 @@ pub struct StatusContext<'a> {
     /// 1-based for display.
     pub line: usize,
     pub col: usize,
-    /// 0..=100 scroll position.
-    pub percent: usize,
+    /// Vim-style ruler position (All/Top/Bot/percent through the file).
+    pub position: ScrollPosition,
+}
+
+/// Vim ruler semantics: All when the whole file fits, Top/Bot at the
+/// edges, percent-scrolled otherwise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScrollPosition {
+    All,
+    Top,
+    Bot,
+    Percent(usize),
+}
+
+impl ScrollPosition {
+    /// Compute from viewport state, mirroring Vim's ruler.
+    pub fn from_viewport(offset: usize, visible_rows: usize, total_lines: usize) -> Self {
+        if total_lines <= visible_rows {
+            ScrollPosition::All
+        } else if offset == 0 {
+            ScrollPosition::Top
+        } else if offset + visible_rows >= total_lines {
+            ScrollPosition::Bot
+        } else {
+            ScrollPosition::Percent((offset * 100) / (total_lines - visible_rows))
+        }
+    }
+
+    fn label(self) -> String {
+        match self {
+            ScrollPosition::All => "All".to_string(),
+            ScrollPosition::Top => "Top".to_string(),
+            ScrollPosition::Bot => "Bot".to_string(),
+            ScrollPosition::Percent(p) => format!("{}%", p),
+        }
+    }
 }
 
 fn mode_color(mode: Mode, theme: &Theme) -> Color {
@@ -62,6 +96,8 @@ fn mode_color(mode: Mode, theme: &Theme) -> Color {
         Mode::Insert => theme.ui.statusline_mode_insert,
         Mode::Visual | Mode::VisualLine | Mode::VisualBlock => theme.ui.statusline_mode_visual,
         Mode::Replace => theme.ui.statusline_mode_replace,
+        // Search reads as its own mode, like INSERT-green does
+        Mode::Search => theme.ui.statusline_mode_command,
         _ => theme.ui.statusline_mode_normal,
     }
 }
@@ -218,7 +254,7 @@ fn build_rich(ctx: &StatusContext, glyphs: &UiGlyphs, theme: &Theme) -> StatusLi
     right.push(seg(format!(" {}{} ", ctx.lang, lsp), base_fg, section_bg));
     right.push(seg(glyphs.sep_right.to_string(), mode_bg, section_bg));
     right.push(seg_bold(
-        format!(" {}:{}  {}% ", ctx.line, ctx.col, ctx.percent),
+        format!(" {}:{}  {} ", ctx.line, ctx.col, ctx.position.label()),
         base_bg,
         mode_bg,
     ));
@@ -324,7 +360,7 @@ mod tests {
             lsp_spinner: "",
             line: 128,
             col: 14,
-            percent: 93,
+            position: ScrollPosition::Percent(93),
         }
     }
 
@@ -393,6 +429,39 @@ mod tests {
         let all = all_text(&content);
         assert!(all.contains("[3d]"));
         assert!(all.contains("@q"));
+    }
+
+    #[test]
+    fn search_mode_gets_command_color_badge() {
+        let theme = theme();
+        let mut ctx = ctx_base();
+        ctx.mode = Mode::Search;
+        let content = build_status_segments(&ctx, &RICH, &theme, false);
+        assert!(content.left[0].text.contains("SEARCH"));
+        assert_eq!(
+            content.left[0].bg, theme.ui.statusline_mode_command,
+            "SEARCH badge uses the command color, not normal-blue"
+        );
+    }
+
+    #[test]
+    fn scroll_position_renders_vim_style_ruler_tokens() {
+        for (pos, expect) in [
+            (ScrollPosition::All, "All"),
+            (ScrollPosition::Top, "Top"),
+            (ScrollPosition::Bot, "Bot"),
+            (ScrollPosition::Percent(52), "52%"),
+        ] {
+            let mut ctx = ctx_base();
+            ctx.position = pos;
+            let content = build_status_segments(&ctx, &RICH, &theme(), false);
+            let last = content.right.last().expect("position segment");
+            assert!(
+                last.text.contains(expect),
+                "expected {expect:?} in {:?}",
+                last.text
+            );
+        }
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -3203,7 +3203,11 @@ impl Terminal {
             lsp_spinner: editor.lsp_spinner_frame(),
             line: editor.cursor.line + 1,
             col: editor.cursor.col + 1,
-            percent: ((editor.cursor.line + 1) * 100 / total_lines).min(100),
+            position: crate::statusline::ScrollPosition::from_viewport(
+                editor.viewport_offset,
+                editor.text_rows(),
+                total_lines,
+            ),
         };
         let content = crate::statusline::build_status_segments(&ctx, glyphs, theme, minimal);
 


### PR DESCRIPTION
- Right-end segment shows All/Top/Bot/percent computed from the viewport (Vim ruler semantics) instead of a cursor-line percentage that read 0% near the top of large files
- New ScrollPosition enum in the pure statusline module, unit-tested without a terminal
- SEARCH mode badge uses the themed command color instead of borrowing normal-blue; no new theme keys needed