### PR TITLE
chore: prepare v0.3.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 .nvimlog
+.DS_Store
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,72 @@
 # Changelog
 
-## 0.3.0 - UNRELEASED
+## 0.3.0 - 2026-08-25
 
-Nevi 0.3.0 brings further improvements.
+Nevi 0.3.0 rebuilds the statusline, finder, and explorer, closes a long list of
+Vim compatibility gaps, and adds PHP and shell language support.
 
-### Highlights
+Existing config files keep working. The one thing to know before upgrading is
+that the new interface is on by default. Set `[ui] style = "minimal"` in
+config.toml if you want the 0.2.0 appearance back.
 
-- New segmented statusline: mode-colored powerline segments, git branch and diff stats, diagnostic counts, an event-driven LSP activity indicator, a Vim-style `Top`/`Bot`/percent ruler, and a distinct SEARCH badge color. Set `[ui] style = "minimal"` in config.toml for a plain-ASCII look with the same layout (automatic if you had `use_nerd_font_icons = false`).
-- The finder gets the rich treatment too: rounded corners, icon border titles, per-filetype devicons in results and the preview title, and a selection accent bar. `[ui] style = "minimal"` keeps the previous finder look (square corners, two-letter file chips) unchanged.
-- The explorer follows: selection accent bar, git status tinting file names, dot git markers, a folder icon in the header, and diagnostic rollup badges on files and folders (a folder containing errors shows the count without expanding it). Buffer gutter diagnostic signs use Nerd Font glyphs in rich mode. Minimal mode keeps the previous explorer letters and `● ▲ ■ ○` gutter signs; the explorer's relative-number column is unchanged in both modes.
-- `:checkhealth` now reports the active UI mode, a Nerd Font glyph probe, and the raw LSP status string (which no longer renders in the statusline).
-- Statusline width math is now Unicode-aware, fixing right-side misalignment with double-width (e.g. CJK) filenames.
-- Themes gain an optional `[ui.statusline] section_bg` key for the mid statusline segments; it falls back to `cursor_line`, so existing themes need no changes.
-- `:Format` now runs the external formatter from `languages.toml` when one is configured for the current language, and falls back to LSP otherwise.
-- Added Vim motions `g_`, `|`, `gM`, `gm`, `go`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
-- `j`/`k` now keep the preferred column (Vim `curswant`) when moving across short or blank lines, and `$` makes vertical motion stick to line ends.
-- Added Bash/shell tree-sitter highlighting for `.sh`/`.bash`/`.zsh` files, common rc/profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, …), and shebang detection for extensionless scripts.
-- Added `[lsp.servers.shell]` with `bash-language-server` (same config shape as Go/Ruby).
-- Fixed `J`/`gJ` on the last line silently deleting the file's trailing newline; they are now a no-op like Vim.
-- Files without a final newline now gain one on load and save (Neovim's `fixendofline` default), fixing the cursor landing on a phantom line when opening a line at end of file.
+### Interface
+
+- Rebuilt the statusline from mode-colored segments. It now shows the git branch and diff stats, diagnostic counts, an LSP activity indicator, and a Vim-style `Top` / `Bot` / percent ruler. SEARCH mode has its own badge color.
+- Gave the finder rounded corners, icon border titles, per-filetype devicons in both the result list and the preview title, and an accent bar on the selected row.
+- Gave the explorer the same accent bar, tinted file names by git status, dot markers on changed files, and a folder icon in the header. Files and folders now carry diagnostic badges, so a folder containing an error reports the count without being expanded.
+- Buffer gutter diagnostic signs use Nerd Font glyphs.
+- Added `[ui] style`, which takes `rich` (the default) or `minimal`. Minimal keeps the 0.2.0 appearance: plain ASCII statusline, square finder corners, two-letter file chips, explorer letters, and `● ▲ ■ ○` gutter signs. Configs that already set `use_nerd_font_icons = false` get minimal automatically.
+- Added an optional `[ui.statusline] section_bg` theme key for the middle statusline segments. It falls back to `cursor_line`, so existing themes need no changes.
+- Added a bundled `github-light` theme.
+- Moved the raw LSP status string out of the statusline. `:checkhealth` reports it instead, along with the active UI mode and a Nerd Font glyph probe.
+- Fixed statusline width math to account for double-width characters. Filenames containing CJK text were pushing the right-hand segments out of alignment.
+- Fixed the hover, completion, diagnostic, and finder popups ignoring theme colors, which left them unreadable on light themes.
+- Fixed the floating terminal drawing partial frames.
+
+### Vim Compatibility
+
+- Added the motions `g_`, `|`, `gM`, `gm`, `go`, `[[`, `]]`, `][`, `[]`, `[{`, `]}`, `[(`, and `])`.
+- `j` and `k` now keep the preferred column across short and blank lines, matching Vim's `curswant`. After `$`, vertical motion sticks to line ends.
+- Fixed `J` and `gJ` on the last line quietly deleting the file's trailing newline. Both are now a no-op, as in Vim.
+- Files without a final newline gain one on load and on save, matching Neovim's `fixendofline` default. This also fixes the cursor landing on a phantom line when opening a line at the end of a file.
+- Fixed `r`, counted `r`, and `R` replace mode to match Vim, including multibyte characters, line boundaries, and undo and redo of counted replaces.
+- Fixed counted `o` and `O`, `I` and `A` insert positioning, the editing operators, and linewise edits in new files to match Neovim.
+- Fixed page scrolling and the screen position motions `H`, `M`, and `L`. They were ignoring the active pane's row count and mispacking the last screen of a wrapped buffer.
+
+### Languages And Tooling
+
+- Added PHP support.
+- Added shell support: tree-sitter highlighting for `.sh`, `.bash`, and `.zsh`, the common rc and profile names (`.bashrc`, `.bash_profile`, `.zshrc`, `PKGBUILD`, and similar), and shebang detection for scripts without an extension.
+- Added `[lsp.servers.shell]` for `bash-language-server`, using the same config shape as Go and Ruby.
+- `:Format` now runs the external formatter configured in `languages.toml` when the current language has one, and falls back to the LSP otherwise.
+- Added `:Macros` and `:MacroEdit` for reviewing and editing recorded macros.
+- Fixed clipboard support on Wayland.
+
+### Parity And Testing
+
+- Added `PARITY.md`, a scoreboard generated from the same inventories the test suite enforces, so it cannot drift from what is actually verified. It currently reports 329 keybinds implemented and 39 planned.
+- Added a keybind coverage inventory mapping every default keybind to the test that protects it, plus a check that the documented keybinds and the inventory agree.
+- Added a key-sequence fuzz harness and a guard against pane state falling out of sync.
+- Extended Vim oracle coverage to WORD motions, find-char motions, matching brackets, and the display-line motion family. CI now pins the Neovim version used for parity checks.
+
+### Performance
+
+- Shebang detection reads at most the first 256 characters of the first line instead of copying the whole line, which matters on minified and generated files.
+
+### Contributors
+
+Thanks to @krawitzzZ for shell highlighting and LSP support, the external
+formatter in `:Format`, Wayland clipboard support, and the first-line
+allocation fix.
+
+### Install And Upgrade
+
+Homebrew users can upgrade after this release with:
+
+```bash
+brew update
+brew upgrade nevi
+```
 
 ## 0.2.0 - 2026-07-07
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "nevi"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "alacritty_terminal",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nevi"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.85"
 description = "A Neovim-like terminal editor in Rust"


### PR DESCRIPTION
## Summary
- bump Nevi from 0.2.0 to 0.3.0
- rewrite the 0.3.0 changelog section to cover the full cycle since v0.2.0, not just the August UI work
- credit @krawitzzZ for the four contributions in this release
- ignore .DS_Store and log files

## Notes
The 0.3.0 section previously listed only the interface polish from the last
week of August. It now also covers PHP support, shell highlighting and LSP,
the macro lens, the github-light theme, PARITY.md, Wayland clipboard, and
the July Vim parity fixes.

Two changes worth calling out for anyone upgrading:

- the rich interface is the default. `[ui] style = "minimal"` restores the
  0.2.0 appearance.
- files without a final newline gain one on load and on save, matching
  Neovim's `fixendofline` default. This changes bytes on disk.

## Verification
Latest master CI was successful before branching (run for #270).

Run on this branch:
- cargo fmt --all -- --check
- cargo test --quiet (872 passed, 0 failed)
- cargo test render_frame_budget -- --ignored --nocapture
- NEVI_VIM_ORACLE=1 cargo test vim_oracle_smoke -- --ignored --nocapture (nvim 0.11.3)
- cargo build --release
- ./target/release/nevi --version reports nevi 0.3.0