### PR TITLE
feat: add shada-lite session state persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Unified the remaining floating windows under the rich chrome. The leader/which-key popup and the command suggestions/history popup are now rounded-corner boxes with icon border titles and right-aligned key hints, and the command popup marks the selected row with the finder's accent bar instead of `>`. The floating terminal's corners now come from the shared glyph table (square in minimal mode, matching the finder) and its title carries a terminal icon. Minimal mode keeps the previous flat headers throughout.
 
+### Vim Compatibility
+
+- Macros, named and unnamed registers, global marks, and search history now survive restarts, like Vim's shada. State is stored in `~/.local/state/nevi/state.json`, following nvim's `stdpath('state')` convention, and `$XDG_STATE_HOME` is respected. Macros are saved as readable key notation, so the file can be inspected or hand-edited, and a corrupt file never blocks startup. The frecency database and command history moved to the same directory; data in the old location is found automatically and migrates on its next save.
+
 ## 0.3.0 - 2026-08-25
 
 Nevi 0.3.0 rebuilds the statusline, finder, and explorer, closes a long list of

--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ nevi file1.rs file2.rs
 - `:ToolInstall` / `:LspInstall` - Open missing LSP/tool install guidance in a read-only `[tool-installer]` buffer
 - `:FlightRecorder` / `:WhySlow` - Open recent in-memory timing report in a read-only `[flight-recorder]` buffer
 - `:Macros` / `:MacroEdit {a-z}` - View recorded macros as readable notation, or edit one as text and `:w` it back into its register
+- Session persistence - macros, registers, global marks, and search history survive restarts (like vim's shada), stored in `~/.local/state/nevi/state.json` (respects `$XDG_STATE_HOME`, same convention as nvim's `stdpath('state')`)
 - `:ConfigOpen` / `:config` - Open your user config file
 - `:ConfigDefaults` - View the latest built-in default config in a read-only `[config-defaults]` buffer
 - `:MarkdownPreview` - Open rendered Markdown reader for `.md` files (`j/k`, `Ctrl-d/u`, `g/G`, `q`)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -906,11 +906,15 @@ fn longest_common_command_prefix(suggestions: &[CommandSuggestion]) -> String {
     prefix
 }
 
+/// Read path for command history (XDG state dir, with a fallback to the
+/// legacy pre-0.4.0 location). Saves go through `command_history_save_path`
+/// so the data migrates to the XDG home on its next write.
 fn command_history_path() -> PathBuf {
-    dirs::config_dir()
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join("nevi")
-        .join("command_history.txt")
+    crate::shada::state_file("command_history.txt")
+}
+
+fn command_history_save_path() -> PathBuf {
+    crate::shada::state_dir().join("command_history.txt")
 }
 
 /// Parse a command string into a Command
@@ -1884,7 +1888,7 @@ impl CommandLine {
     }
 
     fn save_history(&self) {
-        let path = command_history_path();
+        let path = command_history_save_path();
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1927,6 +1927,73 @@ impl Editor {
         Ok(message)
     }
 
+    /// Gather persistable session state (macros, registers, global marks,
+    /// search history) for the shada-lite file. Unencodable macros and
+    /// clipboard-backed registers are session-only by design.
+    pub fn export_shada(&self) -> crate::shada::ShadaState {
+        let mut state = crate::shada::ShadaState {
+            version: crate::shada::FORMAT_VERSION,
+            ..Default::default()
+        };
+
+        for (register, keys) in self.macros.recorded() {
+            if let Ok(notation) = crate::input::key_notation::encode_key_sequence(keys) {
+                state.macros.insert(register, notation);
+            }
+        }
+
+        for register in 'a'..='z' {
+            if let Some(content) = self.registers.get(Some(register)) {
+                state.registers.insert(register, content.to_shada_entry());
+            }
+        }
+        state.unnamed_register = self
+            .registers
+            .get(None)
+            .map(RegisterContent::to_shada_entry);
+
+        for (name, mark) in self.marks.get_global_marks() {
+            if let Some(path) = &mark.path {
+                state.global_marks.insert(
+                    name,
+                    crate::shada::MarkEntry {
+                        path: path.clone(),
+                        line: mark.line,
+                        col: mark.col,
+                    },
+                );
+            }
+        }
+
+        state.search_history = self.search.history.clone();
+        state
+    }
+
+    /// Restore a previous session's shada state. Entries that no longer parse
+    /// (hand-edited macros) are skipped; everything else loads independently.
+    pub fn apply_shada(&mut self, state: crate::shada::ShadaState) {
+        for (register, notation) in state.macros {
+            if let Ok(keys) = crate::input::key_notation::parse_key_sequence(&notation) {
+                self.macros.set_macro(register, keys);
+            }
+        }
+
+        for (register, entry) in state.registers {
+            self.registers
+                .set(Some(register), RegisterContent::from_shada_entry(entry));
+        }
+        if let Some(entry) = state.unnamed_register {
+            self.registers
+                .set(None, RegisterContent::from_shada_entry(entry));
+        }
+
+        for (name, mark) in state.global_marks {
+            self.marks.set_global(name, mark.path, mark.line, mark.col);
+        }
+
+        self.search.history = state.search_history;
+    }
+
     /// Build a project-wide replace preview and open it as a read-only buffer.
     pub fn preview_project_replace(
         &mut self,
@@ -11404,6 +11471,7 @@ mod tests {
     mod open_line;
     mod replace;
     mod screen_position;
+    mod shada;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};
     use crate::input::Motion;

--- a/src/editor/register.rs
+++ b/src/editor/register.rs
@@ -31,6 +31,21 @@ impl RegisterContent {
     pub fn is_linewise(&self) -> bool {
         matches!(self, RegisterContent::Lines(_))
     }
+
+    pub fn to_shada_entry(&self) -> crate::shada::RegisterEntry {
+        crate::shada::RegisterEntry {
+            text: self.as_str().to_string(),
+            linewise: self.is_linewise(),
+        }
+    }
+
+    pub fn from_shada_entry(entry: crate::shada::RegisterEntry) -> Self {
+        if entry.linewise {
+            RegisterContent::Lines(entry.text)
+        } else {
+            RegisterContent::Chars(entry.text)
+        }
+    }
 }
 
 fn clipboard_text_for_content(content: &RegisterContent) -> String {

--- a/src/editor/tests/shada.rs
+++ b/src/editor/tests/shada.rs
@@ -1,0 +1,129 @@
+use crate::editor::{Editor, RegisterContent};
+use crate::input::key_notation::parse_key_sequence;
+use crate::shada::{MarkEntry, RegisterEntry, ShadaState};
+use std::path::PathBuf;
+
+fn populated_editor() -> Editor {
+    let mut editor = Editor::default();
+    editor
+        .macros
+        .set_macro('a', parse_key_sequence("0f,ci\"hi<Esc>").unwrap());
+    editor.registers.set(
+        Some('r'),
+        RegisterContent::Lines("a full line\n".to_string()),
+    );
+    editor
+        .registers
+        .set(None, RegisterContent::Chars("word".to_string()));
+    editor
+        .marks
+        .set_global('A', PathBuf::from("/tmp/lib.rs"), 12, 4);
+    editor.search.history = vec!["needle".to_string(), "haystack".to_string()];
+    editor
+}
+
+#[test]
+fn shada_roundtrips_through_a_fresh_editor() {
+    let exported = populated_editor().export_shada();
+
+    let mut restored = Editor::default();
+    restored.apply_shada(exported);
+
+    assert_eq!(
+        restored.macros.get_macro('a'),
+        Some(&parse_key_sequence("0f,ci\"hi<Esc>").unwrap()),
+        "macros survive via notation"
+    );
+
+    let register = restored.registers.get(Some('r')).expect("register r");
+    assert_eq!(register.as_str(), "a full line\n");
+    assert!(register.is_linewise(), "linewise-ness must survive");
+    assert_eq!(
+        restored.registers.get(None).map(|c| c.as_str()),
+        Some("word"),
+        "unnamed register survives"
+    );
+
+    let mark = restored.marks.get_global('A').expect("global mark A");
+    assert_eq!(
+        mark.path.as_deref(),
+        Some(std::path::Path::new("/tmp/lib.rs"))
+    );
+    assert_eq!((mark.line, mark.col), (12, 4));
+
+    assert_eq!(
+        restored.search.history,
+        vec!["needle".to_string(), "haystack".to_string()]
+    );
+}
+
+#[test]
+fn unencodable_macro_stays_session_only_without_losing_others() {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    let mut editor = populated_editor();
+    editor
+        .macros
+        .set_macro('q', vec![KeyEvent::new(KeyCode::F(5), KeyModifiers::NONE)]);
+
+    let exported = editor.export_shada();
+
+    assert!(!exported.macros.contains_key(&'q'));
+    assert!(exported.macros.contains_key(&'a'));
+}
+
+#[test]
+fn apply_skips_unparseable_macro_notation() {
+    let mut state = ShadaState::default();
+    state.macros.insert('a', "d<Esc".to_string());
+    state.macros.insert('b', "dw".to_string());
+
+    let mut editor = Editor::default();
+    editor.apply_shada(state);
+
+    assert_eq!(editor.macros.get_macro('a'), None);
+    assert_eq!(
+        editor.macros.get_macro('b'),
+        Some(&parse_key_sequence("dw").unwrap())
+    );
+}
+
+#[test]
+fn applied_registers_are_usable_and_marks_jumpable() {
+    let mut state = ShadaState::default();
+    state.registers.insert(
+        'x',
+        RegisterEntry {
+            text: "restored".to_string(),
+            linewise: false,
+        },
+    );
+    state.global_marks.insert(
+        'B',
+        MarkEntry {
+            path: PathBuf::from("/tmp/other.rs"),
+            line: 3,
+            col: 0,
+        },
+    );
+
+    let mut editor = Editor::default();
+    editor.apply_shada(state);
+
+    assert_eq!(
+        editor.registers.get(Some('x')).map(|c| c.as_str()),
+        Some("restored")
+    );
+    assert!(editor.marks.get_global('B').is_some());
+}
+
+#[test]
+fn export_after_apply_is_stable() {
+    let first = populated_editor().export_shada();
+
+    let mut editor = Editor::default();
+    editor.apply_shada(first.clone());
+    let second = editor.export_shada();
+
+    assert_eq!(first, second, "load→save must not mutate state");
+}

--- a/src/frecency/mod.rs
+++ b/src/frecency/mod.rs
@@ -39,9 +39,11 @@ impl FrecencyDb {
         Self::default()
     }
 
-    /// Save frecency database to file
+    /// Save frecency database to file. Always writes the XDG state path —
+    /// paired with the legacy read-fallback in `db_path`, this migrates
+    /// pre-0.4.0 data on its first save.
     pub fn save(&self) {
-        let path = Self::db_path();
+        let path = crate::shada::state_dir().join("frecency.json");
         if let Some(parent) = path.parent() {
             let _ = fs::create_dir_all(parent);
         }
@@ -50,12 +52,10 @@ impl FrecencyDb {
         }
     }
 
-    /// Get the path to the frecency database file
+    /// Read path for the frecency database (XDG state dir, with a fallback
+    /// to the legacy pre-0.4.0 location).
     fn db_path() -> PathBuf {
-        dirs::config_dir()
-            .unwrap_or_else(|| PathBuf::from("."))
-            .join("nevi")
-            .join("frecency.json")
+        crate::shada::state_file("frecency.json")
     }
 
     /// Record that a completion item was selected

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod parity_report;
 pub mod perf;
 pub mod project_replace;
 pub mod render_damage;
+pub mod shada;
 pub mod syntax;
 pub mod terminal;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,10 @@ fn main() -> anyhow::Result<()> {
     // Initialize editor with settings
     let mut editor = Editor::new(settings);
 
+    // Restore persisted session state (macros, registers, marks, search
+    // history). A missing or corrupt file loads as empty state.
+    editor.apply_shada(nevi::shada::load());
+
     // Enable finder profiling when profiling is enabled.
     if profile_enabled {
         nevi::terminal::FINDER_PROFILE_ENABLED.store(true, std::sync::atomic::Ordering::Relaxed);
@@ -2191,6 +2195,9 @@ fn main() -> anyhow::Result<()> {
             let _ = stats.write_summary(file);
         }
     }
+
+    // Persist session state; losing it should never block shutdown.
+    let _ = nevi::shada::save(&editor.export_shada());
 
     // Shutdown all LSP servers gracefully
     if let Some(mut mlsp) = multi_lsp {

--- a/src/shada.rs
+++ b/src/shada.rs
@@ -1,0 +1,299 @@
+//! Shada-lite: persist small editor state across sessions — vim's
+//! shada/viminfo in miniature. Covers macros, named + unnamed registers,
+//! global marks, and search history. Command history keeps its own file
+//! (`command_history.txt`) but shares this module's state-dir resolution.
+//!
+//! Macros are stored as vim notation (the macro-lens codec), so the state
+//! file remains human-readable and a hand-edited entry that fails to parse is
+//! skipped rather than poisoning the rest. Loading never fails: a missing or
+//! corrupt file yields empty state.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::io;
+use std::path::{Path, PathBuf};
+
+pub const FORMAT_VERSION: u32 = 1;
+
+/// Matches `MAX_SEARCH_HISTORY_ENTRIES` in the editor.
+const MAX_HISTORY_ENTRIES: usize = 100;
+/// Registers above this size are session-only (vim's shada caps these too).
+const MAX_REGISTER_TEXT_CHARS: usize = 100_000;
+
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ShadaState {
+    #[serde(default)]
+    pub version: u32,
+    /// Register -> vim notation, e.g. "a" -> "0f,ci\"hi<Esc>".
+    #[serde(default)]
+    pub macros: BTreeMap<char, String>,
+    #[serde(default)]
+    pub registers: BTreeMap<char, RegisterEntry>,
+    #[serde(default)]
+    pub unnamed_register: Option<RegisterEntry>,
+    #[serde(default)]
+    pub global_marks: BTreeMap<char, MarkEntry>,
+    #[serde(default)]
+    pub search_history: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RegisterEntry {
+    pub text: String,
+    pub linewise: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MarkEntry {
+    pub path: PathBuf,
+    pub line: usize,
+    pub col: usize,
+}
+
+/// Machine-written state lives in the XDG state dir on every platform,
+/// matching nvim's `stdpath('state')`: `$XDG_STATE_HOME/nevi`, else
+/// `~/.local/state/nevi`. Deliberately not `dirs::config_dir()` — on macOS
+/// that is `~/Library/Application Support`, and terminal editors follow XDG
+/// everywhere (same reasoning as the hardcoded `~/.config` in the config
+/// loader).
+pub fn state_dir() -> PathBuf {
+    std::env::var_os("XDG_STATE_HOME")
+        .map(PathBuf::from)
+        // Per the XDG spec, a relative $XDG_STATE_HOME must be ignored.
+        .filter(|p| p.is_absolute())
+        .or_else(|| dirs::home_dir().map(|h| h.join(".local").join("state")))
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("nevi")
+}
+
+/// Read location for a state file: the XDG path, falling back to the legacy
+/// `dirs::config_dir()/nevi` location where nevi <= 0.3.0 wrote
+/// `frecency.json` and `command_history.txt`. Writes must use `state_dir()`
+/// so data migrates to the XDG home on its next save; the legacy copy is
+/// left behind, inert.
+pub fn state_file(name: &str) -> PathBuf {
+    let legacy = dirs::config_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("nevi")
+        .join(name);
+    resolve_state_file(state_dir().join(name), legacy)
+}
+
+fn resolve_state_file(new: PathBuf, legacy: PathBuf) -> PathBuf {
+    if !new.exists() && legacy.exists() {
+        legacy
+    } else {
+        new
+    }
+}
+
+/// Global, like vim's shada — registers and macros aren't project-scoped.
+/// No legacy fallback: `state.json` never shipped at the old location.
+pub fn state_file_path() -> PathBuf {
+    state_dir().join("state.json")
+}
+
+pub fn load() -> ShadaState {
+    load_from(&state_file_path())
+}
+
+/// Missing or corrupt state must never block startup.
+pub fn load_from(path: &Path) -> ShadaState {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return ShadaState::default();
+    };
+    let mut state: ShadaState = serde_json::from_str(&contents).unwrap_or_default();
+    enforce_caps(&mut state);
+    state
+}
+
+pub fn save(state: &ShadaState) -> io::Result<()> {
+    save_to(&state_file_path(), state)
+}
+
+pub fn save_to(path: &Path, state: &ShadaState) -> io::Result<()> {
+    let mut capped = state.clone();
+    capped.version = FORMAT_VERSION;
+    enforce_caps(&mut capped);
+
+    let json = serde_json::to_string_pretty(&capped)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    // Atomic replace so a crash mid-write can't corrupt existing state.
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, json)?;
+    std::fs::rename(&tmp, path)
+}
+
+/// Applied on both save and load: caps hold even for hand-edited files.
+fn enforce_caps(state: &mut ShadaState) {
+    state
+        .registers
+        .retain(|name, entry| name.is_ascii_lowercase() && fits_register_cap(entry));
+    if let Some(entry) = &state.unnamed_register {
+        if !fits_register_cap(entry) {
+            state.unnamed_register = None;
+        }
+    }
+    state.macros.retain(|name, _| name.is_ascii_lowercase());
+    state
+        .global_marks
+        .retain(|name, _| name.is_ascii_uppercase());
+    if state.search_history.len() > MAX_HISTORY_ENTRIES {
+        let extra = state.search_history.len() - MAX_HISTORY_ENTRIES;
+        state.search_history.drain(0..extra);
+    }
+}
+
+fn fits_register_cap(entry: &RegisterEntry) -> bool {
+    entry.text.chars().count() <= MAX_REGISTER_TEXT_CHARS
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        FORMAT_VERSION, MAX_HISTORY_ENTRIES, MAX_REGISTER_TEXT_CHARS, MarkEntry, RegisterEntry,
+        ShadaState, load_from, resolve_state_file, save_to,
+    };
+    use std::path::PathBuf;
+
+    fn temp_state_path(tag: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "nevi_shada_{tag}_{}_{}.json",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
+    #[test]
+    fn state_file_resolution_prefers_new_then_falls_back_to_legacy() {
+        let new = temp_state_path("resolve_new");
+        let legacy = temp_state_path("resolve_legacy");
+
+        // Neither exists: resolve to the new path (fresh install).
+        assert_eq!(resolve_state_file(new.clone(), legacy.clone()), new);
+
+        // Only the legacy file exists: read from it (pre-0.4.0 install).
+        std::fs::write(&legacy, "{}").unwrap();
+        assert_eq!(resolve_state_file(new.clone(), legacy.clone()), legacy);
+
+        // Both exist: the new path wins (migration already happened).
+        std::fs::write(&new, "{}").unwrap();
+        assert_eq!(resolve_state_file(new.clone(), legacy.clone()), new);
+
+        let _ = std::fs::remove_file(&new);
+        let _ = std::fs::remove_file(&legacy);
+    }
+
+    fn sample_state() -> ShadaState {
+        let mut state = ShadaState::default();
+        state.macros.insert('a', "0f,ci\"hi<Esc>".to_string());
+        state.registers.insert(
+            'r',
+            RegisterEntry {
+                text: "yanked line\n".to_string(),
+                linewise: true,
+            },
+        );
+        state.unnamed_register = Some(RegisterEntry {
+            text: "word".to_string(),
+            linewise: false,
+        });
+        state.global_marks.insert(
+            'A',
+            MarkEntry {
+                path: PathBuf::from("/tmp/somewhere.rs"),
+                line: 41,
+                col: 3,
+            },
+        );
+        state.search_history = vec!["foo".to_string(), "bar".to_string()];
+        state
+    }
+
+    #[test]
+    fn state_roundtrips_through_disk() {
+        let path = temp_state_path("roundtrip");
+        let state = sample_state();
+
+        save_to(&path, &state).expect("save");
+        let loaded = load_from(&path);
+
+        assert_eq!(loaded.version, FORMAT_VERSION);
+        assert_eq!(loaded.macros, state.macros);
+        assert_eq!(loaded.registers, state.registers);
+        assert_eq!(loaded.unnamed_register, state.unnamed_register);
+        assert_eq!(loaded.global_marks, state.global_marks);
+        assert_eq!(loaded.search_history, state.search_history);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn missing_and_corrupt_files_load_as_empty_state() {
+        let missing = temp_state_path("missing");
+        assert_eq!(load_from(&missing), ShadaState::default());
+
+        let corrupt = temp_state_path("corrupt");
+        std::fs::write(&corrupt, "{ not json !!").unwrap();
+        assert_eq!(load_from(&corrupt), ShadaState::default());
+        let _ = std::fs::remove_file(&corrupt);
+    }
+
+    #[test]
+    fn caps_drop_oversized_registers_and_old_history() {
+        let path = temp_state_path("caps");
+        let mut state = sample_state();
+        state.registers.insert(
+            'h',
+            RegisterEntry {
+                text: "x".repeat(MAX_REGISTER_TEXT_CHARS + 1),
+                linewise: false,
+            },
+        );
+        state.search_history = (0..(MAX_HISTORY_ENTRIES + 25))
+            .map(|i| format!("query {i}"))
+            .collect();
+
+        save_to(&path, &state).expect("save");
+        let loaded = load_from(&path);
+
+        assert!(!loaded.registers.contains_key(&'h'), "oversized dropped");
+        assert!(loaded.registers.contains_key(&'r'), "normal kept");
+        assert_eq!(loaded.search_history.len(), MAX_HISTORY_ENTRIES);
+        assert_eq!(
+            loaded.search_history.last().map(String::as_str),
+            Some("query 124"),
+            "caps keep the newest entries"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn invalid_hand_edited_keys_are_dropped_on_load() {
+        let path = temp_state_path("badkeys");
+        std::fs::write(
+            &path,
+            r#"{
+                "version": 1,
+                "macros": { "A": "x", "b": "dw" },
+                "registers": { "Z": { "text": "no", "linewise": false } },
+                "global_marks": { "q": { "path": "/x", "line": 0, "col": 0 } }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = load_from(&path);
+
+        assert!(!loaded.macros.contains_key(&'A'), "macros are a-z only");
+        assert!(loaded.macros.contains_key(&'b'));
+        assert!(loaded.registers.is_empty(), "registers are a-z only");
+        assert!(loaded.global_marks.is_empty(), "global marks are A-Z only");
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/src/shada.rs
+++ b/src/shada.rs
@@ -296,4 +296,34 @@ mod tests {
         assert!(loaded.global_marks.is_empty(), "global marks are A-Z only");
         let _ = std::fs::remove_file(&path);
     }
+
+    /// A state.json written by a NEWER nevi (higher version, fields this build
+    /// doesn't know) must still load the fields we do understand, so a
+    /// downgrade never wipes user state. Pins that ShadaState keeps serde's
+    /// ignore-unknown-fields default and per-field defaults.
+    #[test]
+    fn future_version_file_loads_known_fields() {
+        let path = temp_state_path("future");
+        std::fs::write(
+            &path,
+            r#"{
+                "version": 99,
+                "macros": { "a": "dw" },
+                "jumplist": [{ "path": "/x", "line": 3 }],
+                "registers": { "b": { "text": "kept", "linewise": false, "shape": "block" } }
+            }"#,
+        )
+        .unwrap();
+
+        let loaded = load_from(&path);
+
+        assert_eq!(loaded.macros.get(&'a').map(String::as_str), Some("dw"));
+        assert_eq!(
+            loaded.registers.get(&'b').map(|r| r.text.as_str()),
+            Some("kept"),
+            "unknown nested fields must not reject the entry"
+        );
+        assert!(loaded.search_history.is_empty(), "absent fields default");
+        let _ = std::fs::remove_file(&path);
+    }
 }


### PR DESCRIPTION
Macros, named and unnamed registers, global marks, and search history now survive restarts, like vim's shada. State is written on exit and loaded on startup, so there is no mid-session I/O on hot paths.

## Where state lives

`~/.local/state/nevi/state.json`, following nvim's `stdpath('state')` convention on every platform. `$XDG_STATE_HOME` is respected. This PR also moves `frecency.json` and `command_history.txt` to the same directory, with a read fallback to the old `dirs::config_dir()` location so existing installs migrate silently on their next save. The old files are left behind and can be deleted.

## Details

- Macros are stored as readable key notation (the macro-lens codec), so the file can be inspected or hand-edited. An entry that fails to parse is skipped without poisoning the rest.
- A missing or corrupt state file loads as empty state and never blocks startup. Writes are atomic (temp file + rename).
- Caps: 100 search history entries, 100k chars per register. Oversized or invalid entries are dropped on load and save.
- Unencodable macros stay session-only without losing the others.
- A state file from a newer nevi version still loads the fields this build understands, so downgrading never wipes user state.

## Testing

11 shada-specific tests: 6 unit tests on the file format (round-trip, corrupt file, caps, invalid keys, migration fallback, forward compatibility) and 5 editor integration tests (export/apply round-trip, restored registers paste and marks jump, unparseable notation skipped, export stability). Full suite passes.