### PR TITLE
feat: add method motions [m ]m [M ]M via tree-sitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Vim Compatibility
+
+- Added the method motions `[m`, `]m`, `[M`, and `]M`. They jump between tree-sitter function boundaries instead of using Vim's brace heuristic, so they land on real functions and methods in Rust-style code. They work with operators (`d]m`, `y[m`) and counts, and do nothing in files without tree-sitter support.
+
 ### Interface
 
 - Unified the remaining floating windows under the rich chrome. The leader/which-key popup and the command suggestions/history popup are now rounded-corner boxes with icon border titles and right-aligned key hints, and the command popup marks the selected row with the finder's accent bar instead of `>`. The floating terminal's corners now come from the shared glyph table (square in minimal mode, matching the finder) and its title carries a terminal icon. Minimal mode keeps the previous flat headers throughout.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -231,8 +231,18 @@ When specifying keys, use these formats:
 | `]}` | Move to next unmatched `}` (out of the enclosing block) |
 | `[(` | Move to previous unmatched `(` |
 | `])` | Move to next unmatched `)` |
+| `[m` | Move to previous method/function start |
+| `]m` | Move to next method/function start |
+| `[M` | Move to previous method/function end |
+| `]M` | Move to next method/function end |
 | `(` | Move to previous sentence |
 | `)` | Move to next sentence |
+
+The method motions `[m` `]m` `[M` `]M` jump between tree-sitter function
+boundaries (functions and methods of the current language) instead of using
+Vim's brace-scanning heuristic, so they land on real functions in Rust-style
+code rather than on `if` braces. In files without tree-sitter support they do
+nothing.
 
 ### File Movement
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 329 keybinds implemented, 39 planned Vim/Neovim parity defaults.**
+**Status: 333 keybinds implemented, 35 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -31,18 +31,6 @@ These apply while editing the command prompt after `:`.
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |
 | `q?` | Open `?` search history in the command-line window |
-
-### Advanced Motions
-
-These are Vim/Neovim defaults that are useful but lower priority than command-line
-mode parity.
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `[m` | Go to previous method/function start |
-| `]m` | Go to next method/function start |
-| `[M` | Go to previous method/function end |
-| `]M` | Go to next method/function end |
 
 ### Larger Feature Areas
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **329 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **39 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **78 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+- **333 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **35 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **82 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
   - 76 verified against real Neovim (v0.11.3) by the Vim oracle
-  - 1 protected by focused Nevi regression tests
+  - 5 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
 - **233 oracle cases**: motions (113), editing (60), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
-- **108 of 426 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **112 of 430 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -119,6 +119,10 @@ Nevi-owned behavior with no Vim equivalent to compare against.
 
 | Keybind | Behavior | Test |
 |---------|----------|----|
+| `]m` | Move to next method/function start (tree-sitter) | `method_motion_jumps_between_function_starts` |
+| `[m` | Move to previous method/function start (tree-sitter) | `method_motion_jumps_between_function_starts` |
+| `]M` | Move to next method/function end (tree-sitter) | `method_motion_ends_land_on_closing_brace` |
+| `[M` | Move to previous method/function end (tree-sitter) | `method_motion_ends_land_on_closing_brace` |
 | `<leader>j` | Start labeled jump navigation | `labeled_jump_jumps_to_selected_visible_match` |
 
 ## Default-keymap plumbing

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -11340,19 +11340,12 @@ impl Editor {
         boundary: crate::method_motion::MethodBoundary,
         count: usize,
     ) -> Option<(usize, usize)> {
-        let language = self.syntax.language_name()?;
         let cursor_byte = self
             .syntax
             .position_to_byte(self.cursor.line, self.cursor.col)?;
-        let (tree, source) = self.syntax.get_tree_and_source()?;
-        let (line, col) = crate::method_motion::find_method_boundary(
-            tree,
-            source,
-            language,
-            cursor_byte,
-            boundary,
-            count,
-        )?;
+        let (line, col) = self
+            .syntax
+            .method_motion_target(cursor_byte, boundary, count)?;
         let buffer = &self.buffers[self.current_buffer_idx];
         let line = line.min(last_addressable_line(buffer));
         let col = col.min(buffer.line_len(line).saturating_sub(1));
@@ -12834,6 +12827,54 @@ mod tests {
         editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
         assert_eq!(editor.cursor.line, 0);
         assert!(editor.cursor.col < editor.buffers[0].line_len(0));
+    }
+
+    #[test]
+    fn method_motion_cache_refreshes_after_reparse() {
+        use crate::method_motion::MethodBoundary;
+        // First motion populates the per-parse boundary cache...
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+
+        // ...then a reparse of a different layout must invalidate it —
+        // stale cached boundaries would jump to line 3 instead of line 1.
+        editor.replace_buffer_content("fn one() {}\nfn two() {}\n");
+        editor.syntax.parse(&editor.buffers[0]);
+        editor.cursor.set(0, 0);
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+    }
+
+    #[test]
+    fn method_motion_no_ops_when_cursor_is_beyond_snapshot() {
+        use crate::method_motion::MethodBoundary;
+        // Buffer grew after the last parse; the cursor line doesn't exist in
+        // the snapshot, so position_to_byte fails and the motion does
+        // nothing rather than resolving against the wrong text.
+        let mut editor = editor_with_parsed_rust("fn a() {}\n");
+        editor.buffers[0].set_content("fn a() {}\nx\nx\nfn b() {}\n");
+        editor.cursor.set(2, 0);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+    }
+
+    #[test]
+    fn method_motion_extends_visual_selection() {
+        use crate::method_motion::MethodBoundary;
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+        editor.cursor.set(0, 3);
+        editor.enter_visual_mode();
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        // Cursor moved, anchor stayed: v]m selects up to the next function.
+        assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+        assert_eq!(editor.mode, Mode::Visual);
+        assert_eq!(
+            (editor.visual.anchor_line, editor.visual.anchor_col),
+            (0, 3)
+        );
     }
 
     // Issue #227: j/k must keep the preferred column (Vim curswant) when

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -10280,6 +10280,17 @@ impl Editor {
             Motion::DisplayLineMiddle => {
                 self.move_to_display_line_position(DisplayLineTarget::Middle);
             }
+            Motion::Method(boundary) => {
+                let started = Instant::now();
+                if let Some((line, col)) = self.method_motion_target(boundary, count) {
+                    self.cursor.line = line;
+                    self.cursor.col = col;
+                    self.clamp_cursor();
+                    self.scroll_to_cursor();
+                }
+                self.flight_recorder
+                    .record("method_motion", started.elapsed());
+            }
             Motion::PageDown if !self.settings.editor.wrap => {
                 self.scroll_full_page(true, count);
             }
@@ -11318,15 +11329,51 @@ impl Editor {
         )
     }
 
-    fn motion_range(&self, motion: Motion, count: usize) -> Option<(usize, usize, usize, usize)> {
-        let (target_line, target_col) = apply_motion(
-            &self.buffers[self.current_buffer_idx],
-            motion,
-            self.cursor.line,
-            self.cursor.col,
+    /// Resolve `]m`-family targets against the background parse tree.
+    ///
+    /// Never parses on the keypress: no tree (unsupported language,
+    /// large-file degradation mode) fails the motion in place, and a stale
+    /// tree lags the buffer by at most one highlight debounce. The target is
+    /// clamped to the live buffer because the tree's source is a snapshot.
+    fn method_motion_target(
+        &self,
+        boundary: crate::method_motion::MethodBoundary,
+        count: usize,
+    ) -> Option<(usize, usize)> {
+        let language = self.syntax.language_name()?;
+        let cursor_byte = self
+            .syntax
+            .position_to_byte(self.cursor.line, self.cursor.col)?;
+        let (tree, source) = self.syntax.get_tree_and_source()?;
+        let (line, col) = crate::method_motion::find_method_boundary(
+            tree,
+            source,
+            language,
+            cursor_byte,
+            boundary,
             count,
-            self.text_rows(),
         )?;
+        let buffer = &self.buffers[self.current_buffer_idx];
+        let line = line.min(last_addressable_line(buffer));
+        let col = col.min(buffer.line_len(line).saturating_sub(1));
+        Some((line, col))
+    }
+
+    fn motion_range(&self, motion: Motion, count: usize) -> Option<(usize, usize, usize, usize)> {
+        let (target_line, target_col) = if let Motion::Method(boundary) = motion {
+            // Tree-sitter motions can't be computed by the pure
+            // apply_motion; this keeps d]m / y[m / c]M working.
+            self.method_motion_target(boundary, count)?
+        } else {
+            apply_motion(
+                &self.buffers[self.current_buffer_idx],
+                motion,
+                self.cursor.line,
+                self.cursor.col,
+                count,
+                self.text_rows(),
+            )?
+        };
 
         if Self::motion_is_linewise(motion) {
             if target_line == self.cursor.line {
@@ -12684,6 +12731,109 @@ mod tests {
         // to that segment's start + half a screenwidth.
         editor.apply_motion(Motion::DisplayLineMiddle, 1);
         assert_eq!((editor.cursor.line, editor.cursor.col), (0, 74 + 37));
+    }
+
+    // Method motions resolve against the background parse tree; these pin
+    // the Editor wiring (cursor path, operator path, no-tree fallback,
+    // stale-tree clamp). Boundary selection itself is tested in
+    // src/method_motion.rs.
+    const METHOD_RS: &str = "fn alpha() {\n    one();\n}\nfn beta() {\n    two();\n}\n";
+
+    fn editor_with_parsed_rust(content: &str) -> Editor {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(content);
+        editor
+            .syntax
+            .set_language_from_path(std::path::Path::new("test.rs"));
+        editor.syntax.parse(&editor.buffers[0]);
+        editor
+    }
+
+    #[test]
+    fn method_motion_jumps_between_function_starts() {
+        use crate::method_motion::MethodBoundary;
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+        editor.cursor.set(1, 4);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (3, 0));
+
+        editor.apply_motion(Motion::Method(MethodBoundary::PrevStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+    }
+
+    #[test]
+    fn method_motion_ends_land_on_closing_brace() {
+        use crate::method_motion::MethodBoundary;
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextEnd), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+
+        editor.cursor.set(4, 0);
+        editor.apply_motion(Motion::Method(MethodBoundary::PrevEnd), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (2, 0));
+    }
+
+    #[test]
+    fn method_motion_supports_counts() {
+        use crate::method_motion::MethodBoundary;
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+        editor.cursor.set(0, 3);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextEnd), 2);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (5, 0));
+
+        // Not enough targets: the whole motion fails, as in Vim.
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 5);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (5, 0));
+    }
+
+    #[test]
+    fn delete_to_next_method_start_is_exclusive() {
+        use crate::method_motion::MethodBoundary;
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+
+        // d]m from the top deletes alpha but leaves beta's line intact
+        // (exclusive motion ending in column 0 stops at the previous line's
+        // last character, per :h exclusive).
+        editor.delete_motion(Motion::Method(MethodBoundary::NextStart), 1, None);
+        assert_eq!(
+            editor.buffers[0].content(),
+            "\nfn beta() {\n    two();\n}\n"
+        );
+    }
+
+    #[test]
+    fn method_motion_without_tree_is_a_no_op() {
+        use crate::method_motion::MethodBoundary;
+        // No language / no parse: unsupported filetypes and large-file
+        // degradation mode both look like this.
+        let mut editor = Editor::default();
+        editor.replace_buffer_content(METHOD_RS);
+        editor.cursor.set(1, 4);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 4));
+        assert_eq!(
+            editor.motion_range(Motion::Method(MethodBoundary::NextStart), 1),
+            None
+        );
+    }
+
+    #[test]
+    fn method_motion_clamps_stale_tree_targets_to_live_buffer() {
+        use crate::method_motion::MethodBoundary;
+        // The tree still describes the six-line file, but the buffer shrank
+        // without a reparse (same staleness window highlighting has). The
+        // target must be clamped, never leave the buffer.
+        let mut editor = editor_with_parsed_rust(METHOD_RS);
+        editor.buffers[0].set_content("fn alpha() {\n");
+        editor.cursor.set(0, 0);
+
+        editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
+        assert_eq!(editor.cursor.line, 0);
+        assert!(editor.cursor.col < editor.buffers[0].line_len(0));
     }
 
     // Issue #227: j/k must keep the preferred column (Vim curswant) when

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1546,6 +1546,42 @@ impl InputState {
                 self.reset();
                 action
             }
+            // ]m - go to next method/function start (tree-sitter)
+            (']', KeyModifiers::NONE, KeyCode::Char('m')) => {
+                let action = self.motion_or_operator(
+                    Motion::Method(crate::method_motion::MethodBoundary::NextStart),
+                    count,
+                );
+                self.reset();
+                action
+            }
+            // [m - go to previous method/function start
+            ('[', KeyModifiers::NONE, KeyCode::Char('m')) => {
+                let action = self.motion_or_operator(
+                    Motion::Method(crate::method_motion::MethodBoundary::PrevStart),
+                    count,
+                );
+                self.reset();
+                action
+            }
+            // ]M - go to next method/function end (modifier is `_`: shifted char)
+            (']', _, KeyCode::Char('M')) => {
+                let action = self.motion_or_operator(
+                    Motion::Method(crate::method_motion::MethodBoundary::NextEnd),
+                    count,
+                );
+                self.reset();
+                action
+            }
+            // [M - go to previous method/function end
+            ('[', _, KeyCode::Char('M')) => {
+                let action = self.motion_or_operator(
+                    Motion::Method(crate::method_motion::MethodBoundary::PrevEnd),
+                    count,
+                );
+                self.reset();
+                action
+            }
             // ]h - go to next harpoon file
             (']', KeyModifiers::NONE, KeyCode::Char('h')) => {
                 self.reset();
@@ -2250,6 +2286,35 @@ mod tests {
         // Shifted chars may arrive with or without the SHIFT modifier
         // depending on the terminal, so both must dispatch.
         assert_motion(&[key('['), key('{')], Motion::UnmatchedOpenBrace, 1);
+        {
+            use crate::method_motion::MethodBoundary;
+            assert_motion(
+                &[key(']'), key('m')],
+                Motion::Method(MethodBoundary::NextStart),
+                1,
+            );
+            assert_motion(
+                &[key('['), key('m')],
+                Motion::Method(MethodBoundary::PrevStart),
+                1,
+            );
+            assert_motion(
+                &[key(']'), shift('M')],
+                Motion::Method(MethodBoundary::NextEnd),
+                1,
+            );
+            assert_motion(
+                &[key('['), shift('M')],
+                Motion::Method(MethodBoundary::PrevEnd),
+                1,
+            );
+            assert_motion(
+                &[key('2'), key(']'), key('m')],
+                Motion::Method(MethodBoundary::NextStart),
+                2,
+            );
+        }
+
         assert_motion(&[key('['), shift('{')], Motion::UnmatchedOpenBrace, 1);
         assert_motion(&[key(']'), key('}')], Motion::UnmatchedCloseBrace, 1);
         assert_motion(&[key('['), key('(')], Motion::UnmatchedOpenParen, 1);

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -82,6 +82,11 @@ pub enum Motion {
     // pane width is available, like the other display-line motions)
     DisplayLineMiddle,
 
+    // ]m [m ]M [M - tree-sitter function boundaries (handled in
+    // Editor::apply_motion / motion_range where the parse tree lives; see
+    // src/method_motion.rs for the deliberate Vim deviation)
+    Method(crate::method_motion::MethodBoundary),
+
     // go - go to the [count]'th byte of the buffer (1-based, default 1)
     GoToByte,
 }
@@ -400,6 +405,12 @@ pub fn apply_motion(
             // Screen-aware handling lives in Editor::apply_motion; operator
             // ranges would need the pane width, so the motion fails there
             // rather than computing a wrong range.
+            None
+        }
+
+        Motion::Method(_) => {
+            // Needs the parse tree; resolved in Editor::apply_motion and
+            // Editor::motion_range, which both hold self.syntax.
             None
         }
 

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -70,6 +70,29 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Move to next unmatched )",
         "unmatched close paren skips nested pair",
     ),
+    // Method motions deliberately deviate from Vim's brace heuristic (they
+    // use tree-sitter function boundaries), so they carry Nevi regression
+    // tests instead of oracle cases.
+    nevi_regression(
+        "]m",
+        "Move to next method/function start (tree-sitter)",
+        "method_motion_jumps_between_function_starts",
+    ),
+    nevi_regression(
+        "[m",
+        "Move to previous method/function start (tree-sitter)",
+        "method_motion_jumps_between_function_starts",
+    ),
+    nevi_regression(
+        "]M",
+        "Move to next method/function end (tree-sitter)",
+        "method_motion_ends_land_on_closing_brace",
+    ),
+    nevi_regression(
+        "[M",
+        "Move to previous method/function end (tree-sitter)",
+        "method_motion_ends_land_on_closing_brace",
+    ),
     vim_oracle(
         "gm",
         "Move to middle of the screen line",
@@ -230,6 +253,22 @@ const fn vim_oracle(
         state: CoverageState::Protected {
             test_id: oracle_case,
         },
+    }
+}
+
+/// Nevi-owned behavior protected by a focused regression test rather than an
+/// oracle case (used where we deliberately deviate from Vim).
+const fn nevi_regression(
+    key: &'static str,
+    description: &'static str,
+    test_id: &'static str,
+) -> KeybindCoverage {
+    KeybindCoverage {
+        mode: KeybindMode::Normal,
+        key,
+        description,
+        kind: CoverageKind::NeviRegression,
+        state: CoverageState::Protected { test_id },
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod labeled_jump;
 pub mod lsp;
 pub mod macro_lens;
 pub mod markdown_preview;
+pub mod method_motion;
 #[cfg(test)]
 mod parity_report;
 pub mod perf;

--- a/src/method_motion.rs
+++ b/src/method_motion.rs
@@ -53,9 +53,11 @@ fn function_node_kinds(language: &str) -> &'static [&'static str] {
 
 /// Every function boundary in one parsed tree, sorted by byte offset.
 ///
-/// Collecting these visits every tree node — measured ~5ms on a 13k-line
-/// Rust file, dominated by per-node FFI calls — so SyntaxManager computes
-/// this once per parse and answers each keypress with a binary search here.
+/// SyntaxManager computes this once per parse and answers each keypress with
+/// a binary search here. Collection is a full TreeCursor walk, measured at
+/// ~6ms release on the 13.7k-line src/editor/mod.rs (625 functions); a
+/// tree-sitter Query for the same kinds measured ~10ms on that file, so the
+/// plain walk is the faster collector despite its per-node FFI calls.
 #[derive(Debug, Default)]
 pub struct MethodBoundaries {
     /// (byte, (line, char col)) of each function start.
@@ -426,6 +428,57 @@ class C {
         assert_eq!(
             boundary("t.php", php, 0, MethodBoundary::NextStart, 2),
             Some((3, 4))
+        );
+    }
+
+    // Perf guard in the spirit of render_frame_budget: collection is the
+    // one-time cost after each parse, so it must fit inside a frame budget
+    // on a file the size of src/editor/mod.rs. Opt-in like the render guard:
+    // cargo test method_motion_collect_budget -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn method_motion_collect_budget() {
+        let mut src = String::new();
+        for i in 0..2000 {
+            src.push_str(&format!(
+                "fn f{i}(x: usize) -> usize {{\n    if x > {i} {{\n        x + {i}\n    }} else {{\n        x\n    }}\n}}\n\n"
+            ));
+        }
+        let mut buffer = crate::editor::Buffer::new();
+        buffer.set_content(&src);
+
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("big.rs"));
+        syntax.parse(&buffer);
+        let (tree, cached) = syntax.get_tree_and_source().expect("tree");
+
+        // Run 1 is the cold pass — the one a user's first `]m` press pays —
+        // so time every run instead of taking a best that hides it.
+        let mut runs = Vec::new();
+        let mut found = 0;
+        for _ in 0..3 {
+            let started = std::time::Instant::now();
+            let boundaries = MethodBoundaries::collect(tree, cached, "rust");
+            runs.push(started.elapsed());
+            found = boundaries.starts.len();
+        }
+        let best = *runs.iter().min().expect("runs");
+        println!(
+            "collect over {} lines: cold {:?}, then {:?} / {:?} ({found} functions)",
+            src.lines().count(),
+            runs[0],
+            runs[1],
+            runs[2],
+        );
+        assert_eq!(found, 2000);
+        // Release must fit the 16ms terminal frame budget (measured ~6ms on
+        // this synthetic and on the real editor/mod.rs); debug builds run
+        // several times slower, so give them the same headroom the render
+        // guard style allows.
+        let budget_ms = if cfg!(debug_assertions) { 120 } else { 16 };
+        assert!(
+            best.as_millis() < budget_ms,
+            "method boundary collection took {best:?}, over the {budget_ms}ms budget"
         );
     }
 

--- a/src/method_motion.rs
+++ b/src/method_motion.rs
@@ -51,81 +51,98 @@ fn function_node_kinds(language: &str) -> &'static [&'static str] {
     }
 }
 
-/// Find the [count]'th method boundary relative to `cursor_byte`.
+/// Every function boundary in one parsed tree, sorted by byte offset.
 ///
-/// Returns `(line, char_col)` in the tree's source snapshot, or `None` when
-/// the language has no function kinds or there are fewer than `count`
-/// boundaries in that direction (Vim fails the whole motion rather than
-/// stopping at the last match).
-pub fn find_method_boundary(
-    tree: &Tree,
-    source: &str,
-    language: &str,
-    cursor_byte: usize,
-    boundary: MethodBoundary,
-    count: usize,
-) -> Option<(usize, usize)> {
-    let kinds = function_node_kinds(language);
-    if kinds.is_empty() {
-        return None;
-    }
-    let count = count.max(1);
-    let want_start = matches!(
-        boundary,
-        MethodBoundary::NextStart | MethodBoundary::PrevStart
-    );
+/// Collecting these visits every tree node — measured ~5ms on a 13k-line
+/// Rust file, dominated by per-node FFI calls — so SyntaxManager computes
+/// this once per parse and answers each keypress with a binary search here.
+#[derive(Debug, Default)]
+pub struct MethodBoundaries {
+    /// (byte, (line, char col)) of each function start.
+    starts: Vec<(usize, (usize, usize))>,
+    /// (byte, (line, char col)) of each function's last character.
+    ends: Vec<(usize, (usize, usize))>,
+}
 
-    // Full pre-order walk collecting every function boundary. The tree is
-    // already in memory, so this is pointer-chasing only — microseconds even
-    // on multi-thousand-line files (:FlightRecorder shows the real cost).
-    // Nested functions come out of order here, hence the sort below.
-    let mut targets: Vec<(usize, (usize, usize))> = Vec::new();
-    let mut walker = tree.walk();
-    'walk: loop {
-        let node = walker.node();
-        if kinds.contains(&node.kind()) {
-            let target = if want_start {
+impl MethodBoundaries {
+    pub fn collect(tree: &Tree, source: &str, language: &str) -> MethodBoundaries {
+        let kinds = function_node_kinds(language);
+        let mut boundaries = MethodBoundaries::default();
+        if kinds.is_empty() {
+            return boundaries;
+        }
+
+        let mut walker = tree.walk();
+        'walk: loop {
+            let node = walker.node();
+            if kinds.contains(&node.kind()) {
                 let point = node.start_position();
                 let line_start = node.start_byte() - point.column;
-                let col = source
-                    .get(line_start..node.start_byte())
-                    .map(|prefix| prefix.chars().count())?;
-                Some((node.start_byte(), (point.row, col)))
-            } else {
-                last_char_target(source, node.end_byte(), node.end_position())
-            };
-            if let Some(target) = target {
-                targets.push(target);
+                if let Some(prefix) = source.get(line_start..node.start_byte()) {
+                    boundaries
+                        .starts
+                        .push((node.start_byte(), (point.row, prefix.chars().count())));
+                }
+                if let Some(end) = last_char_target(source, node.end_byte(), node.end_position()) {
+                    boundaries.ends.push(end);
+                }
+            }
+            if walker.goto_first_child() {
+                continue;
+            }
+            loop {
+                if walker.goto_next_sibling() {
+                    break;
+                }
+                if !walker.goto_parent() {
+                    break 'walk;
+                }
             }
         }
-        if walker.goto_first_child() {
-            continue;
-        }
-        loop {
-            if walker.goto_next_sibling() {
-                break;
-            }
-            if !walker.goto_parent() {
-                break 'walk;
-            }
-        }
+
+        // Pre-order gives sorted starts already, but nested functions put
+        // inner ends before outer ends; sort both for uniform binary search.
+        boundaries.starts.sort_unstable_by_key(|t| t.0);
+        boundaries.starts.dedup_by_key(|t| t.0);
+        boundaries.ends.sort_unstable_by_key(|t| t.0);
+        boundaries.ends.dedup_by_key(|t| t.0);
+        boundaries
     }
 
-    targets.sort_unstable_by_key(|t| t.0);
-    targets.dedup_by_key(|t| t.0);
-
-    match boundary {
-        MethodBoundary::NextStart | MethodBoundary::NextEnd => targets
-            .iter()
-            .filter(|t| t.0 > cursor_byte)
-            .nth(count - 1)
-            .map(|t| t.1),
-        MethodBoundary::PrevStart | MethodBoundary::PrevEnd => targets
-            .iter()
-            .rev()
-            .filter(|t| t.0 < cursor_byte)
-            .nth(count - 1)
-            .map(|t| t.1),
+    /// Find the [count]'th boundary strictly before/after `cursor_byte`.
+    ///
+    /// Returns `(line, char_col)` in the tree's source snapshot, or `None`
+    /// when there are fewer than `count` boundaries in that direction (Vim
+    /// fails the whole motion rather than stopping at the last match).
+    pub fn find(
+        &self,
+        boundary: MethodBoundary,
+        cursor_byte: usize,
+        count: usize,
+    ) -> Option<(usize, usize)> {
+        let count = count.max(1);
+        match boundary {
+            MethodBoundary::NextStart | MethodBoundary::NextEnd => {
+                let targets = if boundary == MethodBoundary::NextStart {
+                    &self.starts
+                } else {
+                    &self.ends
+                };
+                let first_after = targets.partition_point(|t| t.0 <= cursor_byte);
+                targets.get(first_after + count - 1).map(|t| t.1)
+            }
+            MethodBoundary::PrevStart | MethodBoundary::PrevEnd => {
+                let targets = if boundary == MethodBoundary::PrevStart {
+                    &self.starts
+                } else {
+                    &self.ends
+                };
+                let first_at_or_after = targets.partition_point(|t| t.0 < cursor_byte);
+                first_at_or_after
+                    .checked_sub(count)
+                    .map(|idx| targets[idx].1)
+            }
+        }
     }
 }
 
@@ -169,7 +186,7 @@ mod tests {
         syntax.parse_string(source);
         let language = syntax.language_name().expect("language").to_string();
         let (tree, cached) = syntax.get_tree_and_source().expect("tree");
-        find_method_boundary(tree, cached, &language, cursor_byte, boundary, count)
+        MethodBoundaries::collect(tree, cached, &language).find(boundary, cursor_byte, count)
     }
 
     const RUST_SRC: &str = "\
@@ -303,6 +320,30 @@ func (s S) b() {
         assert_eq!(
             boundary("t.go", src, cursor, MethodBoundary::PrevStart, 1),
             Some((0, 0))
+        );
+
+        // Nested ends stay byte-sorted: the literal's `}` comes before b's,
+        // even though the tree walk visits the outer node first.
+        let cursor = src.find("go func").unwrap();
+        assert_eq!(
+            boundary("t.go", src, cursor, MethodBoundary::NextEnd, 1),
+            Some((4, 4))
+        );
+        assert_eq!(
+            boundary("t.go", src, cursor, MethodBoundary::NextEnd, 2),
+            Some((5, 0))
+        );
+    }
+
+    #[test]
+    fn end_col_counts_chars_not_bytes_on_multibyte_lines() {
+        // Multibyte chars before the closing `}` push its byte column past
+        // its char column; the cursor works in chars.
+        let src = "fn f() { let s = \"ππ\"; }\n";
+        let brace_char_col = src.chars().count() - 2;
+        assert_eq!(
+            boundary("t.rs", src, 0, MethodBoundary::NextEnd, 1),
+            Some((0, brace_char_col))
         );
     }
 

--- a/src/method_motion.rs
+++ b/src/method_motion.rs
@@ -1,0 +1,398 @@
+//! Method motions `]m` `[m` `]M` `[M` backed by tree-sitter.
+//!
+//! Deliberate deviation from Vim: Vim's `]m` family runs a Java-shaped brace
+//! heuristic (`nv_bracket_block`) that stops at `if` braces and bare `}` in
+//! Rust-like code. We jump between tree-sitter function boundaries instead,
+//! which is what nvim-treesitter-textobjects users get when they map `]m` to
+//! `@function.outer`. Because of this, these motions have native regression
+//! tests rather than vim-oracle cases — the divergence is by design.
+//!
+//! Performance contract: callers pass in the background parse tree as-is and
+//! never parse on the keypress. A missing tree (unsupported language,
+//! large-file degradation mode) makes the motion fail in place; a stale tree
+//! lags the buffer by at most one highlight debounce, and callers clamp the
+//! result to the live buffer.
+
+use tree_sitter::Tree;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MethodBoundary {
+    NextStart, // ]m
+    PrevStart, // [m
+    NextEnd,   // ]M
+    PrevEnd,   // [M
+}
+
+/// Node kinds that count as a function or method per language.
+///
+/// Languages not listed (json, toml, css, ...) yield no targets, so the
+/// motion fails in place. Rust closures and Python lambdas are excluded so
+/// `]m` doesn't stop at every inline callback; JS/TS arrow functions and Go
+/// func literals stay in to match nvim-treesitter-textobjects'
+/// `@function.outer` captures.
+fn function_node_kinds(language: &str) -> &'static [&'static str] {
+    match language {
+        "rust" => &["function_item"],
+        "javascript" | "typescript" | "tsx" => &[
+            "function_declaration",
+            "generator_function_declaration",
+            "function_expression",
+            "generator_function",
+            "method_definition",
+            "arrow_function",
+        ],
+        "python" => &["function_definition"],
+        "go" => &["function_declaration", "method_declaration", "func_literal"],
+        "ruby" => &["method", "singleton_method"],
+        "php" => &["function_definition", "method_declaration"],
+        // SyntaxManager registers tree-sitter-bash as "shell"
+        "shell" => &["function_definition"],
+        _ => &[],
+    }
+}
+
+/// Find the [count]'th method boundary relative to `cursor_byte`.
+///
+/// Returns `(line, char_col)` in the tree's source snapshot, or `None` when
+/// the language has no function kinds or there are fewer than `count`
+/// boundaries in that direction (Vim fails the whole motion rather than
+/// stopping at the last match).
+pub fn find_method_boundary(
+    tree: &Tree,
+    source: &str,
+    language: &str,
+    cursor_byte: usize,
+    boundary: MethodBoundary,
+    count: usize,
+) -> Option<(usize, usize)> {
+    let kinds = function_node_kinds(language);
+    if kinds.is_empty() {
+        return None;
+    }
+    let count = count.max(1);
+    let want_start = matches!(
+        boundary,
+        MethodBoundary::NextStart | MethodBoundary::PrevStart
+    );
+
+    // Full pre-order walk collecting every function boundary. The tree is
+    // already in memory, so this is pointer-chasing only — microseconds even
+    // on multi-thousand-line files (:FlightRecorder shows the real cost).
+    // Nested functions come out of order here, hence the sort below.
+    let mut targets: Vec<(usize, (usize, usize))> = Vec::new();
+    let mut walker = tree.walk();
+    'walk: loop {
+        let node = walker.node();
+        if kinds.contains(&node.kind()) {
+            let target = if want_start {
+                let point = node.start_position();
+                let line_start = node.start_byte() - point.column;
+                let col = source
+                    .get(line_start..node.start_byte())
+                    .map(|prefix| prefix.chars().count())?;
+                Some((node.start_byte(), (point.row, col)))
+            } else {
+                last_char_target(source, node.end_byte(), node.end_position())
+            };
+            if let Some(target) = target {
+                targets.push(target);
+            }
+        }
+        if walker.goto_first_child() {
+            continue;
+        }
+        loop {
+            if walker.goto_next_sibling() {
+                break;
+            }
+            if !walker.goto_parent() {
+                break 'walk;
+            }
+        }
+    }
+
+    targets.sort_unstable_by_key(|t| t.0);
+    targets.dedup_by_key(|t| t.0);
+
+    match boundary {
+        MethodBoundary::NextStart | MethodBoundary::NextEnd => targets
+            .iter()
+            .filter(|t| t.0 > cursor_byte)
+            .nth(count - 1)
+            .map(|t| t.1),
+        MethodBoundary::PrevStart | MethodBoundary::PrevEnd => targets
+            .iter()
+            .rev()
+            .filter(|t| t.0 < cursor_byte)
+            .nth(count - 1)
+            .map(|t| t.1),
+    }
+}
+
+/// `]M`/`[M` land ON the last character of the function (the `}` in braced
+/// languages, the `d` of Ruby's `end`). `end_byte` is exclusive, so step
+/// back one char; `end_point.column` counts bytes on the final row, which
+/// gives us the row's start without scanning the file.
+fn last_char_target(
+    source: &str,
+    end_byte: usize,
+    end_point: tree_sitter::Point,
+) -> Option<(usize, (usize, usize))> {
+    if end_point.column == 0 {
+        // Node ends exactly at a line boundary — its last char is a newline,
+        // which is not a cursor position. No real grammar produces this for
+        // function nodes; skip rather than guess.
+        return None;
+    }
+    let end_byte = end_byte.min(source.len());
+    let (last_byte, _) = source.get(..end_byte)?.char_indices().next_back()?;
+    let line_start = end_byte - end_point.column;
+    let col = source.get(line_start..last_byte)?.chars().count();
+    Some((last_byte, (end_point.row, col)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::syntax::SyntaxManager;
+    use std::path::Path;
+
+    fn boundary(
+        file_name: &str,
+        source: &str,
+        cursor_byte: usize,
+        boundary: MethodBoundary,
+        count: usize,
+    ) -> Option<(usize, usize)> {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new(file_name));
+        syntax.parse_string(source);
+        let language = syntax.language_name().expect("language").to_string();
+        let (tree, cached) = syntax.get_tree_and_source().expect("tree");
+        find_method_boundary(tree, cached, &language, cursor_byte, boundary, count)
+    }
+
+    const RUST_SRC: &str = "\
+struct S;
+
+impl S {
+    fn method(&self) {
+        let f = || 1;
+    }
+}
+
+fn free() {
+    if true {
+    }
+}
+";
+
+    #[test]
+    fn rust_next_start_finds_impl_method_and_free_fn() {
+        // From the top: first `fn method`, then `fn free` — the closure and
+        // the if-block braces are not stops.
+        let first = boundary("t.rs", RUST_SRC, 0, MethodBoundary::NextStart, 1).unwrap();
+        assert_eq!(first, (3, 4));
+        let second = boundary("t.rs", RUST_SRC, 0, MethodBoundary::NextStart, 2).unwrap();
+        assert_eq!(second, (8, 0));
+    }
+
+    #[test]
+    fn rust_prev_start_from_inside_free_fn() {
+        // Cursor inside `if true {` (line 9) — [m goes to `fn free`, 2[m to
+        // `fn method`.
+        let cursor = RUST_SRC.find("if true").unwrap();
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, cursor, MethodBoundary::PrevStart, 1),
+            Some((8, 0))
+        );
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, cursor, MethodBoundary::PrevStart, 2),
+            Some((3, 4))
+        );
+    }
+
+    #[test]
+    fn rust_next_end_lands_on_closing_brace() {
+        // From the top, ]M lands on `fn method`'s closing `}` (line 5 col 4).
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, 0, MethodBoundary::NextEnd, 1),
+            Some((5, 4))
+        );
+        // From inside `free`, ]M lands on its own `}` (line 11 col 0).
+        let cursor = RUST_SRC.find("if true").unwrap();
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, cursor, MethodBoundary::NextEnd, 1),
+            Some((11, 0))
+        );
+    }
+
+    #[test]
+    fn rust_prev_end_finds_method_close() {
+        let cursor = RUST_SRC.find("if true").unwrap();
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, cursor, MethodBoundary::PrevEnd, 1),
+            Some((5, 4))
+        );
+    }
+
+    #[test]
+    fn rust_fails_when_no_more_boundaries() {
+        // 9]m: fewer than nine functions — the whole motion fails, as in Vim.
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, 0, MethodBoundary::NextStart, 9),
+            None
+        );
+        // [m from the top of the file has nothing behind it.
+        assert_eq!(
+            boundary("t.rs", RUST_SRC, 0, MethodBoundary::PrevStart, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn typescript_counts_methods_and_arrows() {
+        let src = "\
+class C {
+    method() {}
+}
+
+const f = (x: number) => x + 1;
+
+function g() {}
+";
+        assert_eq!(
+            boundary("t.ts", src, 0, MethodBoundary::NextStart, 1),
+            Some((1, 4))
+        );
+        // Arrow functions are targets, matching @function.outer.
+        let arrow_col = "const f = ".chars().count();
+        assert_eq!(
+            boundary("t.ts", src, 0, MethodBoundary::NextStart, 2),
+            Some((4, arrow_col))
+        );
+        assert_eq!(
+            boundary("t.ts", src, 0, MethodBoundary::NextStart, 3),
+            Some((6, 0))
+        );
+    }
+
+    #[test]
+    fn go_counts_funcs_methods_and_literals() {
+        let src = "\
+func a() {}
+
+func (s S) b() {
+    go func() {
+    }()
+}
+";
+        // Cursor sits ON `func a`'s start, so ]m goes to the NEXT start,
+        // matching Vim's strictly-forward rule.
+        assert_eq!(
+            boundary("t.go", src, 0, MethodBoundary::NextStart, 1),
+            Some((2, 0))
+        );
+        // func literal inside b is a target too.
+        assert_eq!(
+            boundary("t.go", src, 0, MethodBoundary::NextStart, 2),
+            Some((3, 7))
+        );
+        // `func a` is itself a target, reachable backward.
+        let cursor = src.find("func (s").unwrap();
+        assert_eq!(
+            boundary("t.go", src, cursor, MethodBoundary::PrevStart, 1),
+            Some((0, 0))
+        );
+    }
+
+    #[test]
+    fn python_defs_including_multibyte_lines() {
+        // The multibyte char before `def` exercises byte→char col conversion.
+        let src = "\
+x = 1
+
+def a():
+    pass
+
+class C:
+    def b(self):  # π comment
+        pass
+";
+        assert_eq!(
+            boundary("t.py", src, 0, MethodBoundary::NextStart, 1),
+            Some((2, 0))
+        );
+        assert_eq!(
+            boundary("t.py", src, 0, MethodBoundary::NextStart, 2),
+            Some((6, 4))
+        );
+        // Python defs end at the last statement char, not a brace.
+        let cursor = src.find("class").unwrap();
+        assert_eq!(
+            boundary("t.py", src, cursor, MethodBoundary::PrevEnd, 1),
+            Some((3, 7))
+        );
+    }
+
+    #[test]
+    fn ruby_methods_end_on_end_keyword() {
+        let src = "\
+def a
+  1
+end
+
+class C
+  def self.b
+  end
+end
+";
+        // Cursor is ON `def a`, so the next start is `def self.b`.
+        assert_eq!(
+            boundary("t.rb", src, 0, MethodBoundary::NextStart, 1),
+            Some((5, 2))
+        );
+        // ]M lands on the `d` of `end`.
+        assert_eq!(
+            boundary("t.rb", src, 0, MethodBoundary::NextEnd, 1),
+            Some((2, 2))
+        );
+    }
+
+    #[test]
+    fn bash_and_php_functions_are_targets() {
+        let sh = "\
+greet() {
+    echo hi
+}
+";
+        assert_eq!(
+            boundary("t.sh", sh, 0, MethodBoundary::NextEnd, 1),
+            Some((2, 0))
+        );
+
+        let php = "\
+<?php
+function a() {}
+class C {
+    function b() {}
+}
+";
+        assert_eq!(
+            boundary("t.php", php, 0, MethodBoundary::NextStart, 1),
+            Some((1, 0))
+        );
+        assert_eq!(
+            boundary("t.php", php, 0, MethodBoundary::NextStart, 2),
+            Some((3, 4))
+        );
+    }
+
+    #[test]
+    fn unsupported_language_yields_no_targets() {
+        assert_eq!(
+            boundary("t.json", "{\"a\": 1}\n", 0, MethodBoundary::NextStart, 1),
+            None
+        );
+    }
+}

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -39,6 +39,12 @@ pub struct SyntaxManager {
     cache_version: Cell<u64>,
     /// Version of the buffer last parsed
     parse_version: u64,
+    /// Sorted function boundaries for `]m`-family motions, computed lazily
+    /// from the current tree (the collecting walk costs ~5ms on a 13k-line
+    /// file, so keypresses after the first are a binary search). Cleared on
+    /// every parse rather than version-keyed: parse_version mirrors
+    /// buffer.version(), which can collide across buffer switches.
+    method_boundaries: RefCell<Option<crate::method_motion::MethodBoundaries>>,
 }
 
 impl SyntaxManager {
@@ -55,6 +61,7 @@ impl SyntaxManager {
             highlight_cache: RefCell::new(Vec::new()),
             cache_version: Cell::new(0),
             parse_version: 0,
+            method_boundaries: RefCell::new(None),
         }
     }
 
@@ -512,6 +519,7 @@ impl SyntaxManager {
         if self.language.is_none() {
             return;
         }
+        self.method_boundaries.replace(None);
 
         if self.language.as_deref() == Some("yaml") {
             self.source_cache = buffer_to_string(buffer);
@@ -566,6 +574,7 @@ impl SyntaxManager {
         if self.language.is_none() {
             return;
         }
+        self.method_boundaries.replace(None);
 
         if self.language.as_deref() == Some("yaml") {
             self.source_cache = content.to_string();
@@ -702,6 +711,26 @@ impl SyntaxManager {
     /// Set a new theme
     pub fn set_theme(&mut self, theme: Theme) {
         self.theme = theme;
+    }
+
+    /// Resolve a `]m`-family target in the current tree's snapshot.
+    ///
+    /// The boundary list is computed on first use after each parse and then
+    /// answered by binary search, so repeated presses cost microseconds.
+    pub fn method_motion_target(
+        &self,
+        cursor_byte: usize,
+        boundary: crate::method_motion::MethodBoundary,
+        count: usize,
+    ) -> Option<(usize, usize)> {
+        let (tree, source) = self.get_tree_and_source()?;
+        let language = self.language.as_deref()?;
+        let mut cache = self.method_boundaries.borrow_mut();
+        cache
+            .get_or_insert_with(|| {
+                crate::method_motion::MethodBoundaries::collect(tree, source, language)
+            })
+            .find(boundary, cursor_byte, count)
     }
 
     /// Get the syntax tree and source for indent calculation.


### PR DESCRIPTION
Adds the four method motions from the roadmap: `]m` / `[m` jump to the next/previous function or method start, `]M` / `[M` to the next/previous function end. They work with operators (`d]m`, `y[m`, `c]M`), counts, and visual mode.

## Deliberate deviation from Vim

Vim's `]m` family uses a Java-shaped brace heuristic that stops at `if` braces and bare `}` in Rust-style code (verified against real nvim 0.11.3). These motions use tree-sitter function boundaries instead, which is what nvim-treesitter-textobjects users get from `@function.outer`. Because the divergence is by design, they are protected by native regression tests rather than vim-oracle cases, and documented as a deviation in KEYBINDINGS.md.

Supported: Rust, JS/TS/TSX, Go, Python, Ruby, PHP, shell. Rust closures and Python lambdas are not stops; JS/TS arrows and Go func literals are. In files without a tree (unsupported language, large-file mode) the keys do nothing.

## Performance

Never parses on a keypress; uses the background parse tree as is, with targets clamped to the live buffer when the tree is stale. Boundaries are collected once per parse (about 6ms on the 13.7k-line src/editor/mod.rs, verified via :FlightRecorder) and cached on SyntaxManager, so every press after that is a binary search costing tens of microseconds. An opt-in budget guard (`method_motion_collect_budget`) pins the collection cost the same way render_frame_budget pins rendering.