### PR TITLE
fix: cw/cW stop at word end instead of including trailing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Vim Compatibility
 
+- `cw` and `cW` now follow Vim's special case (`:h cw`): on a non-blank they change only up to the end of the word, leaving the trailing whitespace in place, and on the last character of a word they change just that character. On whitespace they still behave like `dw` plus insert. (#272)
 - Added the method motions `[m`, `]m`, `[M`, and `]M`. They jump between tree-sitter function boundaries instead of using Vim's brace heuristic, so they land on real functions and methods in Rust-style code. They work with operators (`d]m`, `y[m`) and counts, and do nothing in files without tree-sitter support.
 - Fixed `~` to advance the cursor past the last toggled character, as in Vim.
 - Extended Vim oracle coverage to the editing core: the case operators (`gu`, `gU`, `g~` and their line forms), `~`, `X`, `s`, `S`, `gp`, `gP`, `J`, and `gJ` are now verified against real Neovim and individually tracked in `PARITY.md`.

--- a/PARITY.md
+++ b/PARITY.md
@@ -10,11 +10,11 @@ the test suite enforces, so it cannot drift from what is actually verified.
 ## Summary
 
 - **332 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **36 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **103 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 95 verified against real Neovim (v0.11.3) by the Vim oracle
+- **105 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 97 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **252 oracle cases**: motions (113), editing (79), insert-entry (11), open-line (20), replace (27), undo-redo (2)
+- **259 oracle cases**: motions (113), editing (86), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
 - **141 of 431 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
@@ -77,6 +77,8 @@ claim protection.
 | `o` | Open line below | `open line below` |
 | `O` | Open line above | `open line above` |
 | `dw` | Delete word with motion | `delete word` |
+| `cw` | Change word without trailing spaces | `change word excludes trailing spaces` |
+| `cW` | Change big word without trailing spaces | `change big word excludes trailing spaces` |
 | `ciw` | Change inner word | `change inner word` |
 | `cc` | Change current line | `change current line` |
 | `C` | Change to end of line | `change to line end` |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -22,7 +22,7 @@ use crate::finder::FuzzyFinder;
 use crate::frecency::FrecencyDb;
 use crate::input::{
     CaseOperator, InputState, Motion, TextObject, TextObjectModifier, TextObjectType, apply_motion,
-    motion::last_addressable_line,
+    motion::{change_word_end, last_addressable_line},
 };
 use crate::lsp::types::{CodeActionItem, CompletionItem, Diagnostic, Location, TextEdit};
 use crate::syntax::SyntaxManager;
@@ -4731,7 +4731,23 @@ impl Editor {
 
     /// Change from cursor to motion target (delete + insert mode)
     pub fn change_motion(&mut self, motion: Motion, count: usize, register: Option<char>) {
-        if let Some((start_line, start_col, end_line, end_col)) = self.motion_range(motion, count) {
+        // Vim's cw/cW special case (:h cw): on a non-blank, the change stops
+        // at the end of the word rather than including the trailing
+        // whitespace the w motion would cover.
+        let range = match motion {
+            Motion::WordForward | Motion::BigWordForward => change_word_end(
+                &self.buffers[self.current_buffer_idx],
+                self.cursor.line,
+                self.cursor.col,
+                count,
+                motion == Motion::BigWordForward,
+            )
+            .map(|(end_line, end_col)| (self.cursor.line, self.cursor.col, end_line, end_col)),
+            _ => None,
+        }
+        .or_else(|| self.motion_range(motion, count));
+
+        if let Some((start_line, start_col, end_line, end_col)) = range {
             let linewise = Self::motion_is_linewise(motion);
             let text = self.get_range_text(start_line, start_col, end_line, end_col);
 

--- a/src/editor/tests/editing_operators.rs
+++ b/src/editor/tests/editing_operators.rs
@@ -195,3 +195,71 @@ fn counted_delete_to_line_end_from_column_zero_is_linewise() {
     editor.paste_after(Some('a'));
     assert_eq!(editor.buffer().content(), "gamma\nalpha\nbeta\n");
 }
+
+// Issue #272 (:h cw): cw on a non-blank changes only up to the end of the
+// word, excluding the trailing whitespace the w motion covers.
+#[test]
+fn change_word_excludes_trailing_whitespace() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("abc def  # text\n");
+    editor.cursor.col = 4;
+
+    editor.change_motion(Motion::WordForward, 1, None);
+
+    assert_eq!(editor.buffer().content(), "abc   # text\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 4));
+    assert_eq!(editor.mode, Mode::Insert);
+}
+
+// Unlike ce, cw on the last char of a word changes just that char instead
+// of jumping to the next word's end.
+#[test]
+fn change_word_at_last_char_changes_only_that_char() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("ab cd ef\n");
+    editor.cursor.col = 1;
+
+    editor.change_motion(Motion::WordForward, 1, None);
+
+    assert_eq!(editor.buffer().content(), "a cd ef\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 1));
+}
+
+// With a count, the stand-still at word end consumes the first count
+// (Vim's end_word "stop" flag), so c2w from a word end changes one word
+// less than c2e would.
+#[test]
+fn counted_change_word_from_word_end_consumes_first_count_in_place() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("ab cd ef\n");
+    editor.cursor.col = 1;
+
+    editor.change_motion(Motion::WordForward, 2, None);
+
+    assert_eq!(editor.buffer().content(), "a ef\n");
+}
+
+// On whitespace the special case does not apply: cw keeps the exclusive w
+// range and changes the blanks up to the next word start.
+#[test]
+fn change_word_on_whitespace_keeps_exclusive_range() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("ab   cd\n");
+    editor.cursor.col = 2;
+
+    editor.change_motion(Motion::WordForward, 1, None);
+
+    assert_eq!(editor.buffer().content(), "abcd\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 2));
+}
+
+#[test]
+fn change_big_word_excludes_trailing_whitespace() {
+    let mut editor = Editor::default();
+    editor.replace_buffer_content("a.b c.d  e\n");
+
+    editor.change_motion(Motion::BigWordForward, 1, None);
+
+    assert_eq!(editor.buffer().content(), " c.d  e\n");
+    assert_eq!((editor.cursor.line, editor.cursor.col), (0, 0));
+}

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -1053,6 +1053,52 @@ fn find_word_backward(
     Some((l, c))
 }
 
+/// Inclusive end position for the `cw`/`cW` special case (:h cw): when the
+/// cursor is on a non-blank, change stops at the end of the word instead of
+/// covering the trailing whitespace `w` spans. Not the same as `ce` — Vim's
+/// end_word "stop" flag means a cursor already on the last char of a word
+/// consumes the first count standing still, so `cw` there changes only that
+/// char. Returns None on whitespace or an empty line, where `cw` keeps the
+/// normal exclusive `w` range.
+pub fn change_word_end(
+    buffer: &Buffer,
+    line: usize,
+    col: usize,
+    count: usize,
+    big_word: bool,
+) -> Option<(usize, usize)> {
+    let ch = buffer.char_at(line, col)?;
+    if ch.is_whitespace() {
+        return None;
+    }
+
+    let cursor_class = classify_char(ch);
+    let at_word_end = match buffer.char_at(line, col + 1) {
+        None => true,
+        Some(next) => {
+            let next_class = classify_char(next);
+            if big_word {
+                next_class == CharClass::Whitespace
+            } else {
+                next_class != cursor_class
+            }
+        }
+    };
+
+    let mut l = line;
+    let mut c = col;
+    let reps = count.max(1) - usize::from(at_word_end);
+    for _ in 0..reps {
+        if let Some((nl, nc)) = find_word_end(buffer, l, c, big_word) {
+            l = nl;
+            c = nc;
+        } else {
+            break;
+        }
+    }
+    Some((l, c))
+}
+
 /// Find the end of the current/next word (e motion)
 fn find_word_end(
     buffer: &Buffer,
@@ -1381,5 +1427,35 @@ mod tests {
 
             assert_eq!(position, Some((2, 0)), "motion={motion:?}");
         }
+    }
+
+    #[test]
+    fn change_word_end_stops_at_current_word_end() {
+        // cols: a0 b1 c2 _3 d4 e5 f6 _7 _8 #9
+        let buffer = buffer_with("abc def  # text\n");
+
+        // mid-word: end of the current word, not the trailing spaces
+        assert_eq!(change_word_end(&buffer, 0, 4, 1, false), Some((0, 6)));
+        // already on the last char of a word: stand still
+        assert_eq!(change_word_end(&buffer, 0, 6, 1, false), Some((0, 6)));
+        // counted from a word end: the stand-still consumes the first count
+        assert_eq!(change_word_end(&buffer, 0, 6, 2, false), Some((0, 9)));
+    }
+
+    #[test]
+    fn change_word_end_ignores_whitespace_and_empty_lines() {
+        let buffer = buffer_with("abc def\n\nx\n");
+
+        assert_eq!(change_word_end(&buffer, 0, 3, 1, false), None);
+        assert_eq!(change_word_end(&buffer, 1, 0, 1, false), None);
+    }
+
+    #[test]
+    fn change_word_end_big_word_spans_punctuation() {
+        let buffer = buffer_with("a.b c.d  e\n");
+
+        assert_eq!(change_word_end(&buffer, 0, 0, 1, true), Some((0, 2)));
+        // small-word variant stops at the class boundary instead
+        assert_eq!(change_word_end(&buffer, 0, 0, 1, false), Some((0, 0)));
     }
 }

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -149,6 +149,16 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("o", "Open line below", "open line below"),
     vim_oracle("O", "Open line above", "open line above"),
     vim_oracle("dw", "Delete word with motion", "delete word"),
+    vim_oracle(
+        "cw",
+        "Change word without trailing spaces",
+        "change word excludes trailing spaces",
+    ),
+    vim_oracle(
+        "cW",
+        "Change big word without trailing spaces",
+        "change big word excludes trailing spaces",
+    ),
     vim_oracle("ciw", "Change inner word", "change inner word"),
     vim_oracle("cc", "Change current line", "change current line"),
     vim_oracle("C", "Change to end of line", "change to line end"),

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -410,4 +410,46 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "one\ntwo\n",
         keys: "yygP",
     },
+    // Issue #272: cw on a non-blank must not include the trailing
+    // whitespace the w motion covers (:h cw special case).
+    OracleCase {
+        name: "change word excludes trailing spaces",
+        initial_text: "abc def  # text\n",
+        keys: "llllcwxyz<Esc>",
+    },
+    // On the last char of a word, cw changes just that char (unlike ce,
+    // which would jump to the next word's end).
+    OracleCase {
+        name: "change word at last char of word",
+        initial_text: "ab cd ef\n",
+        keys: "lcwX<Esc>",
+    },
+    // With a count, the stand-still at word end consumes the first count.
+    OracleCase {
+        name: "counted change word from word end",
+        initial_text: "ab cd ef\n",
+        keys: "lc2wX<Esc>",
+    },
+    OracleCase {
+        name: "counted change word excludes trailing spaces",
+        initial_text: "abc def ghi jkl\n",
+        keys: "c2wX<Esc>",
+    },
+    // On whitespace the special case does not apply; cw keeps the
+    // exclusive w range and changes the blanks up to the next word.
+    OracleCase {
+        name: "change word on whitespace",
+        initial_text: "ab   cd\n",
+        keys: "llcwX<Esc>",
+    },
+    OracleCase {
+        name: "change big word excludes trailing spaces",
+        initial_text: "a.b c.d  e\n",
+        keys: "cWX<Esc>",
+    },
+    OracleCase {
+        name: "change word stops at punctuation boundary",
+        initial_text: "abc# def\n",
+        keys: "cwX<Esc>",
+    },
 ];


### PR DESCRIPTION
`cw` was using the same range as `dw`, so changing a word also deleted the whitespace after it:

```
abc def  # text
llllcwxyz<Esc>

nvim: abc xyz  # text
nevi: abc xyz# text
```

Vim has a special case for this (`:h cw`). When the cursor is on a non-blank, `cw` and `cW` only change up to the end of the current word and leave the trailing spaces alone. It's not the same as `ce` though: if the cursor is already on the last char of a word, `cw` only changes that char, and with a count that first word still only counts as one. On whitespace there is no special case, `cw` eats the blanks up to the next word like `dw` does.

## Fix

Every `cw` and `cW` goes through `Editor::change_motion`, so the fix lives in that one place. A new helper `change_word_end` in `src/input/motion.rs` computes the inclusive end position, and returns `None` on whitespace or an empty line so the normal `w` range still applies. `dw`, `yw` and the rest of the operator + motion paths are untouched.

## Tests

- 7 new vim-oracle cases: the issue repro, cw on the last char of a word, counted cw from a word end, counted cw mid word, cw on whitespace, cW, and a punctuation boundary. All pass against real nvim with `NEVI_VIM_ORACLE=1`.
- 5 regression tests in `editing_operators.rs` plus 3 unit tests on the helper.
- `cw` and `cW` were missing from the keybind coverage inventory, so both are added and PARITY.md is regenerated.

Fixes #272
