### PR TITLE
fix: map ruby files to the ruby key in languages.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 - Macros, named and unnamed registers, global marks, and search history now survive restarts, like Vim's shada. State is stored in `~/.local/state/nevi/state.json`, following nvim's `stdpath('state')` convention, and `$XDG_STATE_HOME` is respected. Macros are saved as readable key notation, so the file can be inspected or hand-edited, and a corrupt file never blocks startup. The frecency database and command history moved to the same directory; data in the old location is found automatically and migrates on its next save.
 
+### Configuration
+
+- Fixed `[ruby]` in `languages.toml` being ignored. Ruby files (`.rb`, `.rake`, `.gemspec`, `.ru`, `.podspec`) resolved to their raw extension instead of the `ruby` key, so formatter and tab width settings never applied. The generated `languages.toml` template now includes a commented Ruby example. (#273)
+
 ## 0.3.0 - 2026-08-25
 
 Nevi 0.3.0 rebuilds the statusline, finder, and explorer, closes a long list of

--- a/src/config/languages.rs
+++ b/src/config/languages.rs
@@ -178,6 +178,16 @@ fn default_languages_template() -> &'static str {
 # tab_width = 4
 
 # ============================================================================
+# RUBY (RuboCop autocorrect)
+# ruby-lsp formats via LSP by default; set this to format with RuboCop directly.
+# --fail-level fatal keeps exit 0 on style offenses (Nevi treats a nonzero
+# exit as failure) while still failing on unparseable code.
+# ============================================================================
+# [ruby]
+# formatter = { command = "rubocop", args = ["--stdin", "{file}", "-a", "--stderr", "--format", "quiet", "--fail-level", "fatal"] }
+# tab_width = 2
+
+# ============================================================================
 # SHELL (shfmt)
 # Install: go install mvdan.cc/sh/v3/cmd/shfmt@latest
 # ============================================================================

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1718,6 +1718,9 @@ impl Editor {
             "html" | "htm" => "html".to_string(),
             "py" | "pyi" | "pyw" => "python".to_string(),
             "go" => "go".to_string(),
+            // Keep in sync with the Ruby filetypes the LSP layer recognizes
+            // (src/lsp/mod.rs) so `[ruby]` in languages.toml covers all of them.
+            "rb" | "rake" | "gemspec" | "ru" | "podspec" => "ruby".to_string(),
             "yaml" | "yml" => "yaml".to_string(),
             "sh" | "bash" | "zsh" | "ksh" | "bats" => "shell".to_string(),
             _ => ext_lower,
@@ -11666,6 +11669,40 @@ mod tests {
         assert_eq!(
             editor.get_current_formatter().map(|f| f.command.as_str()),
             Some("shfmt")
+        );
+        assert_eq!(editor.get_effective_tab_width(), 2);
+    }
+
+    #[test]
+    fn ruby_files_use_ruby_languages_toml_settings() {
+        use crate::config::{FormatterConfig, LanguageConfig, LanguagesConfig};
+        use std::collections::HashMap;
+
+        // Every Ruby filetype the LSP layer recognizes must resolve to the
+        // `[ruby]` config key, not fall through to its raw extension.
+        for ext in ["rb", "rake", "gemspec", "ru", "podspec"] {
+            assert_eq!(Editor::extension_to_language(ext), "ruby", "ext: {ext}");
+        }
+
+        let mut editor = Editor::default();
+        editor.set_buffer_path(PathBuf::from("/home/me/app/models/user.rb"));
+        editor.languages_config = LanguagesConfig {
+            languages: HashMap::from([(
+                "ruby".to_string(),
+                LanguageConfig {
+                    formatter: Some(FormatterConfig {
+                        command: "rubocop".to_string(),
+                        args: vec!["--stdin".to_string(), "{file}".to_string()],
+                        timeout: 5,
+                    }),
+                    tab_width: Some(2),
+                },
+            )]),
+        };
+
+        assert_eq!(
+            editor.get_current_formatter().map(|f| f.command.as_str()),
+            Some("rubocop")
         );
         assert_eq!(editor.get_effective_tab_width(), 2);
     }


### PR DESCRIPTION
Ruby files fell through extension_to_language to their raw extension, so a [ruby] section in languages.toml never applied. Also add a commented ruby example to the generated template.

Fixes #273