### PR TITLE
feat: add dot repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - `cw` and `cW` now follow Vim's special case (`:h cw`): on a non-blank they change only up to the end of the word, leaving the trailing whitespace in place, and on the last character of a word they change just that character. On whitespace they still behave like `dw` plus insert. (#272)
 - Added the method motions `[m`, `]m`, `[M`, and `]M`. They jump between tree-sitter function boundaries instead of using Vim's brace heuristic, so they land on real functions and methods in Rust-style code. They work with operators (`d]m`, `y[m`) and counts, and do nothing in files without tree-sitter support.
+- Added dot repeat. `.` replays the last change at the cursor: operators with motions, character edits, insert sessions with their typed text, joins, pastes, and replace mode. A count replaces the change's original count (`3.`), the new count is remembered for the next repeat, and one `u` reverts a whole repeated change. Changes made through visual mode are not repeated yet.
+- Fixed `w` and `W` at the last word of the buffer. They jumped to column 0 of the last line instead of stopping on the buffer's last character, and `dw` there deleted one character short of the word end.
 - Fixed `~` to advance the cursor past the last toggled character, as in Vim.
 - Extended Vim oracle coverage to the editing core: the case operators (`gu`, `gU`, `g~` and their line forms), `~`, `X`, `s`, `S`, `gp`, `gP`, `J`, and `gJ` are now verified against real Neovim and individually tracked in `PARITY.md`.
 - Corrected the docs: `.` (repeat last change) was listed as implemented but only shows a status note today. It moved to the roadmap.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -353,6 +353,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `gP` / `{n}gP` | Paste before and leave cursor after pasted text |
 | `r{char}` / `{n}r{char}` | Replace exactly one/count characters; `Enter` replaces them with one newline |
 | `R` / `{n}R` | Enter replace mode; a count repeats the entered replacement text |
+| `.` / `{n}.` | Repeat the last change; a count replaces the change's original count |
 
 > **Examples:**
 > - `dw` - Delete from cursor to start of next word

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 332 keybinds implemented, 36 planned Vim/Neovim parity defaults.**
+**Status: 333 keybinds implemented, 35 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md).
@@ -31,12 +31,6 @@ These apply while editing the command prompt after `:`.
 | `q:` | Open command-line history in the command-line window |
 | `q/` | Open `/` search history in the command-line window |
 | `q?` | Open `?` search history in the command-line window |
-
-### Editing
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `.` | Repeat the last change (dot repeat; the key currently only shows a status note) |
 
 ### Larger Feature Areas
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **332 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **36 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **105 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 97 verified against real Neovim (v0.11.3) by the Vim oracle
+- **333 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **35 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **106 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 98 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **259 oracle cases**: motions (113), editing (86), insert-entry (11), open-line (20), replace (27), undo-redo (2)
+- **279 oracle cases**: motions (115), editing (104), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
-- **141 of 431 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **142 of 432 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -107,6 +107,7 @@ claim protection.
 | `gUU` | Uppercase entire line | `uppercase entire line` |
 | `g~{motion}` | Toggle case with a motion | `toggle case to word end` |
 | `g~~` | Toggle case of entire line | `toggle case entire line` |
+| `.` | Repeat the last change | `repeat char delete` |
 | `J` | Join lines with a space | `join lines with space` |
 | `gJ` | Join lines without a space | `join without added space` |
 | `u` | Undo latest change | `undo insert` |

--- a/src/dot_repeat.rs
+++ b/src/dot_repeat.rs
@@ -1,0 +1,290 @@
+//! Dot repeat (`.`): records the key sequence of the last buffer change and
+//! replays it, mirroring Vim's redobuff approach.
+//!
+//! Capture is behavior-based rather than command-enumerated: every key that
+//! reaches normal editing flow joins a candidate sequence, and the candidate
+//! is committed as "the last change" once the editor returns to a settled
+//! normal-mode state with the buffer version moved (or after an insert-mode
+//! session). New editing features therefore become repeatable without
+//! touching this module. Sequences that pass through visual, command, or
+//! search mode are never committed — Vim repeats visual changes structurally
+//! rather than as keys, and that variant is deferred.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use crate::editor::Mode;
+
+#[derive(Debug, Default)]
+pub struct DotRepeat {
+    /// The committed last change, replayed by `.`.
+    redo_keys: Vec<KeyEvent>,
+    /// Keys of the sequence currently being built.
+    candidate: Vec<KeyEvent>,
+    /// Buffer version when the candidate started.
+    start_version: u64,
+    /// Buffer index when the candidate started; a switch discards the
+    /// candidate rather than committing keys that straddle buffers.
+    start_buffer_idx: usize,
+    /// The candidate ran an insert/replace session. Committed even when the
+    /// buffer is unchanged (`i<Esc>`), because Vim records those too and a
+    /// stale earlier change must not survive as "the last change".
+    ran_insert_session: bool,
+    /// The candidate touched a flow `.` never repeats (visual mode, command
+    /// line, search, undo/redo).
+    poisoned: bool,
+    /// True while `.` is replaying; replayed keys are not observed.
+    replaying: bool,
+}
+
+impl DotRepeat {
+    /// Observe one key before it is handled. `mode`, `pending`, `version`,
+    /// and `buffer_idx` describe the editor state BEFORE the key runs; a
+    /// fresh normal-mode key (no pending sequence) means whatever came
+    /// before has fully settled, so the previous candidate is committed or
+    /// discarded here rather than through a fragile post-key hook.
+    pub fn observe(
+        &mut self,
+        mode: Mode,
+        pending: bool,
+        version: u64,
+        buffer_idx: usize,
+        key: KeyEvent,
+    ) {
+        if self.replaying {
+            return;
+        }
+
+        if mode == Mode::Normal && !pending {
+            self.settle(version, buffer_idx);
+        }
+
+        match mode {
+            Mode::Normal | Mode::Insert | Mode::Replace => {}
+            _ => self.poisoned = true,
+        }
+        if matches!(mode, Mode::Insert | Mode::Replace) {
+            self.ran_insert_session = true;
+        }
+        // u / Ctrl-r change the buffer but are never a change for `.`.
+        if self.candidate.is_empty() && is_undo_redo(key) {
+            self.poisoned = true;
+        }
+
+        self.candidate.push(key);
+    }
+
+    /// Commit or discard the finished candidate and start a fresh one.
+    fn settle(&mut self, version: u64, buffer_idx: usize) {
+        let changed = version != self.start_version || self.ran_insert_session;
+        let same_buffer = buffer_idx == self.start_buffer_idx;
+        if !self.candidate.is_empty() && changed && same_buffer && !self.poisoned {
+            self.redo_keys = std::mem::take(&mut self.candidate);
+        } else {
+            self.candidate.clear();
+        }
+        self.start_version = version;
+        self.start_buffer_idx = buffer_idx;
+        self.ran_insert_session = false;
+        self.poisoned = false;
+    }
+
+    /// The keys `.` should replay. A count replaces the change's original
+    /// leading count, as in Vim, and the rewritten sequence becomes the
+    /// remembered change so a following plain `.` reuses the new count.
+    pub fn take_replay_keys(&mut self, count: Option<usize>) -> Option<Vec<KeyEvent>> {
+        if self.redo_keys.is_empty() {
+            return None;
+        }
+        if let Some(count) = count {
+            let skip = leading_count_len(&self.redo_keys);
+            let mut keys: Vec<KeyEvent> = count
+                .to_string()
+                .chars()
+                .map(|c| KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+                .collect();
+            keys.extend_from_slice(&self.redo_keys[skip..]);
+            self.redo_keys = keys;
+        }
+        Some(self.redo_keys.clone())
+    }
+
+    pub fn begin_replay(&mut self) {
+        self.replaying = true;
+    }
+
+    pub fn end_replay(&mut self) {
+        self.replaying = false;
+    }
+
+    /// Drop the in-flight candidate. The `.` keystroke (and its count) must
+    /// never become the recorded change.
+    pub fn abandon_candidate(&mut self) {
+        self.candidate.clear();
+        self.ran_insert_session = false;
+        self.poisoned = false;
+    }
+
+    pub fn has_recorded_change(&self) -> bool {
+        !self.redo_keys.is_empty()
+    }
+}
+
+fn is_undo_redo(key: KeyEvent) -> bool {
+    matches!(
+        (key.modifiers, key.code),
+        (KeyModifiers::NONE, KeyCode::Char('u')) | (KeyModifiers::CONTROL, KeyCode::Char('r'))
+    )
+}
+
+/// Length of the count prefix in a recorded sequence (`3x` → 1). A leading
+/// `0` is a motion, never a count.
+fn leading_count_len(keys: &[KeyEvent]) -> usize {
+    let mut len = 0;
+    for key in keys {
+        match key.code {
+            KeyCode::Char(c)
+                if key.modifiers == KeyModifiers::NONE
+                    && c.is_ascii_digit()
+                    && !(len == 0 && c == '0') =>
+            {
+                len += 1;
+            }
+            _ => break,
+        }
+    }
+    len
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(c: char) -> KeyEvent {
+        KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)
+    }
+
+    fn esc() -> KeyEvent {
+        KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)
+    }
+
+    fn chars(keys: &[KeyEvent]) -> String {
+        keys.iter()
+            .map(|k| match k.code {
+                KeyCode::Char(c) => c,
+                KeyCode::Esc => '␛',
+                _ => '?',
+            })
+            .collect()
+    }
+
+    #[test]
+    fn change_commits_when_next_key_arrives() {
+        let mut dot = DotRepeat::default();
+        // `x` changed the buffer (v1 -> v2); the following `j` settles it.
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "x");
+    }
+
+    #[test]
+    fn motion_never_becomes_the_change() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('w'));
+        // `w` did not change the version; the next key discards it and the
+        // committed change stays `x`.
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "x");
+    }
+
+    #[test]
+    fn operator_motion_commits_as_one_sequence() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('d'));
+        // Mid-sequence: pending operator, no settle.
+        dot.observe(Mode::Normal, true, 1, 0, key('w'));
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "dw");
+    }
+
+    #[test]
+    fn insert_session_commits_with_typed_text() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('i'));
+        dot.observe(Mode::Insert, false, 1, 0, key('h'));
+        dot.observe(Mode::Insert, false, 2, 0, key('i'));
+        dot.observe(Mode::Insert, false, 3, 0, esc());
+        dot.observe(Mode::Normal, false, 3, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "ihi␛");
+    }
+
+    #[test]
+    fn empty_insert_session_still_replaces_the_change() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        // i<Esc> typed nothing, but Vim still records it as the last change.
+        dot.observe(Mode::Normal, false, 2, 0, key('i'));
+        dot.observe(Mode::Insert, false, 2, 0, esc());
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "i␛");
+    }
+
+    #[test]
+    fn visual_change_is_not_captured() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('v'));
+        dot.observe(Mode::Visual, false, 2, 0, key('l'));
+        dot.observe(Mode::Visual, false, 2, 0, key('d'));
+        // Version moved, but the sequence went through visual mode.
+        dot.observe(Mode::Normal, false, 3, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "x");
+    }
+
+    #[test]
+    fn undo_is_never_the_change() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('u'));
+        dot.observe(Mode::Normal, false, 1, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "x");
+    }
+
+    #[test]
+    fn buffer_switch_discards_the_candidate() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        // Buffer 1 happens to share the bumped version number.
+        dot.observe(Mode::Normal, false, 2, 1, key('j'));
+        assert!(dot.take_replay_keys(None).is_none());
+    }
+
+    #[test]
+    fn count_override_rewrites_the_leading_count() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('2'));
+        dot.observe(Mode::Normal, true, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(Some(5)).unwrap()), "5x");
+        // The rewritten count is remembered for the next plain repeat.
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "5x");
+    }
+
+    #[test]
+    fn zero_is_a_motion_not_a_count_prefix() {
+        assert_eq!(leading_count_len(&[key('0'), key('x')]), 0);
+        assert_eq!(leading_count_len(&[key('1'), key('0'), key('x')]), 2);
+    }
+
+    #[test]
+    fn replaying_keys_are_not_observed() {
+        let mut dot = DotRepeat::default();
+        dot.observe(Mode::Normal, false, 1, 0, key('x'));
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        dot.begin_replay();
+        dot.observe(Mode::Normal, false, 2, 0, key('d'));
+        dot.observe(Mode::Normal, true, 2, 0, key('d'));
+        dot.end_replay();
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "x");
+    }
+}

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1120,6 +1120,9 @@ pub struct Editor {
     pub pending_visual_block_edit: Option<VisualBlockEdit>,
     /// Macro recording and playback state
     pub macros: MacroState,
+    /// Dot repeat (`.`): the last change's key sequence, captured in the
+    /// key dispatcher and replayed like a one-shot macro.
+    pub dot_repeat: crate::dot_repeat::DotRepeat,
     /// Last insert position for `gi` command (line, col)
     pub last_insert_position: Option<(usize, usize)>,
     /// Text inserted during the most recently completed insert session.
@@ -1629,6 +1632,7 @@ impl Editor {
             last_visual_selection: None,
             pending_visual_block_edit: None,
             macros: MacroState::new(),
+            dot_repeat: crate::dot_repeat::DotRepeat::default(),
             last_insert_position: None,
             last_inserted_text: None,
             current_inserted_text: String::new(),
@@ -10290,13 +10294,6 @@ impl Editor {
     }
 
     /// Repeat last change (. command)
-    /// Note: Full implementation would store last command sequence.
-    /// For now, this is a placeholder that shows a message.
-    pub fn repeat_last_change(&mut self) {
-        // TODO: Implement proper repeat functionality
-        // This requires storing the last change sequence (keys or operations)
-        self.set_status(". (repeat) not fully implemented yet");
-    }
 
     /// Apply motion with screen-relative awareness
     /// This overrides basic motion for H, M, L which need viewport info
@@ -11481,7 +11478,28 @@ impl Editor {
         }
 
         let forward = (target_line, target_col) >= (self.cursor.line, self.cursor.col);
-        let inclusive = forward && Self::motion_is_inclusive(motion);
+        let mut inclusive = forward && Self::motion_is_inclusive(motion);
+
+        // :h w special case: an operator with `w` on the last word of the
+        // buffer operates through the end of that word. The motion itself
+        // clamps to the buffer's last character; treat that as inclusive,
+        // but only when no whitespace separates cursor and target (a real
+        // landing on a short final word stays exclusive).
+        if matches!(motion, Motion::WordForward | Motion::BigWordForward)
+            && target_line == self.cursor.line
+        {
+            let buffer = &self.buffers[self.current_buffer_idx];
+            let last_line = last_addressable_line(buffer);
+            let last_col = buffer.line_len(last_line).saturating_sub(1);
+            let crossed_whitespace = (self.cursor.col..=target_col).any(|c| {
+                buffer
+                    .char_at(target_line, c)
+                    .is_some_and(char::is_whitespace)
+            });
+            if (target_line, target_col) == (last_line, last_col) && !crossed_whitespace {
+                inclusive = true;
+            }
+        }
 
         let (start_line, start_col, mut end_line, mut end_col) =
             if (target_line, target_col) < (self.cursor.line, self.cursor.col) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -161,8 +161,9 @@ pub enum KeyAction {
     ScrollTop,
     /// Scroll cursor to bottom of screen (zb)
     ScrollBottom,
-    /// Repeat last change (.)
-    RepeatLastChange,
+    /// Repeat last change (.). Carries the typed count, if any: Vim treats
+    /// an explicit count (even `1.`) as replacing the change's own count.
+    RepeatLastChange(Option<usize>),
     /// Paste after cursor
     PasteAfter(usize),
     /// Paste before cursor
@@ -1116,9 +1117,10 @@ impl InputState {
                 KeyAction::Hover
             }
             (KeyModifiers::NONE, KeyCode::Char('.')) => {
-                // . - repeat last change
+                // . - repeat last change (count captured before reset clears it)
+                let typed_count = self.count;
                 self.reset();
-                KeyAction::RepeatLastChange
+                KeyAction::RepeatLastChange(typed_count)
             }
             (KeyModifiers::SHIFT, KeyCode::Char('~'))
             | (KeyModifiers::NONE, KeyCode::Char('~')) => {
@@ -2488,8 +2490,12 @@ mod tests {
             other => panic!("expected counted newline ReplaceChar, got {:?}", other),
         }
         match run(&[key('.')]) {
-            KeyAction::RepeatLastChange => {}
+            KeyAction::RepeatLastChange(None) => {}
             other => panic!("expected RepeatLastChange, got {:?}", other),
+        }
+        match run(&[key('3'), key('.')]) {
+            KeyAction::RepeatLastChange(Some(3)) => {}
+            other => panic!("expected counted RepeatLastChange, got {:?}", other),
         }
         match run(&[key('u')]) {
             KeyAction::Undo => {}

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -894,13 +894,20 @@ fn find_word_forward(
     let mut c = col;
     let total_lines = buffer.addressable_line_count();
 
+    // Vim `w` with no next word stops on the buffer's LAST character
+    // (:h w), never at column 0 of the last line.
+    let end_of_buffer = {
+        let last_line = total_lines.saturating_sub(1);
+        (last_line, buffer.line_len(last_line).saturating_sub(1))
+    };
+
     // Get current character class
     let start_class = buffer.char_at(l, c).map(|ch| classify_char(ch));
 
     // Phase 1: Move past current word (same class characters)
     loop {
         if l >= total_lines {
-            return Some((total_lines.saturating_sub(1), 0));
+            return Some(end_of_buffer);
         }
 
         let line_len = buffer.line_len(l);
@@ -938,7 +945,7 @@ fn find_word_forward(
     // Phase 2: Skip whitespace
     loop {
         if l >= total_lines {
-            return Some((total_lines.saturating_sub(1), 0));
+            return Some(end_of_buffer);
         }
 
         let line_len = buffer.line_len(l);
@@ -963,8 +970,7 @@ fn find_word_forward(
 
     // Clamp to valid position
     if l >= total_lines {
-        l = total_lines.saturating_sub(1);
-        c = 0;
+        return Some(end_of_buffer);
     }
 
     Some((l, c))

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -237,6 +237,7 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Toggle case of entire line",
         "toggle case entire line",
     ),
+    vim_oracle(".", "Repeat the last change", "repeat char delete"),
     vim_oracle("J", "Join lines with a space", "join lines with space"),
     vim_oracle(
         "gJ",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod commands;
 pub mod config;
 pub mod copilot;
 pub mod dashboard;
+pub mod dot_repeat;
 pub mod editor;
 pub mod explorer;
 pub mod file_diff;

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -6803,6 +6803,32 @@ fn handle_markdown_preview_key(editor: &mut Editor, key: KeyEvent) {
     }
 }
 
+/// Repeat the last change (`.`) by replaying its keys, like Vim's redobuff.
+fn repeat_last_change(editor: &mut Editor, count: Option<usize>) {
+    // The `.` keystroke (and its count) is sitting in the capture candidate;
+    // it must never become the recorded change itself.
+    editor.dot_repeat.abandon_candidate();
+
+    let Some(keys) = editor.dot_repeat.take_replay_keys(count) else {
+        editor.set_status("No change to repeat");
+        return;
+    };
+
+    // One compound undo group so a single `u` reverts the whole repeat,
+    // matching Vim and the macro playback path.
+    editor
+        .undo_stack
+        .begin_compound_group(editor.cursor.line, editor.cursor.col);
+    editor.dot_repeat.begin_replay();
+    for key in keys {
+        handle_key(editor, key);
+    }
+    editor.dot_repeat.end_replay();
+    editor
+        .undo_stack
+        .end_compound_group(editor.cursor.line, editor.cursor.col);
+}
+
 /// Play a macro from a register
 fn play_macro(editor: &mut Editor, register: char, count: usize) {
     // Get the macro keys (clone to avoid borrow issues)
@@ -7285,6 +7311,19 @@ pub fn handle_key(editor: &mut Editor, key: KeyEvent) {
         editor.macros.record_key(key);
     }
 
+    // Dot repeat: settle the previous key sequence (commit it as the last
+    // change if it modified the buffer) and record this key as part of the
+    // next candidate. Must read the PRE-key state, so it runs before mode
+    // dispatch; overlay keys never get here because of the returns above.
+    {
+        let mode = editor.mode;
+        let pending = editor.input_state.has_pending_sequence();
+        let version = editor.buffer().version();
+        editor
+            .dot_repeat
+            .observe(mode, pending, version, editor.current_buffer_index(), key);
+    }
+
     if editor.pending_insert_normal_once && editor.mode == Mode::Normal {
         handle_normal_mode(editor, key);
         if !editor.input_state.has_pending_sequence() {
@@ -7737,8 +7776,8 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.scroll_cursor_bottom();
         }
 
-        KeyAction::RepeatLastChange => {
-            editor.repeat_last_change();
+        KeyAction::RepeatLastChange(count) => {
+            repeat_last_change(editor, count);
         }
 
         KeyAction::EnterCommand => {

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -179,6 +179,18 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "alpha beta gamma\n",
         keys: "w",
     },
+    // Vim stops on the buffer's last character when there is no next word;
+    // this used to snap to column 0 of the last line.
+    OracleCase {
+        name: "word forward at last word of buffer",
+        initial_text: "alpha beta\n",
+        keys: "ww",
+    },
+    OracleCase {
+        name: "big word forward at last word of buffer",
+        initial_text: "alpha beta\n",
+        keys: "WW",
+    },
     OracleCase {
         name: "big word forward",
         initial_text: "alpha.beta gamma\n",

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -382,6 +382,100 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "one\ntwo\nthree\nfour\n",
         keys: "2Sx<Esc>",
     },
+    // :h w special case: dw on the buffer's last word deletes through the
+    // end of that word; landing on a real final word stays exclusive.
+    OracleCase {
+        name: "delete word on last word of buffer",
+        initial_text: "one two three\n",
+        keys: "wwdw",
+    },
+    OracleCase {
+        name: "delete word landing on short final word",
+        initial_text: "one x\n",
+        keys: "dw",
+    },
+    // Dot repeat: `.` replays the last change at the current cursor
+    // position, with a typed count replacing the change's own count.
+    OracleCase {
+        name: "repeat char delete",
+        initial_text: "abcdef\n",
+        keys: "xl.",
+    },
+    OracleCase {
+        name: "repeat delete word",
+        initial_text: "one two three\n",
+        keys: "dww.",
+    },
+    OracleCase {
+        name: "repeat insert",
+        initial_text: "alpha\nbeta\n",
+        keys: "ihi <Esc>j0.",
+    },
+    OracleCase {
+        name: "repeat change word",
+        initial_text: "one two\nthree four\n",
+        keys: "cwX<Esc>j0.",
+    },
+    OracleCase {
+        name: "repeat with count override",
+        initial_text: "abcdef\n",
+        keys: "x3.",
+    },
+    OracleCase {
+        name: "repeat keeps original count",
+        initial_text: "abcdefgh\n",
+        keys: "2x.",
+    },
+    OracleCase {
+        name: "repeat remembers overridden count",
+        initial_text: "abcdefghij\n",
+        keys: "x3..",
+    },
+    OracleCase {
+        name: "repeat open line below",
+        initial_text: "alpha\n",
+        keys: "oX<Esc>.",
+    },
+    OracleCase {
+        name: "repeat after undo",
+        initial_text: "ab\n",
+        keys: "xu.",
+    },
+    OracleCase {
+        name: "repeat paste",
+        initial_text: "abc\n",
+        keys: "ylp.",
+    },
+    OracleCase {
+        name: "repeat toggle case",
+        initial_text: "hello\n",
+        keys: "~.",
+    },
+    OracleCase {
+        name: "repeat replace char",
+        initial_text: "abcd\n",
+        keys: "rXl.",
+    },
+    OracleCase {
+        name: "repeat join",
+        initial_text: "a\nb\nc\nd\n",
+        keys: "J.",
+    },
+    OracleCase {
+        name: "repeat substitute",
+        initial_text: "abc def\n",
+        keys: "sX<Esc>w.",
+    },
+    OracleCase {
+        name: "undo reverts whole repeated insert",
+        initial_text: "alpha\n",
+        keys: "ohi<Esc>.u",
+    },
+    OracleCase {
+        name: "motion between change and repeat is not recorded",
+        initial_text: "abc def\n",
+        keys: "xww.",
+    },
     // Plain joins (the last-line no-op pins above cover the boundary).
     OracleCase {
         name: "join lines with space",


### PR DESCRIPTION
Adds `.`, which replays the last change at the cursor. It was documented before but only showed a status note. Now it works the way Vim users expect: change a word with `ciw`, move to the next one, press `.`.

## How it works

Same model as Vim's redobuff: the last change is stored as its key sequence and replayed like a one-shot macro. Capture is behavior-based instead of a hardcoded command list. The key dispatcher watches every key, and a sequence is committed as "the last change" when it actually modified the buffer or ran an insert session. That means new editing commands become repeatable automatically without touching the dot-repeat code.

What repeats: operators with motions (`dw`, `ciw` with the typed text), character edits (`x`, `X`, `r`, `s`, `~`), joins, pastes, indents, and full insert sessions (`A;<Esc>` then `j.` down the file). What never repeats: motions, undo/redo, and anything routed through command-line, search, or visual mode. Visual-mode repeat is deferred for now.

Counts match Vim: `3.` replaces the change's original count, the new count is remembered for following repeats, and one `u` reverts an entire repeated change.

## Bugs found along the way

The new oracle cases exposed two existing bugs, both fixed here:

- `w` and `W` at the last word of the buffer jumped to column 0 of the last line instead of stopping on the buffer's last character.
- With that fixed, `dw` on the buffer's last word deleted one character short of the word end. Vim's `:h w` special case deletes through it.

## Testing

11 unit tests on the capture state machine, 16 dot-repeat oracle casesplus 4 motion/operator cases for the `w` fixes, all verified against real Neovim v0.11.3. The 20,000-seed extended fuzz run passes with `.` in the key alphabet, so replay recursion got hammered without a single invariant violation. PARITY.md now reports 333 keybinds implemented and
35 planned, with 142 of 432 documented rows individually tracked.