### PR TITLE
test: cover motions, marks, and jump lists with Vim oracle cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 - Added the method motions `[m`, `]m`, `[M`, and `]M`. They jump between tree-sitter function boundaries instead of using Vim's brace heuristic, so they land on real functions and methods in Rust-style code. They work with operators (`d]m`, `y[m`) and counts, and do nothing in files without tree-sitter support.
 - Added dot repeat. `.` replays the last change at the cursor: operators with motions, character edits, insert sessions with their typed text, joins, pastes, and replace mode. A count replaces the change's original count (`3.`), the new count is remembered for the next repeat, and one `u` reverts a whole repeated change. Changes made through visual mode are not repeated yet.
 - Fixed `w` and `W` at the last word of the buffer. They jumped to column 0 of the last line instead of stopping on the buffer's last character, and `dw` there deleted one character short of the word end.
+- Extended Vim oracle coverage to paragraph and sentence motions, counted `G`, `-`, local marks, the jump and change lists (`Ctrl+o`, `Ctrl+i`, `''`, `g;`, `g,`, `'.`, `'^`), and `gi`, all now individually tracked in `PARITY.md`.
+- Fixed `{` overshooting: from inside a paragraph it jumped past the blank line directly above to an earlier one. It now stops at the nearest blank line, as in Vim.
+- Fixed `gi` resuming insert one column left of where the last insert session stopped. It now continues exactly where typing ended, including after `A` at the end of a line.
 - Fixed `~` to advance the cursor past the last toggled character, as in Vim.
 - Extended Vim oracle coverage to the editing core: the case operators (`gu`, `gU`, `g~` and their line forms), `~`, `X`, `s`, `S`, `gp`, `gP`, `J`, and `gJ` are now verified against real Neovim and individually tracked in `PARITY.md`.
 - Corrected the docs: `.` (repeat last change) was listed as implemented but only shows a status note today. It moved to the roadmap.

--- a/PARITY.md
+++ b/PARITY.md
@@ -10,13 +10,13 @@ the test suite enforces, so it cannot drift from what is actually verified.
 ## Summary
 
 - **333 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **35 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **106 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 98 verified against real Neovim (v0.11.3) by the Vim oracle
+- **123 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 115 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **279 oracle cases**: motions (115), editing (104), insert-entry (11), open-line (20), replace (27), undo-redo (2)
+- **301 oracle cases**: motions (136), editing (105), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
-- **142 of 432 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **162 of 432 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -57,6 +57,23 @@ claim protection.
 | `]}` | Move to next unmatched } | `unmatched close brace` |
 | `[(` | Move to previous unmatched ( | `unmatched open paren skips nested pair` |
 | `])` | Move to next unmatched ) | `unmatched close paren skips nested pair` |
+| `{` | Move to previous paragraph | `paragraph backward` |
+| `}` | Move to next paragraph | `paragraph forward` |
+| `(` | Move to previous sentence | `sentence backward` |
+| `)` | Move to next sentence | `sentence forward` |
+| `-` | Move to first non-blank of previous line | `first non blank of previous line` |
+| `{n}G` | Move to line n | `goto line with count` |
+| `{n}go` | Go to byte n of the file | `go to byte` |
+| `m{a-z}` | Set local mark | `jump to mark line` |
+| `'{a-z}` | Jump to line of local mark | `jump to mark line` |
+| `<C-o>` | Jump to older position | `jump list older position` |
+| `<C-i>` | Jump to newer position | `jump list newer position` |
+| `''` | Jump to the line before the last jump | `jump back to line before last jump` |
+| `g;` | Jump to older change position | `older change position` |
+| `g,` | Jump to newer change position | `newer change position` |
+| `'.` | Jump to the line of the last change | `line of last change` |
+| `'^` | Jump to the line of the last insert | `line of last insert` |
+| `gi` | Go to last insert position and enter insert mode | `go to last insert position and insert` |
 | `gm` | Move to middle of the screen line | `gm on short line` |
 | `go` | Go to [count] byte of the buffer | `go to byte` |
 | `gj` | Move down by display line | `display line down without wrap` |
@@ -169,25 +186,10 @@ like `dw` are tracked as single inventory entries, so their building-block
 rows may already be covered compositionally.)
 
 <details>
-<summary>290 untracked rows</summary>
+<summary>270 untracked rows</summary>
 
 | Keybind | Behavior |
 |---------|----------|
-| `-` | Move to first non-blank of previous line |
-| `{` | Move to previous blank line (paragraph) |
-| `}` | Move to next blank line (paragraph) |
-| `(` | Move to previous sentence |
-| `)` | Move to next sentence |
-| `{n}G` | Move to line n (e.g., `50G` goes to line 50) |
-| `{n}go` | Go to byte n of the file |
-| `Ctrl+o` | Jump to older position |
-| `Ctrl+i` | Jump to newer position |
-| `''` | Jump to the line before the last jump |
-| `g;` | Jump to older change position |
-| `g,` | Jump to newer change position |
-| `'.` | Jump to the line of the last change |
-| `'^` | Jump to the line of the last insert |
-| `gi` | Go to last insert position and enter insert mode |
 | `>` | Indent right |
 | `<` | Indent left |
 | `=` | Auto-indent |
@@ -213,9 +215,7 @@ rows may already be covered compositionally.)
 | `Ctrl+r {reg}` | Insert register contents |
 | `Up` | Navigate to previous search history entry |
 | `Down` | Navigate to next search history entry |
-| `m{a-z}` | Set local mark (buffer-specific) |
 | `m{A-Z}` | Set global mark (works across files) |
-| `'{a-z}` | Jump to line of local mark |
 | `` `{a-z} `` | Jump to exact position of local mark |
 | `'{A-Z}` | Jump to line of global mark |
 | `` `{A-Z} `` | Jump to exact position of global mark |
@@ -226,14 +226,12 @@ rows may already be covered compositionally.)
 | `{n}@{a-z}` | Play macro n times |
 | `:Macros` | Open all recorded macros as notation in a read-only `[macros]` buffer |
 | `:MacroEdit {a-z}` | Edit one register's notation in a `[macro-{register}]` scratch buffer; `:w` applies it back to the register (empty content clears it) |
-| `gi` | Go to last insert position and enter insert mode |
 | `Esc` or `Ctrl+[` | Exit insert mode |
 | `Backspace` | Delete character before cursor |
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+t` | Increase indent of current line |
 | `Ctrl+a` | Insert previously inserted text |
 | `Ctrl+r {reg}` | Insert contents of register |
-| `Ctrl+o` | Run one normal-mode command, then return to insert |
 | `Ctrl+l` | Accept visible Copilot suggestion |
 | `Alt+]` | Next visible Copilot suggestion |
 | `Alt+[` | Previous visible Copilot suggestion |
@@ -367,7 +365,6 @@ rows may already be covered compositionally.)
 | `Esc` / `Ctrl+[` / `q` | Close explorer |
 | `Tab` | Toggle expand/collapse |
 | `?` | Show explorer keymaps |
-| `-` | Go to parent directory |
 | `Ctrl+l` | Focus editor and keep explorer open |
 | `>` | Widen explorer sidebar |
 | `<` | Narrow explorer sidebar |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -5514,9 +5514,14 @@ impl Editor {
     /// Exit to normal mode
     pub fn enter_normal_mode(&mut self) {
         if self.mode == Mode::Insert {
+            // Vim's `^` mark: where insert STOPPED, captured before the Esc
+            // cursor shift so gi resumes typing at exactly that spot (the
+            // column may be one past the last character).
+            self.last_insert_position = Some((self.cursor.line, self.cursor.col));
             self.replay_pending_visual_block_edit();
             self.finish_insert_session();
         } else if self.mode == Mode::Replace {
+            self.last_insert_position = Some((self.cursor.line, self.cursor.col));
             self.finish_replace_session();
         }
 

--- a/src/input/motion.rs
+++ b/src/input/motion.rs
@@ -539,11 +539,9 @@ pub fn apply_motion(
                 // Move back one line to start
                 l = l.saturating_sub(1);
 
-                // Skip current blank lines
-                while l > 0 && is_blank_line(buffer, l) {
-                    l -= 1;
-                }
-                // Skip non-blank lines until we find a blank line
+                // Vim stops at the first blank line above the cursor: if the
+                // line immediately above is blank, that IS the boundary.
+                // Only non-blank lines are skipped on the way up.
                 while l > 0 && !is_blank_line(buffer, l) {
                     l -= 1;
                 }

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -93,6 +93,60 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Move to previous method/function end (tree-sitter)",
         "method_motion_ends_land_on_closing_brace",
     ),
+    // Motions, marks, and jump/change-list batch.
+    vim_oracle("{", "Move to previous paragraph", "paragraph backward"),
+    vim_oracle("}", "Move to next paragraph", "paragraph forward"),
+    vim_oracle("(", "Move to previous sentence", "sentence backward"),
+    vim_oracle(")", "Move to next sentence", "sentence forward"),
+    vim_oracle(
+        "-",
+        "Move to first non-blank of previous line",
+        "first non blank of previous line",
+    ),
+    vim_oracle("{n}G", "Move to line n", "goto line with count"),
+    vim_oracle("{n}go", "Go to byte n of the file", "go to byte"),
+    vim_oracle("m{a-z}", "Set local mark", "jump to mark line"),
+    vim_oracle("'{a-z}", "Jump to line of local mark", "jump to mark line"),
+    vim_oracle(
+        "<C-o>",
+        "Jump to older position",
+        "jump list older position",
+    ),
+    vim_oracle(
+        "<C-i>",
+        "Jump to newer position",
+        "jump list newer position",
+    ),
+    vim_oracle(
+        "''",
+        "Jump to the line before the last jump",
+        "jump back to line before last jump",
+    ),
+    vim_oracle(
+        "g;",
+        "Jump to older change position",
+        "older change position",
+    ),
+    vim_oracle(
+        "g,",
+        "Jump to newer change position",
+        "newer change position",
+    ),
+    vim_oracle(
+        "'.",
+        "Jump to the line of the last change",
+        "line of last change",
+    ),
+    vim_oracle(
+        "'^",
+        "Jump to the line of the last insert",
+        "line of last insert",
+    ),
+    vim_oracle(
+        "gi",
+        "Go to last insert position and enter insert mode",
+        "go to last insert position and insert",
+    ),
     vim_oracle(
         "gm",
         "Move to middle of the screen line",

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7632,11 +7632,16 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
 
         KeyAction::GotoLastInsert => {
             if let Some((line, col)) = editor.last_insert_position {
-                editor.cursor.line = line;
-                editor.cursor.col = col;
-                editor.clamp_cursor();
-                editor.scroll_to_cursor();
                 editor.enter_insert_mode();
+                if editor.mode == Mode::Insert {
+                    // Clamp with insert-mode rules: the stored column may be
+                    // one past the line's last character (e.g. after `A`),
+                    // which normal-mode clamping would pull back.
+                    let max_line = editor.buffer().addressable_line_count().saturating_sub(1);
+                    editor.cursor.line = line.min(max_line);
+                    editor.cursor.col = col.min(editor.buffer().line_len(editor.cursor.line));
+                    editor.scroll_to_cursor();
+                }
             } else {
                 editor.set_status("No previous insert position");
             }

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -714,6 +714,115 @@ const MOTION_CASES: &[OracleCase] = &[
         initial_text: "alpha\nbeta\n",
         keys: "99go",
     },
+    // Paragraph, sentence, and previous-line motions.
+    OracleCase {
+        name: "paragraph forward",
+        initial_text: "one\ntwo\n\nthree\nfour\n\nfive\n",
+        keys: "}",
+    },
+    OracleCase {
+        name: "counted paragraph forward",
+        initial_text: "one\ntwo\n\nthree\nfour\n\nfive\n",
+        keys: "2}",
+    },
+    OracleCase {
+        name: "paragraph backward",
+        initial_text: "one\ntwo\n\nthree\nfour\n\nfive\n",
+        keys: "G{",
+    },
+    OracleCase {
+        name: "counted paragraph backward",
+        initial_text: "one\ntwo\n\nthree\nfour\n\nfive\n",
+        keys: "G2{",
+    },
+    OracleCase {
+        name: "sentence forward",
+        initial_text: "One two. Three four. Five six.\n",
+        keys: ")",
+    },
+    OracleCase {
+        name: "counted sentence forward",
+        initial_text: "One two. Three four. Five six.\n",
+        keys: "2)",
+    },
+    OracleCase {
+        name: "sentence backward",
+        initial_text: "One two. Three four. Five six.\n",
+        keys: "$(",
+    },
+    OracleCase {
+        name: "counted sentence backward",
+        initial_text: "One two. Three four. Five six.\n",
+        keys: "$2(",
+    },
+    OracleCase {
+        name: "first non blank of previous line",
+        initial_text: "  one\n    two\n  three\n",
+        keys: "G-",
+    },
+    OracleCase {
+        name: "counted first non blank of previous line",
+        initial_text: "  one\n    two\n  three\n",
+        keys: "G2-",
+    },
+    OracleCase {
+        name: "goto line with count",
+        initial_text: "a\n  b\nc\nd\ne\n",
+        keys: "2G",
+    },
+    OracleCase {
+        name: "goto line beyond end clamps",
+        initial_text: "a\nb\nc\n",
+        keys: "9G",
+    },
+    // Local marks: ' jumps to the line's first non-blank, backtick to the
+    // exact column.
+    OracleCase {
+        name: "jump to mark line",
+        initial_text: "alpha\n  beta\ngamma\n",
+        keys: "jllmagg'a",
+    },
+    OracleCase {
+        name: "jump to mark exact position",
+        initial_text: "alpha\n  beta\ngamma\n",
+        keys: "jllmagg`a",
+    },
+    // Jump and change lists.
+    OracleCase {
+        name: "jump back to line before last jump",
+        initial_text: "one\ntwo\nthree\nfour\n",
+        keys: "jG''",
+    },
+    OracleCase {
+        name: "jump list older position",
+        initial_text: "one\ntwo\nthree\nfour\n",
+        keys: "G<C-o>",
+    },
+    OracleCase {
+        name: "jump list newer position",
+        initial_text: "one\ntwo\nthree\nfour\n",
+        keys: "G<C-o><C-i>",
+    },
+    OracleCase {
+        name: "older change position",
+        initial_text: "one\ntwo\nthree\n",
+        keys: "xjxggg;",
+    },
+    OracleCase {
+        name: "newer change position",
+        initial_text: "one\ntwo\nthree\n",
+        keys: "xjxggg;g;g,",
+    },
+    OracleCase {
+        name: "line of last change",
+        initial_text: "alpha\n  beta\ngamma\n",
+        keys: "jxgg'.",
+    },
+    OracleCase {
+        name: "line of last insert",
+        initial_text: "alpha\n  beta\ngamma\n",
+        keys: "jA!<Esc>gg'^",
+    },
     // Display-line motions with wrap off fall back to their file-line
     // equivalents (gj≈j, g0≈0, g$≈$, g^≈^), which is also Vim's behavior.
     // Wrapped-segment landings can't be oracle-compared (Nevi's text area

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -476,6 +476,12 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "abc def\n",
         keys: "xww.",
     },
+    // gi returns to where insert mode last stopped and resumes inserting.
+    OracleCase {
+        name: "go to last insert position and insert",
+        initial_text: "alpha\nbeta\n",
+        keys: "jA!<Esc>gggix<Esc>",
+    },
     // Plain joins (the last-line no-op pins above cover the boundary).
     OracleCase {
         name: "join lines with space",


### PR DESCRIPTION
PR covers:
Third coverage batch, working through the untracked rows in PARITY.md. This one covers the navigation core: paragraph and sentence motions, counted `G`, `-`, local marks, the jump and change lists, and `gi`.

## What's covered

23 new oracle cases, all verified against real Neovim v0.11.3:

- `{` and `}` with counts, `(` and `)` with counts, `-` with counts
- `{n}G` including a count past the end of the file
- Local marks: `ma` then `'a` (line) and `` `a `` (exact column)
- Jump list: `''`, `Ctrl+o`, and `Ctrl+o` followed by `Ctrl+i`
- Change list: `g;`, and a `g;` `g;` `g,` round trip, plus `'.` and `'^`
- `gi` resuming insert where the last session stopped

Plus 17 inventory entries tying the documented rows to these cases. PARITY.md now tracks 162 of 432 documented rows with a 123-keybind inventory.

## Bugs found by the new cases

Both fixed here:

- `{` overshot. From inside a paragraph it skipped past the blank line directly above the cursor and landed on an earlier one. Vim stops at the nearest blank line. The fix removes a skip loop rather than adding one.
- `gi` resumed insert one column to the left of where typing stopped. The position was recorded when entering insert mode, but Vim's `^` mark is where insert ended, one column right of the cursor after Esc. `A!<Esc>` then `gi` was inserting before the `!` instead of after it. The jump also now clamps with insert-mode rules, since the stored column can sit one past the line's last character.
