### PR TITLE
feat: add mouse support and ctrl-e/ctrl-y scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Vim Compatibility
 
+- The mouse now works like nvim with `mouse=nvi`: the wheel scrolls the file instead of the terminal scrollback, targeting the pane under the pointer, 3 lines per tick. Horizontal wheel scrolls 6 columns with wrap off. Left click focuses a pane and moves the cursor (insert mode stays insert, a plain click drops visual mode), the wheel and clicks also drive the explorer selection, and the wheel scrolls the finder and markdown previews. On by default; `mouse = false` under `[editor]` or `:set nomouse` / `:set mouse=` turns it off, which also makes `mouse` the first option `:set` actually applies. While captured, terminal-native selection needs the terminal's bypass key (Option in iTerm2, Shift elsewhere). (#274)
+- Added `Ctrl+e` / `Ctrl+y` to scroll the view one line (or a count of lines) without moving the cursor until it would leave the screen. Verified against real Neovim in the oracle suite, including the scrolloff edge cases at the top and bottom of the file.
 - `cw` and `cW` now follow Vim's special case (`:h cw`): on a non-blank they change only up to the end of the word, leaving the trailing whitespace in place, and on the last character of a word they change just that character. On whitespace they still behave like `dw` plus insert. (#272)
 - Added the method motions `[m`, `]m`, `[M`, and `]M`. They jump between tree-sitter function boundaries instead of using Vim's brace heuristic, so they land on real functions and methods in Rust-style code. They work with operators (`d]m`, `y[m`) and counts, and do nothing in files without tree-sitter support.
 - Fixed `~` to advance the cursor past the last toggled character, as in Vim.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,36 @@
+# Nevi
+
+A Neovim-inspired terminal editor where existing vim/nvim muscle memory works unchanged. Terms below are the canonical vocabulary for its editing and rendering model.
+
+## Language
+
+### Mouse & scrolling
+
+**Mouse capture**:
+The terminal handing mouse events to nevi instead of acting on them itself (escape-code mouse reporting). While active, terminal-native selection needs the terminal's bypass key (Option in iTerm2).
+_Avoid_: mouse mode, mouse reporting
+
+**Viewport scroll**:
+Moving a pane's visible window over the buffer without moving the cursor; the cursor is dragged along only when it would leave the visible area. What the wheel and `<C-e>`/`<C-y>` do.
+_Avoid_: cursor scroll, paging
+
+**Scroll target**:
+The pane the pointer is over — wheel events scroll it, not the focused pane.
+_Avoid_: active pane (that's the focused one)
+
+**Wheel tick**:
+One discrete scroll-wheel notch as delivered by the terminal; scrolls the target 3 lines vertically.
+
+### Panes & rendering
+
+**Pane**:
+One rectangular editor window in a split layout, owning its own cursor, viewport offset, and buffer reference. The Editor mirrors the active pane's state.
+_Avoid_: window, split (a split is the act, the pane is the thing)
+
+**Viewport offset**:
+The buffer line at the top of a pane's visible area.
+_Avoid_: scroll position, top line
+
+**Damage**:
+The per-frame record of what must repaint — full frame, or specific rows. Any viewport offset change is full damage.
+_Avoid_: dirty flags

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -273,9 +273,29 @@ When specifying keys, use these formats:
 | `Ctrl+b` | Scroll page up |
 | `Ctrl+d` | Scroll half page down |
 | `Ctrl+u` | Scroll half page up |
+| `Ctrl+e` | Scroll view down one line (cursor stays put) |
+| `Ctrl+y` | Scroll view up one line (cursor stays put) |
 | `zz` | Center cursor on screen |
 | `zt` | Move cursor line to top of screen |
 | `zb` | Move cursor line to bottom of screen |
+
+### Mouse
+
+The mouse works like nvim's `mouse=nvi` (on by default). Turn it off with
+`mouse = false` under `[editor]`, or at runtime with `:set nomouse` /
+`:set mouse=` (any flags, like `:set mouse=a`, turn it back on).
+
+| Input | Action |
+|-------|--------|
+| Wheel | Scroll the pane under the pointer 3 lines (cursor stays put) |
+| Horizontal wheel | Scroll 6 columns (with wrap off) |
+| Left click | Focus that pane and move the cursor there |
+| Wheel / click on explorer | Move / set the selection |
+| Wheel in finder | Scroll the preview pane |
+| Wheel in markdown preview | Scroll the preview |
+
+While the mouse is captured, use your terminal's bypass modifier for native
+text selection and scrollback: Option on iTerm2, Shift on most others.
 
 ### Jump List
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -10,13 +10,13 @@ the test suite enforces, so it cannot drift from what is actually verified.
 ## Summary
 
 - **329 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **39 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **78 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 76 verified against real Neovim (v0.11.3) by the Vim oracle
+- **80 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 78 verified against real Neovim (v0.11.3) by the Vim oracle
   - 1 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **233 oracle cases**: motions (113), editing (60), insert-entry (11), open-line (20), replace (27), undo-redo (2)
+- **241 oracle cases**: motions (121), editing (60), insert-entry (11), open-line (20), replace (27), undo-redo (2)
 - **0 tracked coverage gaps**
-- **108 of 426 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **112 of 428 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -109,6 +109,8 @@ claim protection.
 | `<C-b>` | Scroll page up | `page up` |
 | `<C-d>` | Scroll half page down | `half page down` |
 | `<C-u>` | Scroll half page up | `half page up` |
+| `<C-e>` | Scroll view down one line | `line scroll down` |
+| `<C-y>` | Scroll view up one line | `line scroll up` |
 | `zz` | Center cursor line | `center cursor line` |
 | `zt` | Move cursor line to top | `cursor line to top` |
 | `zb` | Move cursor line to bottom | `cursor line to bottom` |
@@ -141,7 +143,7 @@ like `dw` are tracked as single inventory entries, so their building-block
 rows may already be covered compositionally.)
 
 <details>
-<summary>318 untracked rows</summary>
+<summary>316 untracked rows</summary>
 
 | Keybind | Behavior |
 |---------|----------|
@@ -200,7 +202,6 @@ rows may already be covered compositionally.)
 | `#` | Search word under cursor backward |
 | `gn` | Search forward and select match |
 | `gN` | Search backward and select match |
-| `Ctrl+e` | Move to end of search input |
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+r {reg}` | Insert register contents |
 | `Up` | Navigate to previous search history entry |
@@ -378,7 +379,6 @@ rows may already be covered compositionally.)
 | `c` | Copy selected item |
 | `]h` | Go to next harpoon file |
 | `[h` | Go to previous harpoon file |
-| `Ctrl+e` | Move to end of command line |
 | `Ctrl+w` | Delete word before cursor |
 | `Ctrl+r {reg}` | Insert register contents |
 | `Ctrl+v` / `Ctrl+q` | Insert the next key literally |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A fast, Neovim-inspired terminal editor written in Rust.
 
 *Your vim muscle memory, without the configuration overhead.*
 
-![Nevi demo — fuzzy file finder with preview, vim motions, Harpoon quick-switch, live grep, and live theme switching](nevi-demo.gif)
+![Nevi demo — file explorer with git status and diagnostic badges, LSP hover and goto-definition, vim motions, live grep, and live theme switching](nevi-demo.gif)
 
 > **Tip:** To see every keybinding available in Nevi, run `:Keymaps` (or press `<Space>fk`) — a searchable list with a description for each one.
 > See [CHANGELOG.md](CHANGELOG.md) for release notes and upgrade highlights.
@@ -271,6 +271,10 @@ tab_width = 2
 format_on_save = true
 relative_numbers = true
 scroll_off = 8
+# Wheel scrolls the buffer, clicks move the cursor (like nvim's mouse=nvi).
+# Set to false to leave the mouse to the terminal; at runtime `:set nomouse`
+# and `:set mouse=` toggle it too.
+mouse = true
 
 [theme]
 colorscheme = "onedark"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -131,6 +131,11 @@ pub struct EditorSettings {
     /// Use Nerd Font icons in explorer (default: true)
     /// Set to false to use Unicode fallback icons
     pub use_nerd_font_icons: bool,
+    /// Capture the mouse: wheel scrolls the view, clicks move the cursor
+    /// (default: true, matching nvim's `mouse=nvi`). When enabled,
+    /// terminal-native text selection needs the terminal's bypass modifier
+    /// (Option in iTerm2, Shift in most others). See ADR 0001.
+    pub mouse: bool,
 }
 
 impl Default for EditorSettings {
@@ -149,6 +154,7 @@ impl Default for EditorSettings {
             autosave: AutosaveMode::Off,
             autosave_delay_ms: 1000,
             use_nerd_font_icons: true,
+            mouse: true,
         }
     }
 }
@@ -1762,6 +1768,15 @@ fn merge_explorer_mappings(user_mappings: &[ExplorerModeMapping]) -> Vec<Explore
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mouse_defaults_on_and_toml_can_disable() {
+        assert!(EditorSettings::default().mouse);
+        let s: Settings = toml::from_str("[editor]\nmouse = false\n").expect("parse [editor]");
+        assert!(!s.editor.mouse);
+        let s: Settings = toml::from_str("").expect("parse empty");
+        assert!(s.editor.mouse);
+    }
 
     #[test]
     fn ui_style_resolution_combinations() {

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -185,6 +185,11 @@ impl Rect {
             height,
         }
     }
+
+    /// Whether the screen cell (x, y) falls inside this region.
+    pub fn contains(&self, x: u16, y: u16) -> bool {
+        x >= self.x && x < self.x + self.width && y >= self.y && y < self.y + self.height
+    }
 }
 
 /// A pane/window in the editor showing a buffer
@@ -3287,6 +3292,110 @@ impl Editor {
     }
 
     /// Switch to the previous pane
+    /// Focus a pane by index (mouse click), preserving each pane's state.
+    /// Unlike the cycling commands this stays quiet: vim does not announce
+    /// window changes made with the mouse.
+    pub fn focus_pane(&mut self, pane_idx: usize) {
+        if pane_idx < self.panes.len() && pane_idx != self.active_pane {
+            self.save_pane_state();
+            self.active_pane = pane_idx;
+            self.load_pane_state();
+        }
+    }
+
+    /// Left click inside a pane: focus it and move the cursor to the clicked
+    /// cell, like nvim with 'mouse' enabled. A plain click drops visual mode;
+    /// insert mode stays insert. The view never scrolls (mouse positioning
+    /// ignores 'scrolloff'), so only the cursor and pane mirror change.
+    pub fn click_at(&mut self, pane_idx: usize, screen_col: u16, screen_row: u16) {
+        self.focus_pane(pane_idx);
+        if matches!(
+            self.mode,
+            Mode::Visual | Mode::VisualLine | Mode::VisualBlock
+        ) {
+            self.exit_visual_mode();
+        }
+        if let Some((line, col)) = self.position_for_click(pane_idx, screen_col, screen_row) {
+            self.cursor.line = line;
+            self.cursor.col = col;
+            self.desired_col = None;
+            if self.active_pane < self.panes.len() {
+                self.panes[self.active_pane].cursor = self.cursor;
+                self.panes[self.active_pane].desired_col = None;
+            }
+        }
+    }
+
+    /// Map a screen cell inside a pane to a buffer (line, col), mirroring
+    /// what rendering shows: gutter, h_offset (nowrap) or wrapped display
+    /// segments (wrap). Clicks in the gutter map to the row's first column;
+    /// clicks past the end of text clamp like vim's normal-mode cursor.
+    fn position_for_click(
+        &self,
+        pane_idx: usize,
+        screen_col: u16,
+        screen_row: u16,
+    ) -> Option<(usize, usize)> {
+        let pane = self.panes.get(pane_idx)?;
+        if !pane.rect.contains(screen_col, screen_row) {
+            return None;
+        }
+        let buffer = self.buffers.get(pane.buffer_idx)?;
+        let text_width = self.pane_text_area_width(pane_idx);
+        let gutter = (pane.rect.width as usize).saturating_sub(text_width);
+        let cell = ((screen_col - pane.rect.x) as usize).saturating_sub(gutter);
+        let row = (screen_row - pane.rect.y) as usize;
+        let last_line = last_addressable_line(buffer);
+        let tab_width = self.get_effective_tab_width();
+
+        let line_text = |line: usize| {
+            let mut text = buffer.line(line).map(|l| l.to_string()).unwrap_or_default();
+            // Ropey lines keep their newline; the cursor must not land on it.
+            while text.ends_with(['\n', '\r']) {
+                text.pop();
+            }
+            text
+        };
+
+        if self.settings.editor.wrap {
+            let wrap_width = self.settings.editor.wrap_width.min(text_width);
+            let mut line = pane.viewport_offset.min(last_line);
+            let mut rows_left = row;
+            loop {
+                let text = line_text(line);
+                let segments = Self::display_line_segments(&text, wrap_width, tab_width);
+                if rows_left < segments.len() {
+                    let col = Self::display_col_to_buffer_col(
+                        &text,
+                        segments[rows_left],
+                        cell,
+                        tab_width,
+                    );
+                    return Some((line, col));
+                }
+                if line == last_line {
+                    // Clicked below the end of the buffer: last segment.
+                    let segment = *segments.last()?;
+                    let col = Self::display_col_to_buffer_col(&text, segment, cell, tab_width);
+                    return Some((line, col));
+                }
+                rows_left -= segments.len();
+                line += 1;
+            }
+        } else {
+            let line = pane.viewport_offset.saturating_add(row).min(last_line);
+            let text = line_text(line);
+            let len = text.chars().count();
+            let segment = DisplayLineSegment {
+                start_col: pane.h_offset.min(len),
+                end_col: len,
+                indent_width: 0,
+            };
+            let col = Self::display_col_to_buffer_col(&text, segment, cell, tab_width);
+            Some((line, col))
+        }
+    }
+
     pub fn prev_pane(&mut self) {
         if self.panes.len() > 1 {
             self.save_pane_state();
@@ -4248,18 +4357,22 @@ impl Editor {
 
     /// Calculate the text area width (columns available for text) for the active pane
     fn text_area_width(&self) -> usize {
-        let pane_width = if self.active_pane < self.panes.len() {
-            self.panes[self.active_pane].rect.width as usize
+        self.pane_text_area_width(self.active_pane)
+    }
+
+    /// Text area width for an arbitrary pane (its rect minus sign column,
+    /// line numbers, and separator).
+    fn pane_text_area_width(&self, pane_idx: usize) -> usize {
+        let (pane_width, buffer) = if pane_idx < self.panes.len() {
+            (
+                self.panes[pane_idx].rect.width as usize,
+                &self.buffers[self.panes[pane_idx].buffer_idx],
+            )
         } else {
-            self.term_width as usize
+            (self.term_width as usize, self.buffer())
         };
         const SIGN_COLUMN_WIDTH: usize = 2;
-        let line_num_width = self
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
+        let line_num_width = buffer.addressable_line_count().to_string().len().max(3);
         if self.settings.editor.line_numbers {
             pane_width.saturating_sub(SIGN_COLUMN_WIDTH + line_num_width + 1)
         } else {
@@ -10536,6 +10649,103 @@ impl Editor {
         self.finish_page_scroll();
     }
 
+    /// Scroll one pane's viewport by `delta` lines (mouse wheel, <C-e>/<C-y>).
+    /// Vim semantics: the view moves, the cursor moves only when it would
+    /// leave the visible area, kept `scroll_off` lines from the edge; the
+    /// bottom margin collapses when the last line is visible, and the view
+    /// can scroll until the last line sits at the top. The active pane goes
+    /// through the Editor mirror; inactive panes are mutated directly.
+    pub fn scroll_pane_viewport(&mut self, pane_idx: usize, delta: isize) {
+        if pane_idx >= self.panes.len() {
+            return;
+        }
+        let buffer_idx = self.panes[pane_idx].buffer_idx;
+        let last_line = last_addressable_line(&self.buffers[buffer_idx]);
+        let rows = (self.panes[pane_idx].rect.height as usize).max(1);
+        let scroll_off = self.settings.editor.scroll_off;
+
+        let offset = self.panes[pane_idx]
+            .viewport_offset
+            .saturating_add_signed(delta)
+            .min(last_line);
+        // Vim relaxes the scrolloff margin at the buffer boundaries: with the
+        // view at the top of the file the cursor may sit inside the margin
+        // (mirrored below for the last line at the bottom).
+        let top_margin = if offset == 0 {
+            0
+        } else {
+            scroll_off.min(rows.saturating_sub(1) / 2)
+        };
+        let visible_bottom = offset.saturating_add(rows.saturating_sub(1)).min(last_line);
+        let bottom_margin = if visible_bottom == last_line {
+            0
+        } else {
+            scroll_off.min(rows / 2)
+        };
+        let lo = offset.saturating_add(top_margin).min(visible_bottom);
+        let hi = visible_bottom.saturating_sub(bottom_margin).max(lo);
+
+        if pane_idx == self.active_pane {
+            self.viewport_offset = offset;
+            self.cursor.line = self.cursor.line.clamp(lo, hi);
+            self.finish_page_scroll();
+        } else {
+            let line = self.panes[pane_idx].cursor.line.clamp(lo, hi);
+            let max_col = self.buffers[buffer_idx].line_len(line).saturating_sub(1);
+            let pane = &mut self.panes[pane_idx];
+            pane.viewport_offset = offset;
+            pane.cursor.line = line;
+            pane.cursor.col = pane.cursor.col.min(max_col);
+        }
+    }
+
+    /// Scroll one pane's view horizontally by `delta` columns (horizontal
+    /// wheel). No-op with wrap on. The cursor is dragged along only when it
+    /// would leave the visible columns; the view clamps to the longest
+    /// visible line so it cannot scroll into permanently blank space.
+    pub fn scroll_pane_columns(&mut self, pane_idx: usize, delta: isize) {
+        if pane_idx >= self.panes.len() || self.settings.editor.wrap {
+            return;
+        }
+        let width = self.pane_text_area_width(pane_idx).max(1);
+        let buffer_idx = self.panes[pane_idx].buffer_idx;
+        let rows = (self.panes[pane_idx].rect.height as usize).max(1);
+        let top = self.panes[pane_idx].viewport_offset;
+        let buffer = &self.buffers[buffer_idx];
+        let last_line = last_addressable_line(buffer);
+        // Bounded scan: visible rows only, per the hot-path rules.
+        let longest_visible = (top..=(top + rows - 1).min(last_line))
+            .map(|line| buffer.line_len(line))
+            .max()
+            .unwrap_or(0);
+        let max_offset = longest_visible.saturating_sub(1);
+
+        let offset = self.panes[pane_idx]
+            .h_offset
+            .saturating_add_signed(delta)
+            .min(max_offset);
+        let lo = offset;
+        let hi = offset + width - 1;
+
+        if pane_idx == self.active_pane {
+            let line_cap = self.buffers[buffer_idx]
+                .line_len(self.cursor.line)
+                .saturating_sub(1);
+            self.h_offset = offset;
+            self.cursor.col = self.cursor.col.clamp(lo, hi).min(line_cap);
+            // finish_page_scroll would re-derive h_offset from the cursor,
+            // undoing the scroll; sync the pane mirror directly instead.
+            self.panes[pane_idx].h_offset = self.h_offset;
+            self.panes[pane_idx].cursor = self.cursor;
+        } else {
+            let line = self.panes[pane_idx].cursor.line;
+            let line_cap = self.buffers[buffer_idx].line_len(line).saturating_sub(1);
+            let pane = &mut self.panes[pane_idx];
+            pane.h_offset = offset;
+            pane.cursor.col = pane.cursor.col.clamp(lo, hi).min(line_cap);
+        }
+    }
+
     fn finish_page_scroll(&mut self) {
         self.clamp_cursor();
         if !self.settings.editor.wrap {
@@ -11506,6 +11716,7 @@ mod tests {
     mod open_line;
     mod replace;
     mod screen_position;
+    mod viewport_scroll;
 
     use super::{Editor, JumpList, Mode, SearchDirection, SplitLayout};
     use crate::input::Motion;

--- a/src/editor/tests/viewport_scroll.rs
+++ b/src/editor/tests/viewport_scroll.rs
@@ -1,0 +1,97 @@
+use crate::editor::Editor;
+
+fn editor_with_lines(count: usize) -> Editor {
+    let mut editor = Editor::default();
+    let content: String = (1..=count).map(|i| format!("line{i}\n")).collect();
+    editor.replace_buffer_content(&content);
+    editor.set_size(120, 40); // text_rows = 38
+    editor.update_pane_rects();
+    editor
+}
+
+fn editor_with_vsplit() -> Editor {
+    let mut editor = editor_with_lines(100);
+    editor.vsplit(None).expect("vsplit");
+    editor.update_pane_rects();
+    editor
+}
+
+#[test]
+fn scroll_pane_viewport_moves_view_not_cursor() {
+    let mut editor = editor_with_lines(100);
+    editor.cursor.line = 20;
+    editor.scroll_to_cursor();
+    let before = editor.cursor.line;
+
+    editor.scroll_pane_viewport(editor.active_pane_idx(), 3);
+
+    assert_eq!(editor.viewport_offset, 3);
+    assert_eq!(editor.cursor.line, before);
+}
+
+#[test]
+fn scroll_pane_viewport_drags_cursor_at_view_edge() {
+    let mut editor = editor_with_lines(100);
+    editor.cursor.line = 0;
+
+    editor.scroll_pane_viewport(editor.active_pane_idx(), 3);
+
+    assert_eq!(editor.viewport_offset, 3);
+    assert_eq!(
+        editor.cursor.line,
+        3 + editor.settings.editor.scroll_off,
+        "cursor pulled down to top margin like <C-e> in vim"
+    );
+}
+
+#[test]
+fn scroll_pane_viewport_clamps_at_ends() {
+    let mut editor = editor_with_lines(100);
+
+    editor.scroll_pane_viewport(editor.active_pane_idx(), -5);
+    assert_eq!(editor.viewport_offset, 0);
+
+    editor.scroll_pane_viewport(editor.active_pane_idx(), 10_000);
+    // Vim lets <C-e> run until the last line sits at the top of the window.
+    assert_eq!(editor.viewport_offset, 99);
+    assert_eq!(editor.cursor.line, 99);
+}
+
+#[test]
+fn scroll_up_at_file_top_leaves_cursor_inside_margin() {
+    // Oracle regression (`5Gzz20<C-y>`): with the view already at the top,
+    // vim does not drag a cursor sitting inside the scrolloff margin.
+    let mut editor = editor_with_lines(100);
+    editor.cursor.line = 4;
+
+    editor.scroll_pane_viewport(editor.active_pane_idx(), -20);
+
+    assert_eq!(editor.viewport_offset, 0);
+    assert_eq!(editor.cursor.line, 4);
+}
+
+#[test]
+fn scroll_pane_viewport_syncs_active_pane_mirror() {
+    let mut editor = editor_with_lines(100);
+    let active = editor.active_pane_idx();
+
+    editor.scroll_pane_viewport(active, 7);
+
+    assert_eq!(
+        editor.panes()[active].viewport_offset,
+        editor.viewport_offset
+    );
+    assert_eq!(editor.panes()[active].cursor, editor.cursor);
+}
+
+#[test]
+fn scroll_pane_viewport_on_inactive_pane_leaves_mirror_untouched() {
+    let mut editor = editor_with_vsplit();
+    let inactive = 1 - editor.active_pane_idx();
+    let mirror_before = (editor.viewport_offset, editor.cursor);
+
+    editor.scroll_pane_viewport(inactive, 3);
+
+    assert_eq!(editor.panes()[inactive].viewport_offset, 3);
+    assert_eq!((editor.viewport_offset, editor.cursor), mirror_before);
+}

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -253,6 +253,34 @@ impl FileExplorer {
         }
     }
 
+    /// Scroll offset of the visible window for a list of `list_height` rows,
+    /// keeping the selection roughly centered. Rendering and mouse hit
+    /// testing must share this so a click lands on the row it appears on.
+    pub fn scroll_offset(&self, list_height: usize) -> usize {
+        if self.selected < list_height / 2 {
+            0
+        } else if self.selected >= self.flat_view.len().saturating_sub(list_height / 2) {
+            self.flat_view.len().saturating_sub(list_height)
+        } else {
+            self.selected.saturating_sub(list_height / 2)
+        }
+    }
+
+    /// Select the entry shown on screen row `row` (row 0 is the header).
+    /// Returns false for the header or rows past the last entry.
+    pub fn select_visible_row(&mut self, row: usize, list_height: usize) -> bool {
+        if row == 0 {
+            return false;
+        }
+        let idx = self.scroll_offset(list_height) + (row - 1);
+        if idx < self.flat_view.len() {
+            self.selected = idx;
+            true
+        } else {
+            false
+        }
+    }
+
     /// Move selection to the first visible explorer row.
     pub fn move_to_top(&mut self) {
         self.selected = 0;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -161,6 +161,10 @@ pub enum KeyAction {
     ScrollTop,
     /// Scroll cursor to bottom of screen (zb)
     ScrollBottom,
+    /// Scroll viewport down count lines without moving the cursor (<C-e>)
+    ScrollLineDown(usize),
+    /// Scroll viewport up count lines without moving the cursor (<C-y>)
+    ScrollLineUp(usize),
     /// Repeat last change (.)
     RepeatLastChange,
     /// Paste after cursor
@@ -1037,6 +1041,16 @@ impl InputState {
             }
             (KeyModifiers::CONTROL, KeyCode::Char('b')) => {
                 self.page_motion_or_operator(Motion::PageUp)
+            }
+
+            // <C-e>/<C-y> - scroll the view without moving the cursor
+            (KeyModifiers::CONTROL, KeyCode::Char('e')) => {
+                self.reset();
+                KeyAction::ScrollLineDown(count)
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('y')) => {
+                self.reset();
+                KeyAction::ScrollLineUp(count)
             }
 
             // Insert mode entry (or text object modifier if operator pending)
@@ -2284,6 +2298,26 @@ mod tests {
     #[test]
     fn normal_zz_maps_to_write_quit_if_modified() {
         assert_write_quit_if_modified(&[shift('Z'), shift('Z')]);
+    }
+
+    #[test]
+    fn ctrl_e_and_ctrl_y_map_to_line_scroll_actions_with_counts() {
+        match run(&[ctrl('e')]) {
+            KeyAction::ScrollLineDown(1) => {}
+            other => panic!("expected ScrollLineDown(1), got {:?}", other),
+        }
+        match run(&[key('3'), ctrl('e')]) {
+            KeyAction::ScrollLineDown(3) => {}
+            other => panic!("expected ScrollLineDown(3), got {:?}", other),
+        }
+        match run(&[ctrl('y')]) {
+            KeyAction::ScrollLineUp(1) => {}
+            other => panic!("expected ScrollLineUp(1), got {:?}", other),
+        }
+        match run(&[key('5'), ctrl('y')]) {
+            KeyAction::ScrollLineUp(5) => {}
+            other => panic!("expected ScrollLineUp(5), got {:?}", other),
+        }
     }
 
     #[test]

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -212,6 +212,8 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("<C-b>", "Scroll page up", "page up"),
     vim_oracle("<C-d>", "Scroll half page down", "half page down"),
     vim_oracle("<C-u>", "Scroll half page up", "half page up"),
+    vim_oracle("<C-e>", "Scroll view down one line", "line scroll down"),
+    vim_oracle("<C-y>", "Scroll view up one line", "line scroll up"),
     vim_oracle("zz", "Center cursor line", "center cursor line"),
     vim_oracle("zt", "Move cursor line to top", "cursor line to top"),
     vim_oracle("zb", "Move cursor line to bottom", "cursor line to bottom"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod labeled_jump;
 pub mod lsp;
 pub mod macro_lens;
 pub mod markdown_preview;
+pub mod mouse;
 #[cfg(test)]
 mod parity_report;
 pub mod perf;

--- a/src/main.rs
+++ b/src/main.rs
@@ -686,6 +686,24 @@ fn main() -> anyhow::Result<()> {
                                         terminal_redraw_pending = true;
                                     }
                                 }
+                            } else {
+                                let t_handle_mouse = Instant::now();
+                                let handled = nevi::mouse::handle_mouse_event(&mut editor, mouse);
+                                record_metric!(
+                                    editor,
+                                    profile_stats,
+                                    profile_file,
+                                    "handle_mouse",
+                                    t_handle_mouse.elapsed()
+                                );
+                                if handled {
+                                    // Multiple wheel ticks in one input batch
+                                    // each mutate state here; a single render
+                                    // follows the batch.
+                                    needs_redraw = true;
+                                    redraw_from_input = true;
+                                    last_input_at = Some(Instant::now());
+                                }
                             }
                             if !finish_input_batch_event(
                                 &terminal,

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -1,0 +1,459 @@
+//! Mouse event routing: hit-testing, wheel scrolling, click positioning.
+//!
+//! Terminal mouse capture is enabled by default (see
+//! `docs/adr/0001-mouse-capture-on-by-default.md`); events arrive here from
+//! the main loop's `EditorEvent::Mouse` arm whenever the floating terminal
+//! isn't consuming them.
+
+use crate::editor::{Editor, Mode};
+use crossterm::event::{MouseButton, MouseEvent, MouseEventKind};
+
+/// One wheel tick scrolls 3 lines, matching nvim's `mousescroll=ver:3` and
+/// the floating terminal's MOUSE_SCROLL_LINES.
+const WHEEL_LINES: isize = 3;
+/// Horizontal ticks move 6 columns, matching nvim's `mousescroll=hor:6`.
+const WHEEL_COLS: isize = 6;
+
+/// Pane under the screen cell (col, row), if any. Rects are kept current by
+/// `update_pane_rects`; the bottom two rows (statusline + command line) and
+/// the explorer sidebar are outside every pane rect by construction.
+pub fn pane_at(editor: &Editor, col: u16, row: u16) -> Option<usize> {
+    editor
+        .panes()
+        .iter()
+        .position(|pane| pane.rect.contains(col, row))
+}
+
+/// Route one mouse event to editor state. Returns true when the event was
+/// handled and the frame must repaint. Wheel events scroll the pane under
+/// the pointer (nvim behavior), not the focused pane.
+pub fn handle_mouse_event(editor: &mut Editor, event: MouseEvent) -> bool {
+    let handled = route_event(editor, event);
+    if handled {
+        // Mouse events bypass handle_key, which is where damage is normally
+        // marked full; without this a partial-damage plan captured by an
+        // earlier key could render a stale frame.
+        editor.render_damage.mark_full();
+    }
+    handled
+}
+
+fn route_event(editor: &mut Editor, event: MouseEvent) -> bool {
+    // Overlay gates mirror handle_key's interception order (the floating
+    // terminal is consumed earlier, in the main loop).
+    if editor.markdown_preview.is_some() {
+        let delta = match event.kind {
+            MouseEventKind::ScrollDown => WHEEL_LINES,
+            MouseEventKind::ScrollUp => -WHEEL_LINES,
+            _ => return false,
+        };
+        let visible_rows = crate::terminal::Terminal::markdown_preview_visible_rows(editor).max(1);
+        editor.scroll_markdown_preview(delta, visible_rows);
+        return true;
+    }
+    if editor.references_picker.is_some()
+        || editor.code_actions_picker.is_some()
+        || editor.theme_picker.is_some()
+    {
+        // Small selection pickers stay keyboard-driven.
+        return false;
+    }
+    if editor.mode == Mode::Finder {
+        // The results list follows the selection; the wheel drives the
+        // preview pane regardless of pointer position.
+        match event.kind {
+            MouseEventKind::ScrollDown => editor.finder.scroll_preview_down(WHEEL_LINES as usize),
+            MouseEventKind::ScrollUp => editor.finder.scroll_preview_up(WHEEL_LINES as usize),
+            _ => return false,
+        }
+        return true;
+    }
+    if editor.explorer.visible && event.column <= editor.explorer.width {
+        // A selection list, not a viewport: one row per tick.
+        match event.kind {
+            MouseEventKind::ScrollDown => editor.explorer.move_down(),
+            MouseEventKind::ScrollUp => editor.explorer.move_up(),
+            MouseEventKind::Down(MouseButton::Left) => {
+                let list_height = editor.text_rows().saturating_sub(1);
+                return editor
+                    .explorer
+                    .select_visible_row(event.row as usize, list_height);
+            }
+            _ => return false,
+        }
+        return true;
+    }
+
+    match event.kind {
+        MouseEventKind::ScrollDown => wheel_vertical(editor, event.column, event.row, WHEEL_LINES),
+        MouseEventKind::ScrollUp => wheel_vertical(editor, event.column, event.row, -WHEEL_LINES),
+        MouseEventKind::ScrollRight => {
+            wheel_horizontal(editor, event.column, event.row, WHEEL_COLS)
+        }
+        MouseEventKind::ScrollLeft => {
+            wheel_horizontal(editor, event.column, event.row, -WHEEL_COLS)
+        }
+        MouseEventKind::Down(MouseButton::Left) => match pane_at(editor, event.column, event.row) {
+            Some(idx) => {
+                editor.click_at(idx, event.column, event.row);
+                true
+            }
+            None => false,
+        },
+        // Motion floods and unhandled buttons fall through at match-arm cost.
+        _ => false,
+    }
+}
+
+fn wheel_vertical(editor: &mut Editor, col: u16, row: u16, delta: isize) -> bool {
+    match pane_at(editor, col, row) {
+        Some(idx) => {
+            editor.scroll_pane_viewport(idx, delta);
+            true
+        }
+        None => false,
+    }
+}
+
+fn wheel_horizontal(editor: &mut Editor, col: u16, row: u16, delta: isize) -> bool {
+    match pane_at(editor, col, row) {
+        Some(idx) => {
+            editor.scroll_pane_columns(idx, delta);
+            true
+        }
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    fn single_pane_editor(width: u16, height: u16) -> Editor {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("alpha\nbeta\ngamma\n");
+        editor.set_size(width, height);
+        editor.update_pane_rects();
+        editor
+    }
+
+    fn editor_with_lines(count: usize) -> Editor {
+        let mut editor = Editor::default();
+        let content: String = (1..=count).map(|i| format!("line{i}\n")).collect();
+        editor.replace_buffer_content(&content);
+        editor.set_size(120, 40);
+        editor.update_pane_rects();
+        editor
+    }
+
+    fn test_editor_with_vsplit() -> Editor {
+        let mut editor = editor_with_lines(100);
+        editor.vsplit(None).expect("vsplit");
+        editor.update_pane_rects();
+        editor
+    }
+
+    fn mouse(kind: MouseEventKind, column: u16, row: u16) -> MouseEvent {
+        MouseEvent {
+            kind,
+            column,
+            row,
+            modifiers: KeyModifiers::empty(),
+        }
+    }
+
+    fn center_of_pane(editor: &Editor, idx: usize) -> (u16, u16) {
+        let rect = editor.panes()[idx].rect;
+        (rect.x + rect.width / 2, rect.y + rect.height / 2)
+    }
+
+    #[test]
+    fn wheel_flood_accumulates_into_state() {
+        // Perf gate: a trackpad flick is dozens of ticks; each one must be a
+        // pure state mutation (renders stay per-frame in the main loop).
+        let mut editor = editor_with_lines(200);
+        let (col, row) = center_of_pane(&editor, 0);
+        for _ in 0..32 {
+            assert!(handle_mouse_event(
+                &mut editor,
+                mouse(MouseEventKind::ScrollDown, col, row)
+            ));
+        }
+        assert_eq!(editor.viewport_offset, 96);
+        assert!(editor.render_damage.requires_full_render());
+    }
+
+    #[test]
+    fn wheel_scrolls_pane_under_pointer_not_active() {
+        let mut editor = test_editor_with_vsplit();
+        let inactive = 1 - editor.active_pane_idx();
+        let (col, row) = center_of_pane(&editor, inactive);
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollDown, col, row));
+
+        assert_eq!(editor.panes()[inactive].viewport_offset, 3);
+        assert_eq!(editor.viewport_offset, 0, "focused pane untouched");
+    }
+
+    #[test]
+    fn wheel_outside_any_pane_is_ignored() {
+        let mut editor = single_pane_editor(120, 40);
+        assert!(!handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::ScrollDown, 10, 39)
+        ));
+        assert_eq!(editor.viewport_offset, 0);
+    }
+
+    fn gutter_width(editor: &Editor, idx: usize) -> u16 {
+        // These tests use buffers of at most 100 lines, so the gutter is
+        // 2 (sign column) + 3 (line numbers) + 1 (separator) = 6 cells.
+        editor.panes()[idx].rect.x + 6
+    }
+
+    #[test]
+    fn click_positions_cursor_accounting_for_gutter_and_offset() {
+        let mut editor = editor_with_lines(100);
+        editor.scroll_pane_viewport(0, 10);
+        let gutter = gutter_width(&editor, 0);
+
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), gutter + 4, 2),
+        );
+
+        assert_eq!(editor.cursor.line, 12, "viewport 10 + clicked row 2");
+        assert_eq!(editor.cursor.col, 4);
+        assert_eq!(
+            editor.panes()[0].cursor,
+            editor.cursor,
+            "pane mirror synced"
+        );
+    }
+
+    #[test]
+    fn click_beyond_eol_clamps_to_line_end() {
+        let mut editor = editor_with_lines(100);
+        let gutter = gutter_width(&editor, 0);
+
+        // Row 2 shows "line3" (5 chars): clicking far right lands on its end.
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), gutter + 90, 2),
+        );
+
+        assert_eq!(editor.cursor.line, 2);
+        assert_eq!(editor.cursor.col, 4);
+    }
+
+    #[test]
+    fn click_in_other_pane_focuses_and_positions() {
+        let mut editor = test_editor_with_vsplit();
+        let inactive = 1 - editor.active_pane_idx();
+        let (col, row) = center_of_pane(&editor, inactive);
+
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), col, row),
+        );
+
+        assert_eq!(editor.active_pane_idx(), inactive);
+    }
+
+    #[test]
+    fn click_in_insert_mode_stays_insert() {
+        let mut editor = editor_with_lines(100);
+        editor.mode = Mode::Insert;
+        let gutter = gutter_width(&editor, 0);
+
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), gutter + 2, 5),
+        );
+
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!(editor.cursor.line, 5);
+    }
+
+    #[test]
+    fn click_in_visual_mode_clears_to_normal() {
+        let mut editor = editor_with_lines(100);
+        editor.enter_visual_mode();
+        assert_eq!(editor.mode, Mode::Visual);
+        let gutter = gutter_width(&editor, 0);
+
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), gutter + 1, 8),
+        );
+
+        assert_eq!(editor.mode, Mode::Normal);
+        assert_eq!(editor.cursor.line, 8);
+    }
+
+    #[test]
+    fn click_on_wide_char_line_maps_display_columns() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("日本語abc\nplain\n");
+        editor.set_size(120, 40);
+        editor.update_pane_rects();
+        let gutter = gutter_width(&editor, 0);
+
+        // The three double-width chars cover display cells 0-5; cell 6 is 'a'.
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), gutter + 6, 0),
+        );
+
+        assert_eq!(editor.cursor.line, 0);
+        assert_eq!(editor.cursor.col, 3, "char index, not display cell");
+    }
+
+    #[test]
+    fn click_on_explorer_row_selects_it() {
+        let tmp = std::env::temp_dir().join(format!(
+            "nevi_mouse_explorer_click_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            std::fs::write(tmp.join(name), "x\n").expect("write file");
+        }
+
+        let mut editor = editor_with_lines(50);
+        editor.explorer.set_root(tmp.clone());
+        editor.explorer.show();
+        editor.update_pane_rects();
+
+        // Row 0 is the header; row 2 is the second visible entry.
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), 1, 2),
+        );
+        assert_eq!(editor.explorer.selected, 1);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn wheel_scrolls_markdown_preview_when_open() {
+        let tmp = std::env::temp_dir().join(format!(
+            "nevi_mouse_md_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("notes.md");
+        let body: String = (1..=80).map(|i| format!("- item {i}\n")).collect();
+        std::fs::write(&path, format!("# Notes\n\n{body}")).expect("write markdown");
+
+        let mut editor = Editor::default();
+        editor.set_size(120, 40);
+        editor.open_file(path).expect("open markdown");
+        editor.open_markdown_preview().expect("open preview");
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 0);
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollDown, 10, 10));
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 3);
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollUp, 10, 10));
+        assert_eq!(editor.markdown_preview.as_ref().unwrap().scroll, 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn wheel_in_finder_scrolls_preview_pane_only() {
+        let mut editor = editor_with_lines(50);
+        editor.mode = Mode::Finder;
+        editor.finder.preview_content = (1..=100).map(|i| format!("line {i}")).collect();
+        let viewport_before = editor.viewport_offset;
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollDown, 60, 20));
+        assert_eq!(editor.finder.preview_scroll, 3);
+        assert_eq!(editor.viewport_offset, viewport_before, "buffer untouched");
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollUp, 60, 20));
+        assert_eq!(editor.finder.preview_scroll, 0);
+    }
+
+    #[test]
+    fn wheel_over_explorer_moves_selection_one_row() {
+        let tmp = std::env::temp_dir().join(format!(
+            "nevi_mouse_explorer_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        for name in ["a.txt", "b.txt", "c.txt"] {
+            std::fs::write(tmp.join(name), "x\n").expect("write file");
+        }
+
+        let mut editor = editor_with_lines(50);
+        editor.explorer.set_root(tmp.clone());
+        editor.explorer.show();
+        editor.update_pane_rects();
+        assert_eq!(editor.explorer.selected, 0);
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollDown, 1, 5));
+        assert_eq!(editor.explorer.selected, 1, "one row per tick");
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollUp, 1, 5));
+        assert_eq!(editor.explorer.selected, 0);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn horizontal_wheel_moves_h_offset() {
+        let mut editor = Editor::default();
+        let long_line: String = "x".repeat(600);
+        editor.replace_buffer_content(&format!("{long_line}\nshort\n"));
+        editor.set_size(120, 40);
+        editor.update_pane_rects();
+        let (col, row) = center_of_pane(&editor, 0);
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollRight, col, row));
+        assert_eq!(editor.h_offset, 6);
+        assert!(editor.cursor.col >= 6, "cursor dragged into view");
+
+        handle_mouse_event(&mut editor, mouse(MouseEventKind::ScrollLeft, col, row));
+        assert_eq!(editor.h_offset, 0);
+    }
+
+    #[test]
+    fn pane_at_finds_pane_in_vertical_split() {
+        let editor = test_editor_with_vsplit();
+        let left = editor.panes()[0].rect;
+        let right = editor.panes()[1].rect;
+        assert_eq!(pane_at(&editor, left.x, left.y), Some(0));
+        assert_eq!(pane_at(&editor, right.x + 1, right.y + 1), Some(1));
+    }
+
+    #[test]
+    fn pane_at_rejects_statusline_and_command_rows() {
+        // text_rows = term_height - 2; the bottom two rows belong to no pane.
+        let editor = single_pane_editor(120, 40);
+        assert_eq!(pane_at(&editor, 10, 38), None);
+        assert_eq!(pane_at(&editor, 10, 39), None);
+    }
+
+    #[test]
+    fn pane_at_rejects_explorer_column_when_visible() {
+        let mut editor = single_pane_editor(120, 40);
+        editor.explorer.show();
+        editor.update_pane_rects();
+        assert_eq!(pane_at(&editor, 0, 5), None);
+    }
+}

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -218,7 +218,7 @@ impl FlightRecorder {
 
 fn slow_threshold_us(name: &str) -> u128 {
     match name {
-        "handle_key" => 1_000,
+        "handle_key" | "handle_mouse" => 1_000,
         "render" | "render_after_lsp" | "syntax_update" => 16_000,
         "finder_preview" | "finder_grep" | "terminal_tick" | "terminal_render" => 5_000,
         "lsp_poll" | "copilot_poll" => 10_000,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2515,14 +2515,8 @@ impl Terminal {
         let selected = editor.explorer.selected;
         let list_height = height.saturating_sub(1); // -1 for header
 
-        // Calculate scroll offset to keep selection visible
-        let scroll_offset = if selected < list_height / 2 {
-            0
-        } else if selected >= flat_view.len().saturating_sub(list_height / 2) {
-            flat_view.len().saturating_sub(list_height)
-        } else {
-            selected.saturating_sub(list_height / 2)
-        };
+        // Shared with mouse hit testing so clicks land on the row they show on.
+        let scroll_offset = editor.explorer.scroll_offset(list_height);
 
         // Available width for file entries (subtract line number column)
         let content_width = width.saturating_sub(line_num_width);
@@ -4412,7 +4406,7 @@ impl Terminal {
         )
     }
 
-    fn markdown_preview_visible_rows(editor: &Editor) -> usize {
+    pub(crate) fn markdown_preview_visible_rows(editor: &Editor) -> usize {
         Self::markdown_preview_rect(editor).height.saturating_sub(3) as usize
     }
 
@@ -4436,7 +4430,7 @@ impl Terminal {
     }
 
     fn should_capture_mouse(editor: &Editor) -> bool {
-        editor.floating_terminal.is_visible()
+        editor.settings.editor.mouse || editor.floating_terminal.is_visible()
     }
 
     fn should_skip_background(editor: &Editor) -> bool {
@@ -7445,6 +7439,15 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.scroll_cursor_bottom();
         }
 
+        KeyAction::ScrollLineDown(count) => {
+            editor.scroll_pane_viewport(editor.active_pane_idx(), count as isize);
+        }
+
+        KeyAction::ScrollLineUp(count) => {
+            let delta = -(count.min(isize::MAX as usize) as isize);
+            editor.scroll_pane_viewport(editor.active_pane_idx(), delta);
+        }
+
         KeyAction::RepeatLastChange => {
             editor.repeat_last_change();
         }
@@ -10238,7 +10241,21 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
-        Command::Set(option, _value) => CommandResult::Error(format!("Unknown option: {}", option)),
+        Command::Set(option, value) => match option.as_str() {
+            // Vim's 'mouse' is a string option: `:set mouse=` (empty) disables,
+            // any flag characters (`=a`, `=nvi`) enable. The bool-style
+            // `:set mouse` / `:set nomouse` forms work too. Capture is synced
+            // from this setting on the next render.
+            "mouse" => {
+                editor.settings.editor.mouse = value.as_deref().is_none_or(|v| !v.is_empty());
+                CommandResult::Ok
+            }
+            "nomouse" => {
+                editor.settings.editor.mouse = false;
+                CommandResult::Ok
+            }
+            _ => CommandResult::Error(format!("Unknown option: {}", option)),
+        },
 
         Command::LazyGit => CommandResult::RunExternal("lazygit".to_string()),
 
@@ -10900,6 +10917,40 @@ mod tests {
         let mut terminal = Terminal::new_for_test(Box::new(output.clone()));
         terminal.render(editor).expect("render should succeed");
         output.into_string()
+    }
+
+    #[test]
+    fn wheel_scrolled_frame_renders_from_new_viewport() {
+        let mut editor = Editor::default();
+        let content: String = (1..=100).map(|i| format!("line{i}\n")).collect();
+        editor.replace_buffer_content(&content);
+        editor.set_size(120, 40);
+        editor.update_pane_rects();
+
+        // Three wheel ticks = 9 lines; the frame must start at line 10.
+        let (col, row) = (30, 10);
+        for _ in 0..3 {
+            crate::mouse::handle_mouse_event(
+                &mut editor,
+                crossterm::event::MouseEvent {
+                    kind: crossterm::event::MouseEventKind::ScrollDown,
+                    column: col,
+                    row,
+                    modifiers: crossterm::event::KeyModifiers::empty(),
+                },
+            );
+        }
+        assert_eq!(editor.viewport_offset, 9);
+
+        let rendered = render_editor_to_string(&editor);
+        assert!(
+            rendered.contains("line10"),
+            "scrolled frame shows line 10 first"
+        );
+        assert!(
+            !rendered.contains("line1\x1b") && !rendered.contains(" 1 "),
+            "line 1 no longer on screen"
+        );
     }
 
     #[test]
@@ -15086,6 +15137,39 @@ mod tests {
     }
 
     #[test]
+    fn mouse_capture_follows_editor_setting() {
+        let mut editor = Editor::default();
+        assert!(
+            Terminal::should_capture_mouse(&editor),
+            "capture is on by default (ADR 0001)"
+        );
+
+        editor.settings.editor.mouse = false;
+        assert!(!Terminal::should_capture_mouse(&editor));
+    }
+
+    #[test]
+    fn set_mouse_accepts_vim_string_forms() {
+        let mut editor = Editor::default();
+        for (option, value, expect) in [
+            ("nomouse", None, false),
+            ("mouse", None, true),
+            ("mouse", Some(""), false), // vim reflex `:set mouse=` disables
+            ("mouse", Some("a"), true),
+            ("mouse", Some("nvi"), true),
+        ] {
+            execute_command(
+                &mut editor,
+                Command::Set(option.to_string(), value.map(str::to_string)),
+            );
+            assert_eq!(
+                editor.settings.editor.mouse, expect,
+                ":set {option}={value:?}"
+            );
+        }
+    }
+
+    #[test]
     fn markdown_preview_does_not_capture_mouse_while_overlay_is_open() {
         let tmp = unique_temp_dir("nevi_markdown_preview_mouse_capture");
         std::fs::create_dir_all(&tmp).expect("create temp dir");
@@ -15093,6 +15177,9 @@ mod tests {
         std::fs::write(&markdown_path, "# Notes\n").expect("write markdown");
 
         let mut editor = Editor::default();
+        // The preview alone must not force capture; disable the default-on
+        // mouse setting so that is what this test observes.
+        editor.settings.editor.mouse = false;
         editor.open_file(markdown_path).expect("open markdown");
         assert!(!Terminal::should_capture_mouse(&editor));
 

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -405,6 +405,46 @@ const MOTION_CASES: &[OracleCase] = &[
         keys: "50G7lzz<C-f>",
     },
     OracleCase {
+        name: "line scroll down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-e>",
+    },
+    OracleCase {
+        name: "line scroll up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz<C-y>",
+    },
+    OracleCase {
+        name: "counted line scroll down",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz5<C-e>",
+    },
+    OracleCase {
+        name: "counted line scroll up",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz5<C-y>",
+    },
+    OracleCase {
+        name: "line scroll drags cursor from top edge",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz20<C-e>",
+    },
+    OracleCase {
+        name: "line scroll drags cursor from bottom edge",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "50Gzz20<C-y>",
+    },
+    OracleCase {
+        name: "line scroll down clamps at file end",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "95Gzz200<C-e>",
+    },
+    OracleCase {
+        name: "line scroll up clamps at file start",
+        initial_text: SCREEN_POSITION_TEXT,
+        keys: "5Gzz20<C-y>",
+    },
+    OracleCase {
         name: "enter next line first nonblank",
         initial_text: "zero\n    one\n  two\nthree\n",
         keys: "<CR>",


### PR DESCRIPTION
Fixes #274.

The wheel now scrolls the buffer instead of the terminal scrollback, matching nvim's mouse=nvi default.

What is in here:

- The wheel scrolls the pane under the pointer, 3 lines per tick, without moving the cursor until it would leave the screen. Horizontal wheel moves 6 columns when wrap is off.
- Left click focuses a pane and moves the cursor to the clicked cell. Gutter, horizontal offset, wrapped lines, and wide characters are all handled. Insert mode stays in insert, a plain click drops visual mode, like nvim.
- The explorer takes wheel and click for its selection, the finder wheel scrolls the preview pane, and the markdown preview scrolls too.
- New Ctrl-e and Ctrl-y binds scroll the view one line (or a count of lines), verified against real Neovim in the oracle suite. The oracle caught one edge during development: vim relaxes the scrolloff margin when the view sits at the top of the file. There is a regression test pinning that now.
- Capture is on by default. mouse = false under [editor] turns it off in config, and :set nomouse / :set mouse= work at runtime, which makes mouse the first option :set actually applies. While captured, terminal native selection needs the terminal's bypass key (Option in iTerm2, Shift in most others).

Performance: handling is instrumented as handle_mouse in :FlightRecorder. A real session measured 1572 mouse events at 2us average, coalescing into 293 renders with zero slow events. Ticks in one input batch mutate state and repaint once, so cost scales with frames, not input rate.

Testing: 17 unit tests in src/mouse.rs (hit testing, wheel routing, click mapping including wide chars and wrap), viewport scroll regressions, a render regression, config and :set tests, and 8 new oracle cases that pass against real nvim. Full suite, fmt, and the frame budget guard are green.

