### PR TITLE
docs: add mouse capture ADR, move ctrl-e/ctrl-y off the roadmap

### DIFF
--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 337 keybinds implemented, 90 planned Vim/Neovim parity defaults.**
+**Status: 339 keybinds implemented, 88 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md). This list comes
@@ -30,7 +30,7 @@ ordering leans on the common proxies (vimtutor and cheat-sheet staples, what
 Neovim itself promotes to a default, plugin popularity like vim-unimpaired) and
 on what Nevi users actually ask for in issues — user reports move a key up
 immediately. The keys most hands reach for first: `Ctrl+a` / `Ctrl+x`,
-`Ctrl+e` / `Ctrl+y`, `Ctrl+^`, `ZQ`, the visual-mode operators (`gu` / `gU` /
+`Ctrl+^`, `ZQ`, the visual-mode operators (`gu` / `gU` /
 `g~`, `r`, `J`, `=`), `gq` / `gw`, and among the larger areas, folds and
 quickfix before tabs and tags.
 
@@ -56,8 +56,6 @@ quickfix before tabs and tags.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+e` | Scroll the view one line down without moving the cursor |
-| `Ctrl+y` | Scroll the view one line up without moving the cursor |
 | `z<CR>` | Like `zt`, and move the cursor to the first non-blank |
 | `z.` | Like `zz`, and move the cursor to the first non-blank |
 | `z-` | Like `zb`, and move the cursor to the first non-blank |

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,7 +9,7 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **337 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **90 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **339 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **88 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
 - **125 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
   - 117 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests

--- a/docs/adr/0001-mouse-capture-on-by-default.md
+++ b/docs/adr/0001-mouse-capture-on-by-default.md
@@ -1,0 +1,20 @@
+---
+status: accepted
+---
+
+# Mouse capture is on by default
+
+Nevi aims to feel like nvim, and nvim has shipped `mouse=nvi` since 0.8: the wheel scrolls the buffer, not the terminal scrollback (issue #274). To match that, nevi asks the terminal for mouse events whenever it runs. That takes over clicks and drags too, so selecting text with the terminal itself needs the terminal's bypass key while nevi is open. That key is Option in iTerm2 and Shift in most other terminals.
+
+We chose nvim parity over terminal-native selection. Capture is on by default, `mouse = false` under `[editor]` in config.toml turns it off for good, and `:set nomouse` or `:set mouse=` turns it off for the current session. The `:set mouse=` form matters because it is the reflex vim users already have for "let me copy something real quick".
+
+## Considered Options
+
+- Off by default, opt-in. Rejected because it leaves issue #274 unfixed for anyone who never reads release notes, and it breaks with nvim's default, which is the whole point of the project.
+- Always on with no way to turn it off. Rejected because losing native selection with no escape hatch punishes people who copy text out of their terminal all day.
+
+## What this changes going forward
+
+- `mouse` became the first option that `:set` actually applies. The way it parses (an empty value means off, any flags like `a` or `nvi` mean on) is the precedent for future runtime options.
+- Wheel and click behavior is pinned to nvim's: 3 lines per wheel tick, scrolling targets the pane under the pointer, and the cursor only moves when it would fall off screen.
+- Anyone who prefers the old behavior sets `mouse = false` once and never has to think about it again.


### PR DESCRIPTION
Follow-up to #289, which merged before its last revision. Two doc pieces:

- The keybind roadmap still listed Ctrl+e and Ctrl+y as planned in the Scrolling table even though #289 shipped them. Rows removed, status counts now 339 implemented and 88 planned, and PARITY.md regenerated to match. The insert mode Ctrl+e and Ctrl+y rows further down stay, that is a different vim feature we have not built.
- Adds docs/adr/0001, the first architecture decision record, explaining why mouse capture is on by default, what it costs (terminal native selection needs Option or Shift while nevi runs), the alternatives that were rejected, and how to turn it off.