### PR TITLE
feat: hide end-of-buffer tildes in rich mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Interface
 
+- Rich mode no longer draws the `~` column on rows past the end of the buffer, like Vim's `fillchars=eob:' '`. Minimal mode keeps the tildes.
 - The statusline now shows a `[3/12]` match counter on the right side after a search (`/`, `?`, `n`, `N`, `*`, `#`), in both rich and minimal layouts. It clears together with the search highlights when the cursor moves.
 - Unified the remaining floating windows under the rich chrome. The leader/which-key popup and the command suggestions/history popup are now rounded-corner boxes with icon border titles and right-aligned key hints, and the command popup marks the selected row with the finder's accent bar instead of `>`. The floating terminal's corners now come from the shared glyph table (square in minimal mode, matching the finder) and its title carries a terminal icon. Minimal mode keeps the previous flat headers throughout.
 - Added a start screen. Launching `nevi` with nothing to edit now shows recent files with their project names, harpoon pins, startup time, and key hints; `1`–`9` opens the numbered recent file and `h` + `1`–`9` jumps to that harpoon slot. Recently opened files persist to `~/.local/state/nevi/recent_files.json`, alongside the other shada-lite state. The screen is a pure render condition — it disappears as soon as any real buffer, edit, or mode change happens, and costs nothing afterward.

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -2176,10 +2176,11 @@ impl Terminal {
             terminal_print!(self, "  "); // Empty sign column
 
             execute!(self.stdout, SetForegroundColor(Color::Blue))?;
+            let eob = editor.ui_glyphs().eob;
             if show_line_numbers {
-                terminal_print!(self, "{:>width$} ~", "", width = line_num_width);
+                terminal_print!(self, "{:>width$} {}", "", eob, width = line_num_width);
             } else {
-                terminal_print!(self, "~");
+                terminal_print!(self, "{}", eob);
             }
             execute!(self.stdout, SetForegroundColor(editor_fg))?;
 
@@ -2594,10 +2595,11 @@ impl Terminal {
                 terminal_print!(self, "  "); // Empty sign column
 
                 execute!(self.stdout, SetForegroundColor(Color::Blue))?;
+                let eob = editor.ui_glyphs().eob;
                 if show_line_numbers {
-                    terminal_print!(self, "{:>width$} ~", "", width = line_num_width);
+                    terminal_print!(self, "{:>width$} {}", "", eob, width = line_num_width);
                 } else {
-                    terminal_print!(self, "~");
+                    terminal_print!(self, "{}", eob);
                 }
                 execute!(
                     self.stdout,
@@ -11610,6 +11612,26 @@ mod tests {
         assert!(
             rendered.contains("\u{f057} 1"),
             "dir and file rows show the error rollup badge; output={rendered:?}"
+        );
+    }
+
+    #[test]
+    fn end_of_buffer_filler_follows_ui_style() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 10);
+        editor.replace_buffer_content("only line\n");
+
+        let rendered = render_editor_to_string(&editor);
+        assert!(
+            !rendered.contains('~'),
+            "rich mode hides end-of-buffer tildes; output={rendered:?}"
+        );
+
+        editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
+        let rendered = render_editor_to_string(&editor);
+        assert!(
+            rendered.contains('~'),
+            "minimal mode keeps end-of-buffer tildes; output={rendered:?}"
         );
     }
 

--- a/src/terminal/tests/viewport_rendering.rs
+++ b/src/terminal/tests/viewport_rendering.rs
@@ -5,6 +5,9 @@ use crate::input::Motion;
 fn rendered_tilde_count(content: &str, wrap: bool) -> usize {
     let mut editor = Editor::default();
     editor.set_size(80, 12);
+    // The tilde is the observable for end-of-buffer rows; rich mode renders
+    // them blank, so these probes pin minimal mode.
+    editor.settings.ui.style = Some(crate::config::UiStyle::Minimal);
     editor.settings.editor.wrap = wrap;
     editor.settings.editor.wrap_width = 80;
     editor.replace_buffer_content(content);

--- a/src/ui_glyphs.rs
+++ b/src/ui_glyphs.rs
@@ -54,6 +54,9 @@ pub struct UiGlyphs {
     pub gutter_hint: &'static str,
     /// Icon before the project name in the explorer header.
     pub explorer_header_icon: &'static str,
+    /// End-of-buffer filler drawn on rows past the last line (Vim's `~`).
+    /// Blank in rich — the `fillchars=eob:' '` look; minimal keeps the tilde.
+    pub eob: &'static str,
 }
 
 pub static RICH: UiGlyphs = UiGlyphs {
@@ -84,6 +87,7 @@ pub static RICH: UiGlyphs = UiGlyphs {
     gutter_info: "\u{f05a}",
     gutter_hint: "\u{f0eb}",
     explorer_header_icon: "\u{f07b} ",
+    eob: " ",
 };
 
 pub static MINIMAL: UiGlyphs = UiGlyphs {
@@ -114,6 +118,7 @@ pub static MINIMAL: UiGlyphs = UiGlyphs {
     gutter_info: "■",
     gutter_hint: "○",
     explorer_header_icon: "",
+    eob: "~",
 };
 
 /// Devicon glyph for the finder's two-char file-type chips. The chip
@@ -262,6 +267,7 @@ mod tests {
             g.gutter_info,
             g.gutter_hint,
             g.explorer_header_icon,
+            g.eob,
         ];
         v.extend(g.lsp_busy_frames);
         v


### PR DESCRIPTION
Rich mode no longer draws the `~` column past the last line — Vim's `fillchars=eob:' '` look. Minimal mode keeps the tildes.

One new `eob` field in the shared `UiGlyphs` table, routed through the two existing end-of-buffer print sites. No new config, zero render cost. A new test covers both modes; the viewport probes that count tildes to find end-of-buffer now pin minimal mode, since the tilde was their observable, not the behavior under test.