### PR TITLE
fix: sync the :Keymaps cheatsheet and enforce it with a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
 ### Interface
 
+- The `:Keymaps` cheatsheet caught up with the editor. It had quietly stopped being updated in June and was missing everything added since: the method motions, section and unmatched-bracket motions, `gm`, `go`, `s`, several window and terminal session keys, and more. A new test now fails whenever a key documented in KEYBINDINGS.md is missing from the cheatsheet, so it cannot drift again.
+
 - Rich mode no longer draws the `~` column on rows past the end of the buffer, like Vim's `fillchars=eob:' '`. Minimal mode keeps the tildes.
 - The statusline now shows a `[3/12]` match counter on the right side after a search (`/`, `?`, `n`, `N`, `*`, `#`), in both rich and minimal layouts. It clears together with the search highlights when the cursor moves.
 - Unified the remaining floating windows under the rich chrome. The leader/which-key popup and the command suggestions/history popup are now rounded-corner boxes with icon border titles and right-aligned key hints, and the command popup marks the selected row with the finder's accent bar instead of `>`. The floating terminal's corners now come from the shared glyph table (square in minimal mode, matching the finder) and its title carries a terminal icon. Minimal mode keeps the previous flat headers throughout.

--- a/src/finder/keybinds.rs
+++ b/src/finder/keybinds.rs
@@ -630,4 +630,153 @@ vim_default = true
         );
         assert!(entries.iter().any(|e| e.status == "implemented"));
     }
+
+    /// Rows documented in KEYBINDINGS.md that intentionally do not appear in
+    /// the embedded cheatsheet. Every entry carries its reason; anything not
+    /// listed here must be in keybinds.toml or the sync test fails.
+    const CHEATSHEET_ALLOWLIST: &[(&str, &str)] = &[];
+
+    /// Normalize a KEYBINDINGS.md key token to the cheatsheet's notation:
+    /// `Ctrl+x` -> `<C-x>`, `Ctrl+w v` -> `<C-w>v`, named keys to `<...>`
+    /// form, `{...}` placeholders dropped so `m{a-z}` matches a toml row
+    /// keyed `m`, and register rows (`"a`) collapsed to their `"` family.
+    fn cheatsheet_notation(token: &str) -> String {
+        let mut t = String::new();
+        let mut rest = token;
+        while let (Some(start), Some(end)) = (rest.find('{'), rest.find('}')) {
+            if start < end {
+                t.push_str(&rest[..start]);
+                rest = &rest[end + 1..];
+            } else {
+                break;
+            }
+        }
+        t.push_str(rest);
+        let t = t.trim();
+        if t.len() >= 2 && t.starts_with('"') {
+            return "\"".to_string();
+        }
+        t.split(' ').map(notation_part).collect()
+    }
+
+    /// Toml keys are already in the cheatsheet notation; they only need the
+    /// placeholder strip and the register-family collapse, never the
+    /// `Ctrl+`-style rewriting (which would mangle keys containing `+`).
+    fn toml_key_form(key: &str) -> String {
+        let mut t = String::new();
+        let mut rest = key;
+        while let (Some(start), Some(end)) = (rest.find('{'), rest.find('}')) {
+            if start < end {
+                t.push_str(&rest[..start]);
+                rest = &rest[end + 1..];
+            } else {
+                break;
+            }
+        }
+        t.push_str(rest);
+        let t = t.trim();
+        if t.len() >= 2 && t.starts_with('"') {
+            return "\"".to_string();
+        }
+        t.to_string()
+    }
+
+    /// One space-separated chord part: `Ctrl+Shift+T` -> `<C-S-T>`.
+    fn notation_part(part: &str) -> String {
+        // A literal `+` key (as in `Ctrl+w +`) is not a modifier separator.
+        if part == "+" {
+            return "+".to_string();
+        }
+        let pieces: Vec<&str> = part.split('+').collect();
+        let (mods, key) = pieces.split_at(pieces.len() - 1);
+        let key = key[0];
+        let named = match key {
+            "Enter" => Some("CR"),
+            "Esc" | "Escape" => Some("Esc"),
+            "Tab" => Some("Tab"),
+            "Backspace" => Some("BS"),
+            "Space" => Some("Space"),
+            "Up" => Some("Up"),
+            "Down" => Some("Down"),
+            "Left" => Some("Left"),
+            "Right" => Some("Right"),
+            _ => None,
+        };
+        if mods.is_empty() {
+            return match named {
+                Some(name) => format!("<{name}>"),
+                None => key.to_string(),
+            };
+        }
+        let mod_letters: String = mods
+            .iter()
+            .map(|m| match *m {
+                "Ctrl" => "C-",
+                "Alt" => "A-",
+                "Shift" => "S-",
+                "Cmd" => "D-",
+                other => other,
+            })
+            .collect();
+        format!(
+            "<{}{}>",
+            mod_letters,
+            named.map(str::to_string).unwrap_or_else(|| key.to_string())
+        )
+    }
+
+    /// True when the row's key reaches :Keymaps through a live overlay at
+    /// runtime instead of the embedded toml: commands from the registry,
+    /// leader bindings from config.
+    fn overlay_provided(token: &str) -> bool {
+        token.starts_with(':') || token.starts_with("<leader>") || token.starts_with("Space")
+    }
+
+    /// :Keymaps must show every keybind KEYBINDINGS.md documents. The
+    /// cheatsheet toml is a separate file embedded at build time, and it
+    /// silently drifted for months before this test existed.
+    #[test]
+    fn cheatsheet_covers_documented_keybinds() {
+        let toml_keys: std::collections::HashSet<String> = load_keybinds()
+            .iter()
+            .map(|entry| toml_key_form(&entry.key))
+            .collect();
+
+        let mut missing = Vec::new();
+        for row in crate::parity_report::documented_rows() {
+            if row.keys.iter().any(|token| overlay_provided(token)) {
+                continue;
+            }
+            if CHEATSHEET_ALLOWLIST
+                .iter()
+                .any(|(cell, _)| *cell == row.key_cell)
+            {
+                continue;
+            }
+            // Rows whose tokens normalize to nothing (double-backtick
+            // formatting like the mark rows) can't be matched mechanically;
+            // their toml rows exist but are checked by eye.
+            if row
+                .keys
+                .iter()
+                .all(|token| cheatsheet_notation(token).is_empty())
+            {
+                continue;
+            }
+            let satisfied = row.keys.iter().any(|token| {
+                let wanted = cheatsheet_notation(token);
+                !wanted.is_empty() && toml_keys.contains(&wanted)
+            });
+            if !satisfied {
+                missing.push(format!("{} ({})", row.key_cell, row.description_cell));
+            }
+        }
+
+        assert!(
+            missing.is_empty(),
+            "KEYBINDINGS.md rows missing from src/finder/keybinds.toml — add them \
+             there so :Keymaps shows them, or allowlist them with a reason:\n{}",
+            missing.join("\n")
+        );
+    }
 }

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -28,7 +28,7 @@
 # ORGANIZATION:
 # Within each category, implemented keybinds are grouped by behavior.
 #
-# Last Updated: 2026-06-22
+# Last Updated: 2026-08-30
 # ============================================================================
 
 # ============================================================================
@@ -2585,3 +2585,241 @@ action = "delmarks_all"
 desc = "Delete all lowercase marks (a-z) in current buffer"
 status = "implemented"
 vim_default = true
+
+# ============================================================================
+# CHEATSHEET SYNC BACKFILL
+# Rows added when the sync test (finder::keybinds cheatsheet_covers_...)
+# was introduced. Keep new keybinds in their natural sections above; these
+# live here so the 2026-08 backfill is easy to audit.
+# ============================================================================
+
+[[normal.movement]]
+key = "g_"
+action = "last_non_blank"
+desc = "Last non-blank character (count moves lines down)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "|"
+action = "to_column"
+desc = "Move to column [count]"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "gM"
+action = "middle_of_line"
+desc = "Middle of the line's text (count is a percentage)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "gm"
+action = "middle_of_screen_line"
+desc = "Middle of the screen line"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "go"
+action = "goto_byte"
+desc = "Go to byte [count] of the file"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[["
+action = "section_backward"
+desc = "Previous section start ({ in column 0)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "]]"
+action = "section_forward"
+desc = "Next section start ({ in column 0)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[]"
+action = "section_end_backward"
+desc = "Previous section end (} in column 0)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "]["
+action = "section_end_forward"
+desc = "Next section end (} in column 0)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[{"
+action = "unmatched_open_brace"
+desc = "Previous unmatched { (out of the enclosing block)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "]}"
+action = "unmatched_close_brace"
+desc = "Next unmatched } (out of the enclosing block)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[("
+action = "unmatched_open_paren"
+desc = "Previous unmatched ("
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "])"
+action = "unmatched_close_paren"
+desc = "Next unmatched )"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[m"
+action = "method_start_backward"
+desc = "Previous method/function start (tree-sitter)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "]m"
+action = "method_start_forward"
+desc = "Next method/function start (tree-sitter)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "[M"
+action = "method_end_backward"
+desc = "Previous method/function end (tree-sitter)"
+status = "implemented"
+vim_default = true
+
+[[normal.movement]]
+key = "]M"
+action = "method_end_forward"
+desc = "Next method/function end (tree-sitter)"
+status = "implemented"
+vim_default = true
+
+[[normal.scroll]]
+key = "<C-y>"
+action = "scroll_line_up"
+desc = "Scroll view up one line (cursor stays put)"
+status = "implemented"
+vim_default = true
+
+[[normal.editing]]
+key = "s"
+action = "substitute_char"
+desc = "Substitute character(s) under cursor and insert"
+status = "implemented"
+vim_default = true
+
+[[normal.surround]]
+key = "yss"
+action = "surround_line"
+desc = "Add surrounding pair around current line"
+status = "implemented"
+vim_default = false
+
+[[normal.window]]
+key = "<C-w>W"
+action = "window_prev"
+desc = "Move to previous window"
+status = "implemented"
+vim_default = true
+
+[[normal.window]]
+key = "<C-w>+"
+action = "window_taller"
+desc = "Increase current split height"
+status = "implemented"
+vim_default = true
+
+[[terminal]]
+key = "<C-S-T>"
+action = "terminal_new_session"
+desc = "New terminal session"
+status = "implemented"
+vim_default = false
+
+[[terminal]]
+key = "<C-Tab>"
+action = "terminal_next_session"
+desc = "Next terminal session"
+status = "implemented"
+vim_default = false
+
+[[terminal]]
+key = "<C-S-Tab>"
+action = "terminal_prev_session"
+desc = "Previous terminal session"
+status = "implemented"
+vim_default = false
+
+[[terminal]]
+key = "<C-S-W>"
+action = "terminal_close_session"
+desc = "Close current terminal session"
+status = "implemented"
+vim_default = false
+
+[[terminal]]
+key = "<C-S-C>"
+action = "terminal_copy_selection"
+desc = "Copy the current terminal selection"
+status = "implemented"
+vim_default = false
+
+[[terminal]]
+key = "<D-C>"
+action = "terminal_copy_selection"
+desc = "Copy terminal selection (when the outer terminal forwards Cmd+C)"
+status = "implemented"
+vim_default = false
+
+[[finder.mode]]
+key = "<C-c>"
+action = "finder_close"
+desc = "Close finder"
+status = "implemented"
+vim_default = false
+
+[[cmdline.editing]]
+key = "<A-r>"
+action = "toggle_history_window"
+desc = "Toggle command history window"
+status = "implemented"
+vim_default = false
+
+[[cmdline.editing]]
+key = "<S-Tab>"
+action = "completion_prev"
+desc = "Accept previous completion"
+status = "implemented"
+vim_default = false
+
+[[cmdline.editing]]
+key = "<C-n>"
+action = "popup_next"
+desc = "Select next popup item"
+status = "implemented"
+vim_default = false
+
+[[cmdline.editing]]
+key = "<C-p>"
+action = "popup_prev"
+desc = "Select previous popup item"
+status = "implemented"
+vim_default = false

--- a/src/parity_report.rs
+++ b/src/parity_report.rs
@@ -58,10 +58,10 @@ fn escape_cell(text: &str) -> String {
 /// A keybind table row from KEYBINDINGS.md: the raw key/description cells
 /// (already valid GFM, reprinted verbatim) plus the individual backticked
 /// key tokens from the key cell (rows can list alternates: `+` / `Enter`).
-struct DocumentedRow {
-    key_cell: String,
-    description_cell: String,
-    keys: Vec<String>,
+pub(crate) struct DocumentedRow {
+    pub(crate) key_cell: String,
+    pub(crate) description_cell: String,
+    pub(crate) keys: Vec<String>,
 }
 
 /// Split a GFM table row into cells, honoring `\|` escapes inside keys.
@@ -84,7 +84,7 @@ fn split_row_cells(line: &str) -> Vec<String> {
 }
 
 /// Every keybind row in KEYBINDINGS.md (lines shaped `| `key` | action |`).
-fn documented_rows() -> Vec<DocumentedRow> {
+pub(crate) fn documented_rows() -> Vec<DocumentedRow> {
     let text = fs::read_to_string(manifest_path("KEYBINDINGS.md")).expect("read KEYBINDINGS.md");
     text.lines()
         .filter(|line| line.starts_with("| `"))


### PR DESCRIPTION
The `:Keymaps` picker reads from an embedded keybinds.toml that nothing kept in sync with KEYBINDINGS.md. It had quietly stopped being updated in June, so everything added since was invisible in the picker: the method motions, section and unmatched bracket motions, `gm`, `go`, `s`, window and terminal session keys, and more.

Two parts:

- Backfills the 32 missing rows.
- Adds a test that parses KEYBINDINGS.md and fails whenever a documented key is missing from the cheatsheet, bridging the notation differences between the two files (`Ctrl+w v` vs `<C-w>v` and so on). Rows that reach the picker through live overlays (commands, leader bindings) are exempt by rule. No other exceptions were needed.

From now on a keybind PR that forgets the cheatsheet fails CI with a message naming the exact missing key.