### PR TITLE
feat: add flight recorder drain and baseline perf metrics

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3069,7 +3069,10 @@ impl Editor {
     /// Refresh git-backed explorer markers.
     pub fn refresh_explorer_git_statuses(&mut self) {
         if let Some(repo) = &self.git_repo {
+            let started = Instant::now();
             let mut statuses = repo.file_statuses();
+            self.flight_recorder
+                .record("git_file_statuses", started.elapsed());
             for buffer in &self.buffers {
                 if buffer.dirty {
                     if let Some(path) = &buffer.path {
@@ -11185,7 +11188,10 @@ impl Editor {
     /// Open the fuzzy finder in file mode
     pub fn open_finder_files(&mut self) {
         let root = self.working_directory();
+        let started = Instant::now();
         self.finder.open_files(&root);
+        self.flight_recorder
+            .record("finder_list_files", started.elapsed());
         self.mode = Mode::Finder;
         // Initialize preview for the first selected item
         self.update_finder_preview();
@@ -11808,9 +11814,11 @@ impl Editor {
 
     fn parse_current_buffer(&mut self) {
         let buffer_idx = self.current_buffer_idx;
-        let buffer = &self.buffers[buffer_idx];
-        self.syntax.parse(buffer);
-        self.last_syntax_version = buffer.version();
+        let started = Instant::now();
+        self.syntax.parse(&self.buffers[buffer_idx]);
+        self.flight_recorder
+            .record("syntax_parse", started.elapsed());
+        self.last_syntax_version = self.buffers[buffer_idx].version();
         self.last_edit_at = None;
     }
 
@@ -14116,6 +14124,34 @@ mod tests {
         assert_eq!(editor.current_diagnostics()[0].col_start, 2);
         assert_eq!(editor.current_diagnostics()[0].col_end, 3);
         assert_eq!(editor.all_diagnostics_at_cursor().len(), 1);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn perf_metrics_record_syntax_parse_and_git_file_statuses() {
+        let tmp = unique_temp_dir("nevi_perf_metrics");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let root = tmp.canonicalize().expect("canonical temp dir");
+        let path = root.join("main.rs");
+        std::fs::write(&path, "fn main() {}\n").expect("write file");
+        let repo = git2::Repository::init(&root).expect("init repo");
+        commit_file(&repo, Path::new("main.rs"), "initial");
+
+        let mut editor = Editor::default();
+        editor.set_project_root(root.clone());
+        editor.init_git();
+        editor.open_file(path).expect("open file");
+
+        let names: Vec<&str> = editor.flight_recorder.events().map(|e| e.name).collect();
+        assert!(
+            names.contains(&"git_file_statuses"),
+            "init_git must record the full-repo status scan: {names:?}"
+        );
+        assert!(
+            names.contains(&"syntax_parse"),
+            "opening a .rs file must record the parse: {names:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -370,16 +370,47 @@ fn main() -> anyhow::Result<()> {
             }
         };
     }
+    // Metrics go to the always-on flight recorder only; when NEVI_PROFILE=1,
+    // drain_profile_metrics! copies new events into PerfStats and the log file.
+    // Editor-internal code records the same way (editor.flight_recorder.record),
+    // so deep metrics like syntax_parse reach the profile summary too.
     macro_rules! record_metric {
         ($editor:expr, $stats:expr, $file:expr, $name:literal, $duration:expr) => {{
-            let elapsed = $duration;
-            $editor.flight_recorder.record($name, elapsed);
+            $editor.flight_recorder.record($name, $duration);
+        }};
+    }
+    // Copy flight-recorder events newer than `$seq` into the profile stats and
+    // log, then advance `$seq`. The ring can wrap within one long operation
+    // (e.g. thousands of syntax_parse events from a single gg=G), so report
+    // the gap instead of silently undercounting.
+    macro_rules! drain_profile_metrics {
+        ($editor:expr, $stats:expr, $file:expr, $seq:expr) => {{
             if profile_enabled {
-                if let Some(ref mut stats) = $stats {
-                    stats.record($name, elapsed);
+                let first_retained = $editor.flight_recorder.events().next().map(|e| e.sequence);
+                if let Some(first) = first_retained {
+                    if first > $seq {
+                        if let Some(Some(ref mut f)) = $file {
+                            let _ =
+                                writeln!(f, "# {} events dropped by ring overflow", first - $seq);
+                        }
+                    }
                 }
-                if let Some(Some(ref mut f)) = $file {
-                    let _ = writeln!(f, "{}: {:?}", $name, elapsed);
+                for event in $editor.flight_recorder.events() {
+                    if event.sequence < $seq {
+                        continue;
+                    }
+                    let elapsed = std::time::Duration::from_micros(event.duration_us as u64);
+                    if let Some(ref mut stats) = $stats {
+                        stats.record(event.name, elapsed);
+                    }
+                    if let Some(Some(ref mut f)) = $file {
+                        let _ = writeln!(f, "{}: {:?}", event.name, elapsed);
+                    }
+                }
+                // The exit-path drain's bump is never read again; that's fine.
+                #[allow(unused_assignments)]
+                {
+                    $seq = $editor.flight_recorder.next_sequence();
                 }
             }
         }};
@@ -402,6 +433,16 @@ fn main() -> anyhow::Result<()> {
 
     // Initialize editor with settings
     let mut editor = Editor::new(settings);
+
+    // Profiling drains the flight recorder into PerfStats each loop iteration,
+    // but a single long operation (gg=G emits one syntax_parse per line) can
+    // outrun the default 2048-event ring before the drain runs. Give profiling
+    // sessions enough headroom that per-event counts stay exact (~3MB).
+    if profile_enabled {
+        editor.flight_recorder = nevi::perf::FlightRecorder::with_capacity(65_536);
+    }
+    // First flight-recorder sequence not yet drained into the profile log.
+    let mut profiled_metric_seq: u64 = 0;
 
     // Restore persisted session state (macros, registers, marks, search
     // history). A missing or corrupt file loads as empty state.
@@ -641,6 +682,11 @@ fn main() -> anyhow::Result<()> {
 
     // Setup is done; freeze the start screen's "ready in Nms" number here.
     editor.startup_ready_ms = Some(process_start.elapsed().as_millis());
+    profile!(
+        profile_file,
+        "startup_ready_ms: {}",
+        process_start.elapsed().as_millis()
+    );
 
     // Main event loop
     let mut loop_start = Instant::now();
@@ -1144,23 +1190,21 @@ fn main() -> anyhow::Result<()> {
                         // Clone path once for reuse in LSP and Copilot notifications
                         let current_buffer_path = editor.buffer().path.clone();
 
-                        // Send document change to LSP (only if ready for this file type)
+                        // Send document change to LSP (only if ready for this file type).
+                        // The metric covers the full per-keystroke cost: the
+                        // rope→String serialization plus the full-document send.
                         if let Some(ref mut mlsp) = multi_lsp {
                             if let Some(ref path) = current_buffer_path {
                                 if mlsp.is_ready_for_file(path) {
                                     let t_lsp = Instant::now();
                                     let text = editor.buffer().content();
-                                    profile!(
-                                        profile_file,
-                                        "buffer.content() for LSP: {:?}",
-                                        t_lsp.elapsed()
-                                    );
-                                    let t_send = Instant::now();
                                     let _ = mlsp.did_change(path, &text);
-                                    profile!(
+                                    record_metric!(
+                                        editor,
+                                        profile_stats,
                                         profile_file,
-                                        "mlsp.did_change: {:?}",
-                                        t_send.elapsed()
+                                        "lsp_did_change",
+                                        t_lsp.elapsed()
                                     );
                                 }
                             }
@@ -1175,9 +1219,11 @@ fn main() -> anyhow::Result<()> {
                                     let text = editor.buffer().content();
                                     let version = editor.buffer().version() as i32;
                                     let _ = cop.did_change(&uri, version, &text);
-                                    profile!(
+                                    record_metric!(
+                                        editor,
+                                        profile_stats,
                                         profile_file,
-                                        "copilot.did_change: {:?}",
+                                        "copilot_did_change",
                                         t_cop.elapsed()
                                     );
                                 }
@@ -2059,7 +2105,17 @@ fn main() -> anyhow::Result<()> {
 
         // Poll for async grep results. The search itself runs off the UI loop;
         // this only applies the newest matching result set when it is ready.
+        // Only batch applications are recorded — an empty poll is nanoseconds
+        // and would drown the flight recorder at one event per loop iteration.
+        let t_grep_poll = Instant::now();
         if editor.finder.poll_grep_search() {
+            record_metric!(
+                editor,
+                profile_stats,
+                profile_file,
+                "grep_poll_apply",
+                t_grep_poll.elapsed()
+            );
             needs_redraw = true;
         }
 
@@ -2218,8 +2274,11 @@ fn main() -> anyhow::Result<()> {
                 redraw_from_input = false;
             }
         }
+
+        drain_profile_metrics!(editor, profile_stats, profile_file, profiled_metric_seq);
     }
 
+    drain_profile_metrics!(editor, profile_stats, profile_file, profiled_metric_seq);
     if profile_enabled {
         if let (Some(stats), Some(Some(file))) = (profile_stats.as_ref(), profile_file.as_mut()) {
             let _ = stats.write_summary(file);

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -125,6 +125,17 @@ impl FlightRecorder {
         self.events.push_back(event);
     }
 
+    /// Retained events, oldest first. The ring drops oldest events at
+    /// capacity, so a reader tracking sequence numbers can detect gaps.
+    pub fn events(&self) -> impl Iterator<Item = &FlightEvent> {
+        self.events.iter()
+    }
+
+    /// Sequence number the next recorded event will receive.
+    pub fn next_sequence(&self) -> u64 {
+        self.next_sequence
+    }
+
     pub fn render_report(&self) -> String {
         let mut report = String::new();
         report.push_str("# Nevi Flight Recorder\n\n");
@@ -219,9 +230,11 @@ impl FlightRecorder {
 fn slow_threshold_us(name: &str) -> u128 {
     match name {
         "handle_key" | "handle_mouse" => 1_000,
-        "render" | "render_after_lsp" | "syntax_update" => 16_000,
+        "render" | "render_after_lsp" | "syntax_update" | "syntax_parse" => 16_000,
         "finder_preview" | "finder_grep" | "terminal_tick" | "terminal_render" => 5_000,
         "lsp_poll" | "copilot_poll" => 10_000,
+        // One-off bulk operations (full walk / full-repo status), not per-frame work.
+        "finder_list_files" | "git_file_statuses" => 100_000,
         "slow_cycle" => 100_000,
         _ => 10_000,
     }
@@ -311,6 +324,24 @@ mod tests {
         assert!(report.contains("syntax_update"));
         assert!(report.contains("slow"));
         assert!(!report.contains("900us"));
+    }
+
+    #[test]
+    fn flight_recorder_exposes_events_and_sequence_for_draining() {
+        let mut recorder = FlightRecorder::with_capacity(2);
+
+        recorder.record("a", Duration::from_micros(1));
+        recorder.record("b", Duration::from_micros(2));
+        recorder.record("c", Duration::from_micros(3));
+
+        assert_eq!(recorder.next_sequence(), 3);
+        // Oldest event (sequence 0) was evicted; a drain tracking sequence 0
+        // sees the gap via the first retained sequence.
+        let retained: Vec<_> = recorder
+            .events()
+            .map(|event| (event.sequence, event.name))
+            .collect();
+        assert_eq!(retained, vec![(1, "b"), (2, "c")]);
     }
 
     #[test]

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -9769,14 +9769,23 @@ fn handle_finder_mode(editor: &mut Editor, key: KeyEvent) {
 
         // Backspace
         (KeyModifiers::NONE, KeyCode::Backspace) => {
+            // finder_filter times the query edit + the full re-filter it triggers.
+            let started = Instant::now();
             editor.finder.delete_char_before();
+            editor
+                .flight_recorder
+                .record("finder_filter", started.elapsed());
             selection_changed = true; // Filter might have changed selection
         }
 
         // Regular character - insert mode types, normal mode switches to insert first
         (_, KeyCode::Char(c)) if !c.is_control() => {
             // insert_char already switches to insert mode if needed
+            let started = Instant::now();
             editor.finder.insert_char(c);
+            editor
+                .flight_recorder
+                .record("finder_filter", started.elapsed());
             selection_changed = true; // Filter might have changed selection
         }
 


### PR DESCRIPTION
Adds the instrumentation needed to measure upcoming perf work with real numbers. Metrics now go through the always-on flight recorder, and when NEVI_PROFILE=1 the main loop drains new events into the profile summary each iteration, so timings recorded deep inside editor code finally show up there. The profiling ring grows to 65k events because a single gg=G can emit thousands of syntax_parse events in one keypress and would overflow the default ring before the drain runs.

New metrics: syntax_parse, finder_filter, finder_list_files, git_file_statuses, grep_poll_apply, lsp_did_change, copilot_did_change. Startup ready time is also written to the profile log. No behavior changes outside profiling.