### PR TITLE
chore: run finder perf guards in CI and add changelog entries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run render frame-budget guard
         run: cargo test render_frame_budget -- --ignored --nocapture
 
+      - name: Run finder perf budget guards
+        run: cargo test -- --ignored --nocapture grep_index_budget finder_filter_budget
+
       - name: Install pinned Neovim for parity smoke test
         uses: rhysd/action-setup-vim@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Performance
+
+- Live grep applies incoming result batches in about 0.1ms instead of 2.3ms and no longer redoes highlight work for results already on the list, so the finder stays responsive while matches stream in. (#301)
+- Typing in the file, buffer, and git changes pickers now computes match highlights only for the rows on screen instead of every match, roughly halving keystroke cost in large projects. (#302)
+- Document changes go to the LSP once per input batch instead of once per keystroke, with the serialized text shared with Copilot, so fast input bursts cost one document pass instead of one per key. (#303)
+
 ### Vim Compatibility
 
 - Fixed the quote text objects (`i"`, `a"`, `i'`, `a'`, `` i` ``, `` a` ``) doing nothing when the cursor sits before the first quote. They now seek forward on the line, as in Vim, so `ci"` works from the start of the line.

--- a/src/finder/mod.rs
+++ b/src/finder/mod.rs
@@ -1915,7 +1915,10 @@ mod tests {
 
         batch_times.sort_unstable();
         let p95 = batch_times[(batch_times.len() * 95).div_ceil(100) - 1];
-        let budget = Duration::from_millis(5);
+        // Debug-build budget with CI-runner headroom (release p95 is ~114us,
+        // debug ~416us). Catches order-of-magnitude regressions like the old
+        // full-rescan, which grows past this as batches accumulate.
+        let budget = Duration::from_millis(25);
         println!(
             "grep batch apply: p95={p95:?} max={:?} budget={budget:?}",
             batch_times.last().unwrap()
@@ -1963,7 +1966,10 @@ mod tests {
 
         keystroke_times.sort_unstable();
         let p95 = keystroke_times[(keystroke_times.len() * 95).div_ceil(100) - 1];
-        let budget = Duration::from_millis(10);
+        // Debug-build budget with CI-runner headroom (release p95 is ~3.2ms,
+        // debug ~46ms). The laziness itself is guarded by the visible-rows
+        // regression tests; this catches order-of-magnitude blowups.
+        let budget = Duration::from_millis(250);
         println!(
             "finder filter keystroke: p95={p95:?} max={:?} budget={budget:?}",
             keystroke_times.last().unwrap()


### PR DESCRIPTION
Follow up to #301, #302, and #303. The two budget tests those PRs added only ran when invoked by hand, so CI now runs them next to the render frame guard. Their budgets are recalibrated for debug builds on slower runners (release numbers stay in the test output for reference). The changelog gets a Performance section with the measured before and after numbers.