### PR TITLE
docs: changelog entries for the finder streaming and parallel grep work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Live grep applies incoming result batches in about 0.1ms instead of 2.3ms and no longer redoes highlight work for results already on the list, so the finder stays responsive while matches stream in. (#301)
 - Typing in the file, buffer, and git changes pickers now computes match highlights only for the rows on screen instead of every match, roughly halving keystroke cost in large projects. (#302)
 - Document changes go to the LSP once per input batch instead of once per keystroke, with the serialized text shared with Copilot, so fast input bursts cost one document pass instead of one per key. (#303)
+- The file picker no longer blocks the editor while scanning the project. The walk runs on parallel background workers and streams results in as they are found, so the picker opens instantly with a scanning counter, and the walk itself is about 5x faster. (#305)
+- Live grep walks and searches files with parallel workers instead of one file at a time. Results are unchanged; only the order files appear in can differ between runs. (#306)
 
 ### Vim Compatibility
 


### PR DESCRIPTION
Adds the Performance changelog entries for #305 and #306: the file picker streaming from a parallel background walk, and live grep searching with parallel workers.