### PR TITLE
perf: reuse the syntax tree with incremental parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - The file picker no longer blocks the editor while scanning the project. The walk runs on parallel background workers and streams results in as they are found, so the picker opens instantly with a scanning counter, and the walk itself is about 5x faster. (#305)
 - Live grep walks and searches files with parallel workers instead of one file at a time. Results are unchanged; only the order files appear in can differ between runs. (#306)
 - The full repo git status scan runs in the background instead of blocking startup, saving, focus changes, and opening the explorer. Explorer markers apply when the scan finishes, a frame or two later. Opening a 15k file repo went from about 130ms to about 30ms. (#308)
+- Syntax highlighting now reparses incrementally: edits are applied to the previous tree instead of reparsing the whole file, with an automatic fallback to a full parse on buffer switches, reloads, and formatter output. A mid edit reparse of an 18k line file went from 43.8ms to 5.4ms, and gg=G on a 2.1k line file from 8 seconds to about 1.3. Set NEVI_INCREMENTAL_PARSE=0 to force the old full reparse path. (#309)
 
 ### Vim Compatibility
 

--- a/src/editor/buffer.rs
+++ b/src/editor/buffer.rs
@@ -3,10 +3,38 @@ use std::ffi::{OsStr, OsString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Unicode scalar values taken from the first line for shebang detection.
 const FIRST_LINE_PREFIX_CHARS: usize = 256;
+
+/// A text mutation in tree-sitter's InputEdit shape: byte offsets plus
+/// (row, byte-column) points. Recorded on every change so the syntax layer
+/// can reparse incrementally instead of from scratch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BufferEdit {
+    pub start_byte: usize,
+    pub old_end_byte: usize,
+    pub new_end_byte: usize,
+    pub start_point: (usize, usize),
+    pub old_end_point: (usize, usize),
+    pub new_end_point: (usize, usize),
+}
+
+/// Beyond this the queue is dropped and the next parse is a full one; an
+/// unparsed buffer (no language) must not accumulate edits forever.
+const MAX_PENDING_EDITS: usize = 10_000;
+
+/// Sentinel for a broken edit history (bulk replace, overflow): no version
+/// can match it, so the next parse falls back to a full reparse.
+const EDIT_HISTORY_BROKEN: u64 = u64::MAX;
+
+static NEXT_BUFFER_ID: AtomicU64 = AtomicU64::new(1);
+
+fn next_buffer_id() -> u64 {
+    NEXT_BUFFER_ID.fetch_add(1, Ordering::Relaxed)
+}
 
 /// A text buffer backed by a rope data structure.
 /// Ropes provide O(log n) insertions and deletions, making them
@@ -23,6 +51,14 @@ pub struct Buffer {
     /// Last known modification time of the file on disk (for autoread)
     last_mtime: Option<SystemTime>,
     kind: BufferKind,
+    /// Unique identity, so the syntax layer only reuses a tree for the
+    /// buffer that produced it
+    id: u64,
+    /// Text edits since edits_base_version, drained by incremental reparse
+    pending_edits: Vec<BufferEdit>,
+    /// Buffer version where pending_edits starts; EDIT_HISTORY_BROKEN after
+    /// a bulk replace or queue overflow
+    edits_base_version: u64,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +78,9 @@ impl Buffer {
     /// Create a new empty buffer
     pub fn new() -> Self {
         Self {
+            id: next_buffer_id(),
+            pending_edits: Vec::new(),
+            edits_base_version: 0,
             text: Rope::new(),
             path: None,
             dirty: false,
@@ -73,6 +112,9 @@ impl Buffer {
         };
 
         Ok(Self {
+            id: next_buffer_id(),
+            pending_edits: Vec::new(),
+            edits_base_version: 0,
             text,
             path: Some(path),
             dirty: false,
@@ -89,6 +131,9 @@ impl Buffer {
         syntax_hint_path: Option<PathBuf>,
     ) -> Self {
         Self {
+            id: next_buffer_id(),
+            pending_edits: Vec::new(),
+            edits_base_version: 0,
             text: Rope::from_str(content),
             path: None,
             dirty: false,
@@ -109,6 +154,9 @@ impl Buffer {
         syntax_hint_path: Option<PathBuf>,
     ) -> Self {
         Self {
+            id: next_buffer_id(),
+            pending_edits: Vec::new(),
+            edits_base_version: 0,
             text: Rope::from_str(content),
             path: None,
             dirty: false,
@@ -210,13 +258,16 @@ impl Buffer {
     pub fn reload(&mut self) -> anyhow::Result<()> {
         let path = self
             .path
-            .as_ref()
+            .clone()
             .ok_or_else(|| anyhow::anyhow!("No file path set"))?;
 
         if path.exists() {
-            self.text = Rope::from_reader(std::fs::File::open(path)?)?;
+            self.text = Rope::from_reader(std::fs::File::open(&path)?)?;
             Self::fix_missing_final_newline(&mut self.text);
-            self.last_mtime = std::fs::metadata(path).ok().and_then(|m| m.modified().ok());
+            self.break_edit_history();
+            self.last_mtime = std::fs::metadata(&path)
+                .ok()
+                .and_then(|m| m.modified().ok());
             self.dirty = false;
             self.version = self.version.wrapping_add(1);
         }
@@ -309,8 +360,59 @@ impl Buffer {
         }
         self.text = Rope::from_str(content);
         Self::fix_missing_final_newline(&mut self.text);
+        self.break_edit_history();
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
+    }
+
+    /// Buffer identity for syntax-tree reuse guards.
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+
+    /// Byte offset and (row, byte-column) point of a char index, in the
+    /// rope's CURRENT state. Callers capture old-state values before
+    /// mutating and new-state values after.
+    fn point_at_char(&self, char_idx: usize) -> (usize, (usize, usize)) {
+        let char_idx = char_idx.min(self.text.len_chars());
+        let byte = self.text.char_to_byte(char_idx);
+        let line = self.text.char_to_line(char_idx);
+        (byte, (line, byte - self.text.line_to_byte(line)))
+    }
+
+    fn push_edit(&mut self, edit: BufferEdit) {
+        if self.edits_base_version == EDIT_HISTORY_BROKEN {
+            return;
+        }
+        if self.pending_edits.len() >= MAX_PENDING_EDITS {
+            self.break_edit_history();
+            return;
+        }
+        self.pending_edits.push(edit);
+    }
+
+    fn break_edit_history(&mut self) {
+        self.pending_edits.clear();
+        self.edits_base_version = EDIT_HISTORY_BROKEN;
+    }
+
+    /// Drain the edits covering exactly (since_version ..= now). Returns
+    /// None when the history does not start at since_version (bulk replace,
+    /// overflow, or a different consumer drained it); the caller must then
+    /// do a full reparse and call reset_edit_history.
+    pub fn take_edits_since(&mut self, since_version: u64) -> Option<Vec<BufferEdit>> {
+        if self.edits_base_version == since_version {
+            self.edits_base_version = self.version;
+            Some(std::mem::take(&mut self.pending_edits))
+        } else {
+            None
+        }
+    }
+
+    /// Restart edit history from the current version, after a full parse.
+    pub fn reset_edit_history(&mut self) {
+        self.pending_edits.clear();
+        self.edits_base_version = self.version;
     }
 
     /// Get the char index for a given line and column
@@ -330,7 +432,17 @@ impl Buffer {
             return;
         }
         let idx = self.line_col_to_char(line, col);
+        let (start_byte, start_point) = self.point_at_char(idx);
         self.text.insert_char(idx, ch);
+        let (new_end_byte, new_end_point) = self.point_at_char(idx + 1);
+        self.push_edit(BufferEdit {
+            start_byte,
+            old_end_byte: start_byte,
+            new_end_byte,
+            start_point,
+            old_end_point: start_point,
+            new_end_point,
+        });
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -341,7 +453,17 @@ impl Buffer {
             return;
         }
         let idx = self.line_col_to_char(line, col);
+        let (start_byte, start_point) = self.point_at_char(idx);
         self.text.insert(idx, s);
+        let (new_end_byte, new_end_point) = self.point_at_char(idx + s.chars().count());
+        self.push_edit(BufferEdit {
+            start_byte,
+            old_end_byte: start_byte,
+            new_end_byte,
+            start_point,
+            old_end_point: start_point,
+            new_end_point,
+        });
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -353,7 +475,17 @@ impl Buffer {
         }
         let idx = self.line_col_to_char(line, col);
         if idx < self.text.len_chars() {
+            let (start_byte, start_point) = self.point_at_char(idx);
+            let (old_end_byte, old_end_point) = self.point_at_char(idx + 1);
             self.text.remove(idx..idx + 1);
+            self.push_edit(BufferEdit {
+                start_byte,
+                old_end_byte,
+                new_end_byte: start_byte,
+                start_point,
+                old_end_point,
+                new_end_point: start_point,
+            });
             self.dirty = true;
             self.version = self.version.wrapping_add(1);
         }
@@ -373,7 +505,17 @@ impl Buffer {
         let start = self.line_col_to_char(start_line, start_col);
         let end = self.line_col_to_char(end_line, end_col);
         if start < end && end <= self.text.len_chars() {
+            let (start_byte, start_point) = self.point_at_char(start);
+            let (old_end_byte, old_end_point) = self.point_at_char(end);
             self.text.remove(start..end);
+            self.push_edit(BufferEdit {
+                start_byte,
+                old_end_byte,
+                new_end_byte: start_byte,
+                start_point,
+                old_end_point,
+                new_end_point: start_point,
+            });
             self.dirty = true;
             self.version = self.version.wrapping_add(1);
         }
@@ -396,6 +538,9 @@ impl Buffer {
             self.text.len_chars()
         };
 
+        let (start_byte, start_point) = self.point_at_char(start_idx);
+        let (old_end_byte, old_end_point) = self.point_at_char(end_idx);
+
         // Remove the old line content
         if start_idx < end_idx {
             self.text.remove(start_idx..end_idx);
@@ -412,6 +557,16 @@ impl Buffer {
         };
 
         self.text.insert(start_idx, &content_to_insert);
+        let (new_end_byte, new_end_point) =
+            self.point_at_char(start_idx + content_to_insert.chars().count());
+        self.push_edit(BufferEdit {
+            start_byte,
+            old_end_byte,
+            new_end_byte,
+            start_point,
+            old_end_point,
+            new_end_point,
+        });
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -525,11 +680,16 @@ impl Buffer {
     /// Deletes old_text at position and inserts new_text
     pub fn apply_change(&mut self, line: usize, col: usize, old_text: &str, new_text: &str) {
         let idx = self.line_col_to_char(line, col);
+        let (start_byte, start_point) = self.point_at_char(idx);
+        let (mut old_end_byte, mut old_end_point) = (start_byte, start_point);
 
         // Delete old text if any
         if !old_text.is_empty() {
             let end_idx = idx + old_text.chars().count();
             if end_idx <= self.text.len_chars() {
+                let old_end = self.point_at_char(end_idx);
+                old_end_byte = old_end.0;
+                old_end_point = old_end.1;
                 self.text.remove(idx..end_idx);
             }
         }
@@ -539,6 +699,15 @@ impl Buffer {
             self.text.insert(idx, new_text);
         }
 
+        let (new_end_byte, new_end_point) = self.point_at_char(idx + new_text.chars().count());
+        self.push_edit(BufferEdit {
+            start_byte,
+            old_end_byte,
+            new_end_byte,
+            start_point,
+            old_end_point,
+            new_end_point,
+        });
         self.dirty = true;
         self.version = self.version.wrapping_add(1);
     }
@@ -762,5 +931,85 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn edit_history_drains_only_for_the_matching_version() {
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, "hello\n");
+        let v1 = buffer.version();
+        buffer.insert_char(0, 5, '!');
+
+        // Wrong base version: no drain, full reparse required.
+        assert!(buffer.take_edits_since(v1 + 10).is_none());
+
+        // After a full parse resets history, draining from the reset point
+        // yields exactly the edits since then.
+        buffer.reset_edit_history();
+        let base = buffer.version();
+        buffer.insert_char(0, 0, 'x');
+        buffer.delete_char(0, 0);
+        let edits = buffer.take_edits_since(base).expect("matching base drains");
+        assert_eq!(edits.len(), 2);
+
+        // Drained: the next drain from the new version is empty but valid.
+        let edits = buffer
+            .take_edits_since(buffer.version())
+            .expect("empty drain");
+        assert!(edits.is_empty());
+    }
+
+    #[test]
+    fn bulk_replace_breaks_edit_history_until_reset() {
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, "one\n");
+        buffer.reset_edit_history();
+        let base = buffer.version();
+
+        buffer.set_content("two\n");
+        assert!(
+            buffer.take_edits_since(base).is_none(),
+            "set_content must force a full reparse"
+        );
+        assert!(buffer.take_edits_since(buffer.version()).is_none());
+
+        buffer.reset_edit_history();
+        buffer.insert_char(0, 0, 'a');
+        // The old pre-replace base still cannot drain; only the reset
+        // point can.
+        assert!(buffer.take_edits_since(base).is_none());
+        let reset_point = buffer.version().wrapping_sub(1);
+        assert_eq!(
+            buffer
+                .take_edits_since(reset_point)
+                .map(|edits| edits.len()),
+            Some(1)
+        );
+    }
+
+    #[test]
+    fn recorded_edit_has_correct_bytes_for_multibyte_text() {
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, "h\u{e9}llo\nworld\n");
+        buffer.reset_edit_history();
+        let base = buffer.version();
+
+        // Insert after the 2-byte 'é': char col 2 is byte col 3.
+        buffer.insert_char(0, 2, '\u{2713}');
+        let edits = buffer.take_edits_since(base).expect("drain");
+        assert_eq!(edits.len(), 1);
+        let edit = edits[0];
+        assert_eq!(edit.start_byte, 3);
+        assert_eq!(edit.start_point, (0, 3));
+        assert_eq!(edit.old_end_byte, 3);
+        assert_eq!(edit.new_end_byte, 6, "check mark is 3 bytes");
+        assert_eq!(edit.new_end_point, (0, 6));
+
+        // Delete across the newline: old end lands on line 1.
+        let base = buffer.version();
+        buffer.delete_range(0, 5, 1, 2);
+        let edits = buffer.take_edits_since(base).expect("drain");
+        assert_eq!(edits[0].old_end_point, (1, 2));
+        assert_eq!(edits[0].new_end_point, edits[0].start_point);
     }
 }

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -6,7 +6,7 @@ mod register;
 mod replace;
 mod undo;
 
-pub use buffer::Buffer;
+pub use buffer::{Buffer, BufferEdit};
 pub use cursor::{Cursor, DesiredCol};
 pub use macros::MacroState;
 pub use marks::{Mark, Marks};
@@ -9859,7 +9859,13 @@ impl Editor {
             };
         }
 
-        self.parse_current_buffer();
+        // Reparse only when the buffer actually changed since the last parse.
+        // During a range re-indent every changed line bumps the version, so
+        // this still parses per changed line, but incrementally (microseconds
+        // instead of a full parse); clean lines cost nothing.
+        if self.buffers[self.current_buffer_idx].version() != self.last_syntax_version {
+            self.parse_current_buffer();
+        }
 
         let prev_line = line_num.saturating_sub(1);
         let prev_col = self.buffers[self.current_buffer_idx].line_len(prev_line);
@@ -11935,7 +11941,7 @@ impl Editor {
     fn parse_current_buffer(&mut self) {
         let buffer_idx = self.current_buffer_idx;
         let started = Instant::now();
-        self.syntax.parse(&self.buffers[buffer_idx]);
+        self.syntax.parse(&mut self.buffers[buffer_idx]);
         self.flight_recorder
             .record("syntax_parse", started.elapsed());
         self.last_syntax_version = self.buffers[buffer_idx].version();
@@ -13320,7 +13326,7 @@ mod tests {
         editor
             .syntax
             .set_language_from_path(std::path::Path::new("test.rs"));
-        editor.syntax.parse(&editor.buffers[0]);
+        editor.syntax.parse(&mut editor.buffers[0]);
         editor
     }
 
@@ -13422,7 +13428,7 @@ mod tests {
         // ...then a reparse of a different layout must invalidate it —
         // stale cached boundaries would jump to line 3 instead of line 1.
         editor.replace_buffer_content("fn one() {}\nfn two() {}\n");
-        editor.syntax.parse(&editor.buffers[0]);
+        editor.syntax.parse(&mut editor.buffers[0]);
         editor.cursor.set(0, 0);
         editor.apply_motion(Motion::Method(MethodBoundary::NextStart), 1);
         assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));

--- a/src/method_motion.rs
+++ b/src/method_motion.rs
@@ -449,7 +449,7 @@ class C {
 
         let mut syntax = SyntaxManager::new();
         syntax.set_language_from_path(Path::new("big.rs"));
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
         let (tree, cached) = syntax.get_tree_and_source().expect("tree");
 
         // Run 1 is the cold pass — the one a user's first `]m` press pays —

--- a/src/syntax/mod.rs
+++ b/src/syntax/mod.rs
@@ -13,6 +13,26 @@ use crate::editor::Buffer;
 pub const MAX_HIGHLIGHT_LINES: usize = 200_000;
 pub const MAX_HIGHLIGHT_CHARS: usize = 2_000_000;
 
+fn to_input_edit(edit: &crate::editor::BufferEdit) -> tree_sitter::InputEdit {
+    tree_sitter::InputEdit {
+        start_byte: edit.start_byte,
+        old_end_byte: edit.old_end_byte,
+        new_end_byte: edit.new_end_byte,
+        start_position: tree_sitter::Point {
+            row: edit.start_point.0,
+            column: edit.start_point.1,
+        },
+        old_end_position: tree_sitter::Point {
+            row: edit.old_end_point.0,
+            column: edit.old_end_point.1,
+        },
+        new_end_position: tree_sitter::Point {
+            row: edit.new_end_point.0,
+            column: edit.new_end_point.1,
+        },
+    }
+}
+
 pub fn exceeds_highlight_limits(line_count: usize, char_count: usize) -> bool {
     line_count > MAX_HIGHLIGHT_LINES || char_count > MAX_HIGHLIGHT_CHARS
 }
@@ -45,6 +65,18 @@ pub struct SyntaxManager {
     /// every parse rather than version-keyed: parse_version mirrors
     /// buffer.version(), which can collide across buffer switches.
     method_boundaries: RefCell<Option<crate::method_motion::MethodBoundaries>>,
+    /// (buffer id, language) the current tree was parsed from. Incremental
+    /// reparse is only safe when both still match; anything else falls back
+    /// to a full parse.
+    incremental_identity: Option<(u64, String)>,
+}
+
+/// Kill switch: NEVI_INCREMENTAL_PARSE=0 forces full reparses, in case an
+/// incremental corruption slips past the equivalence tests in the wild.
+fn incremental_parse_disabled() -> bool {
+    static DISABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *DISABLED
+        .get_or_init(|| std::env::var("NEVI_INCREMENTAL_PARSE").is_ok_and(|value| value == "0"))
 }
 
 impl SyntaxManager {
@@ -62,6 +94,7 @@ impl SyntaxManager {
             cache_version: Cell::new(0),
             parse_version: 0,
             method_boundaries: RefCell::new(None),
+            incremental_identity: None,
         }
     }
 
@@ -133,6 +166,7 @@ impl SyntaxManager {
         self.language = None;
         self.query = None;
         self.tree = None;
+        self.incremental_identity = None;
         self.source_cache.clear();
         self.line_start_bytes.clear();
         self.highlight_cache.borrow_mut().clear();
@@ -514,9 +548,14 @@ impl SyntaxManager {
         }
     }
 
-    /// Parse the entire buffer
-    pub fn parse(&mut self, buffer: &Buffer) {
+    /// Parse the buffer. Reuses the previous tree via tree-sitter's
+    /// incremental parsing when the buffer's recorded edits exactly cover
+    /// the span since the last parse; otherwise falls back to a full parse.
+    pub fn parse(&mut self, buffer: &mut Buffer) {
         if self.language.is_none() {
+            // No language means no tree; keep the buffer's edit queue from
+            // growing without bound.
+            buffer.reset_edit_history();
             return;
         }
         self.method_boundaries.replace(None);
@@ -532,6 +571,8 @@ impl SyntaxManager {
             }
             self.tree = None;
             self.query = None;
+            self.incremental_identity = None;
+            buffer.reset_edit_history();
             self.parse_version = buffer.version();
             self.cache_version.set(self.parse_version);
             self.highlight_cache
@@ -541,6 +582,8 @@ impl SyntaxManager {
 
         if exceeds_highlight_limits(buffer.len_lines(), buffer.len_chars()) {
             self.tree = None;
+            self.incremental_identity = None;
+            buffer.reset_edit_history();
             self.source_cache.clear();
             self.line_start_bytes.clear();
             self.highlight_cache.borrow_mut().clear();
@@ -558,10 +601,28 @@ impl SyntaxManager {
                 self.line_start_bytes.push(idx + 1);
             }
         }
-        // Note: Incremental parsing requires calling tree.edit() before parse()
-        // to inform tree-sitter of document changes. Without proper edit tracking,
-        // passing the old tree causes highlighting corruption. Full reparse for now.
-        self.tree = self.parser.parse(&self.source_cache, None);
+        // Reuse the old tree when it belongs to this exact buffer and
+        // language AND the buffer's edit queue covers precisely the span
+        // since the last parse. tree.edit() maps the old tree onto the new
+        // byte layout; tree-sitter then re-lexes only around the changes.
+        let identity = (buffer.id(), self.language.clone().unwrap_or_default());
+        let mut old_tree = None;
+        if !incremental_parse_disabled() && self.incremental_identity.as_ref() == Some(&identity) {
+            if let (Some(mut tree), Some(edits)) = (
+                self.tree.take(),
+                buffer.take_edits_since(self.parse_version),
+            ) {
+                for edit in &edits {
+                    tree.edit(&to_input_edit(edit));
+                }
+                old_tree = Some(tree);
+            }
+        }
+        if old_tree.is_none() {
+            buffer.reset_edit_history();
+        }
+        self.tree = self.parser.parse(&self.source_cache, old_tree.as_ref());
+        self.incremental_identity = self.tree.is_some().then_some(identity);
         self.parse_version = buffer.version();
         self.cache_version.set(self.parse_version);
         self.highlight_cache
@@ -620,6 +681,7 @@ impl SyntaxManager {
             }
         }
         self.tree = self.parser.parse(&self.source_cache, None);
+        self.incremental_identity = None;
         self.parse_version = self.parse_version.wrapping_add(1);
         self.cache_version.set(self.parse_version);
         self.highlight_cache
@@ -951,7 +1013,7 @@ mod tests {
 
         let mut buffer = Buffer::new();
         buffer.set_content("{\"enabled\": true}\n");
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("json"));
         assert!(syntax.has_highlighting());
@@ -968,7 +1030,7 @@ mod tests {
 
         let mut buffer = Buffer::new();
         buffer.set_content("$accent: #ff00aa;\n.button { color: $accent; }\n");
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("scss"));
         assert!(syntax.has_highlighting());
@@ -985,7 +1047,7 @@ mod tests {
 
         let mut buffer = Buffer::new();
         buffer.set_content("package main\n\nfunc main() {\n\tprintln(\"hello\")\n}\n");
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("go"));
         assert!(syntax.has_highlighting());
@@ -1004,7 +1066,7 @@ mod tests {
         buffer.set_content(
             "class Greeter\n  def hello(name)\n    puts \"hello #{name}\"\n  end\nend\n",
         );
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("ruby"));
         assert!(syntax.has_highlighting());
@@ -1021,7 +1083,7 @@ mod tests {
 
         let mut buffer = Buffer::new();
         buffer.set_content("source \"https://rubygems.org\"\ngem \"rails\"\n");
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("ruby"));
         assert!(syntax.has_highlighting());
@@ -1040,7 +1102,7 @@ mod tests {
         buffer.set_content(
             "<?php\nfunction greet(string $name): void {\n    echo \"Hello $name\";\n}\n",
         );
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
 
         assert_eq!(syntax.language_name(), Some("php"));
         assert!(syntax.has_highlighting());
@@ -1059,7 +1121,7 @@ mod tests {
     fn parse_shell_snippet(syntax: &mut SyntaxManager) {
         let mut buffer = Buffer::new();
         buffer.set_content("if true; then\n  echo hello\nfi\n");
-        syntax.parse(&buffer);
+        syntax.parse(&mut buffer);
         assert_eq!(syntax.language_name(), Some("shell"));
         assert!(syntax.has_highlighting());
         assert!(
@@ -1155,5 +1217,133 @@ mod tests {
         assert!(shebang_is_shell("#!/usr/bin/env zsh"));
         assert!(!shebang_is_shell("#!/usr/bin/env fish"));
         assert!(!shebang_is_shell("echo hi"));
+    }
+
+    use crate::editor::Buffer;
+
+    /// The incremental tree must be indistinguishable from a from-scratch
+    /// parse of the same text. This is the guard whose absence caused the
+    /// original old-tree corruption.
+    fn assert_tree_matches_fresh_parse(syntax: &SyntaxManager) {
+        let (tree, source) = syntax.get_tree_and_source().expect("tree after parse");
+        let mut fresh_parser = Parser::new();
+        fresh_parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("rust grammar");
+        let fresh = fresh_parser.parse(source, None).expect("fresh parse");
+        assert_eq!(
+            tree.root_node().to_sexp(),
+            fresh.root_node().to_sexp(),
+            "incremental tree diverged from full parse\nsource:\n{source}"
+        );
+    }
+
+    fn rust_syntax_and_buffer(content: &str) -> (SyntaxManager, Buffer) {
+        let mut syntax = SyntaxManager::new();
+        syntax.set_language_from_path(Path::new("fuzz.rs"));
+        let mut buffer = Buffer::new();
+        buffer.insert_str(0, 0, content);
+        syntax.parse(&mut buffer);
+        (syntax, buffer)
+    }
+
+    #[test]
+    fn incremental_parse_survives_targeted_edits() {
+        let (mut syntax, mut buffer) = rust_syntax_and_buffer("fn main() {\n    let x = 1;\n}\n");
+
+        // Insert a newline mid-line, splitting a statement.
+        buffer.insert_char(1, 7, '\n');
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+
+        // Multibyte insert before existing code.
+        buffer.insert_str(0, 3, "h\u{e9}llo_\u{2713}");
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+
+        // Delete a range spanning lines.
+        buffer.delete_range(0, 2, 2, 1);
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+
+        // replace_line and the undo-shaped apply_change.
+        buffer.replace_line(0, "fn other() { let y = 2; }");
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+
+        buffer.apply_change(0, 3, "other", "renamed");
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+    }
+
+    #[test]
+    fn incremental_parse_matches_full_parse_under_random_edits() {
+        let (mut syntax, mut buffer) = rust_syntax_and_buffer(
+            "fn main() {\n    let x = 1;\n    println!(\"h\u{e9}llo {}\", x);\n}\n",
+        );
+        assert_tree_matches_fresh_parse(&syntax);
+
+        // Deterministic xorshift so failures reproduce.
+        let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+        let mut rand = move || {
+            seed ^= seed << 13;
+            seed ^= seed >> 7;
+            seed ^= seed << 17;
+            seed
+        };
+        let snippets = [
+            "let y = 2;",
+            "fn f() {}",
+            "\u{e9}\u{2713}",
+            "\"s\"",
+            "}",
+            "{",
+            "// note \u{f8}\n",
+        ];
+
+        for _ in 0..150 {
+            // 1-4 edits per parse, like a debounced typing burst.
+            for _ in 0..(1 + rand() % 4) {
+                let line_count = buffer.addressable_line_count().max(1);
+                let line = (rand() as usize) % line_count;
+                let col = (rand() as usize) % (buffer.line_len(line) + 1);
+                match rand() % 4 {
+                    0 => {
+                        let s = snippets[(rand() as usize) % snippets.len()];
+                        buffer.insert_str(line, col, s);
+                    }
+                    1 => {
+                        let ch = ['a', '\u{e9}', '\n', '}'][(rand() as usize) % 4];
+                        buffer.insert_char(line, col, ch);
+                    }
+                    2 => buffer.delete_char(line, col),
+                    _ => {
+                        let end_line = (line + (rand() as usize) % 2)
+                            .min(buffer.addressable_line_count().saturating_sub(1));
+                        let end_col = (rand() as usize) % (buffer.line_len(end_line) + 1);
+                        buffer.delete_range(line, col, end_line, end_col);
+                    }
+                }
+            }
+            syntax.parse(&mut buffer);
+            assert_tree_matches_fresh_parse(&syntax);
+        }
+    }
+
+    #[test]
+    fn bulk_replace_and_buffer_switch_fall_back_to_full_parse() {
+        let (mut syntax, mut buffer) = rust_syntax_and_buffer("fn a() {}\n");
+
+        // set_content breaks the edit history; the next parse must be full
+        // and still correct.
+        buffer.set_content("fn b() { let z = 3; }\n");
+        syntax.parse(&mut buffer);
+        assert_tree_matches_fresh_parse(&syntax);
+
+        // A different buffer must never reuse this buffer's tree.
+        let mut other = Buffer::new();
+        other.insert_str(0, 0, "fn c() {}\n");
+        syntax.parse(&mut other);
+        assert_tree_matches_fresh_parse(&syntax);
     }
 }


### PR DESCRIPTION
This is the biggest perf change in the editor and it touches the parse path behind every single edit, so the description is longer than usual.

## What it does

Until now, every change to a buffer threw away the entire syntax tree and reparsed the whole file from scratch: every debounced edit while typing, every undo and redo, and every line of a gg=G re-indent. On large files that was the dominant editing cost.

The buffer now records each mutation in tree-sitter's edit shape (byte offsets plus row and column points). All writes already go through a handful of Buffer methods, so that is the single place edits are recorded. At parse time the syntax layer drains those edits, applies them to the previous tree with tree.edit, and reparses with the old tree, so tree-sitter only re-analyzes around what changed.

## Numbers

| What | Before | After |
| --- | --- | --- |
| Reparse while editing an 18k line file | 43.8ms | 5.4ms |
| gg=G on a 2.1k line messy file | 8.0s blocked | about 1.3s |
| Cost per parse inside that gg=G | 3.5ms | 0.4ms |

The remaining gg=G time is the per line indent computation itself, which is serial by nature (each line's indent depends on the previous line's new indent). A single pass batch indent could cut it further but changes behavior for cascading indents, so it is left for its own change.

## Why it is safe to reuse the tree now

Reusing the old tree without edit tracking is exactly what corrupted highlighting when this was tried before, which is why the code carried a full reparse comment for so long. What is different now:

- The incremental path only runs when three things all match: the tree belongs to this exact buffer, the language is unchanged, and the recorded edits exactly cover the span since the last parse. Anything else (buffer switch, reload, formatter replacing the content, language change, edit queue overflow) falls back to a full parse and restarts the history.
- A fuzz test runs 150 rounds of random multi edit bursts (inserts, deletes, newlines, multibyte text) and asserts after every round that the incremental tree is identical to a from scratch parse of the same text. That equivalence check is the guard that did not exist before.
- Targeted tests cover the classic traps: multibyte byte offsets, edits spanning newlines, replace line, and the undo shaped change path.
- NEVI_INCREMENTAL_PARSE=0 forces the old full reparse path at runtime, as an escape hatch for the first release.

Also folded in: the auto indent path only reparses when the buffer version actually changed, instead of unconditionally per line.

## What stays a full parse

First parse of a file, buffer switches, reloads from disk, formatter output, and language changes. Those are correct fallbacks, not gaps.