### PR TITLE
fix: anchor search at its origin and cover the search family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@
 
 ### Vim Compatibility
 
+- Search now anchors at the position where `/` or `?` was pressed, like Vim. Every keystroke evaluates the whole pattern from that origin instead of chasing the cursor around, so editing the pattern with backspace cannot land on an earlier match than Vim would. Escape cancels back to the original cursor and view, and a pattern with no match leaves the cursor where the search started.
+- Repeating a search with an empty prompt (`/` or `?` then Enter) now moves off a match under the cursor instead of standing still, and it updates the direction that `n` and `N` follow, so `n` after `?` and Enter keeps searching backward.
+- `n` and `N` now take a count, so `3n` jumps three matches ahead.
+- `gN` now leaves the cursor on the start of the selected match like Vim. It used to sit on the end, same as `gn`.
+- Extended Vim oracle coverage to the search family: `/`, `?`, `n`, `N`, `*`, `#`, `gn`, `gN`, and the search prompt editing keys (`Backspace`, `Ctrl+w`, `Ctrl+u`, `Ctrl+b`, `Ctrl+e`, `Ctrl+r`, history recall with `Up`), all verified against real Neovim and tracked in `PARITY.md`.
 - Fixed the quote text objects (`i"`, `a"`, `i'`, `a'`, `` i` ``, `` a` ``) doing nothing when the cursor sits before the first quote. They now seek forward on the line, as in Vim, so `ci"` works from the start of the line.
 - Fixed `a"` and friends not spanning surrounding whitespace. They now take the trailing whitespace after the closing quote, or the leading whitespace when there is none trailing.
 - Fixed `ip` and `ap` on a blank line operating on the next paragraph instead of the blank lines themselves, and `ap` after a paragraph now takes all trailing blank lines instead of just one.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -435,7 +435,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `gn` | Search forward and select match |
 | `gN` | Search backward and select match |
 
-> **Tip:** Search supports regex. Use `\c` at the start for case-insensitive search (e.g., `/\cfoo`).
+> **Note:** Search matches literal text and is case sensitive, like Vim with default settings. Regex patterns are not supported yet.
 
 ### Search Prompt Editing
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -10,13 +10,13 @@ the test suite enforces, so it cannot drift from what is actually verified.
 ## Summary
 
 - **339 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **88 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **159 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 151 verified against real Neovim (v0.11.3) by the Vim oracle
+- **167 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 159 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **366 oracle cases**: motions (144), editing (132), insert-entry (11), open-line (20), replace (27), text-objects (30), undo-redo (2)
+- **402 oracle cases**: motions (144), editing (132), insert-entry (11), open-line (20), replace (27), search (36), text-objects (30), undo-redo (2)
 - **0 tracked coverage gaps**
-- **213 of 438 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **224 of 438 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -187,6 +187,14 @@ claim protection.
 | `zz` | Center cursor line | `center cursor line` |
 | `zt` | Move cursor line to top | `cursor line to top` |
 | `zb` | Move cursor line to bottom | `cursor line to bottom` |
+| `/` | Search forward | `search forward lands on match start` |
+| `?` | Search backward | `search backward lands on previous match` |
+| `n` | Go to next match | `next match` |
+| `N` | Go to previous match | `previous match reverses direction` |
+| `*` | Search word under cursor forward | `star searches word forward` |
+| `#` | Search word under cursor backward | `hash searches word backward` |
+| `gn` | Search forward and select match | `gn selects next match from outside` |
+| `gN` | Search backward and select match | `gN selects match backward` |
 
 ## Protected by Nevi regression tests
 
@@ -222,7 +230,7 @@ like `dw` are tracked as single inventory entries, so their building-block
 rows may already be covered compositionally.)
 
 <details>
-<summary>225 untracked rows</summary>
+<summary>214 untracked rows</summary>
 
 | Keybind | Behavior |
 |---------|----------|
@@ -239,14 +247,6 @@ rows may already be covered compositionally.)
 | `<{motion}` | Dedent with motion |
 | `==` | Auto-indent current line |
 | `={motion}` | Auto-indent with motion |
-| `/` | Search forward |
-| `?` | Search backward |
-| `n` | Go to next match |
-| `N` | Go to previous match |
-| `*` | Search word under cursor forward |
-| `#` | Search word under cursor backward |
-| `gn` | Search forward and select match |
-| `gN` | Search backward and select match |
 | `Up` | Navigate to previous search history entry |
 | `Down` | Navigate to next search history entry |
 | `m{A-Z}` | Set global mark (works across files) |
@@ -360,14 +360,11 @@ rows may already be covered compositionally.)
 | `g` | Go to first result |
 | `K` | Move selected Harpoon item up |
 | `Tab` | Toggle expand/collapse |
-| `?` | Show explorer keymaps |
 | `Ctrl+l` | Focus editor and keep explorer open |
 | `>` | Widen explorer sidebar |
 | `<` | Narrow explorer sidebar |
 | `=` | Reset explorer sidebar width |
 | `r` | Rename selected item |
-| `/` | Search explorer |
-| `n` / `N` | Next/previous search match |
 | `]h` | Go to next harpoon file |
 | `[h` | Go to previous harpoon file |
 | `1` - `9` | Open the numbered recent file |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -353,6 +353,20 @@ pub struct SearchState {
     /// `[current/total]` counter for the statusline, recomputed on search
     /// jumps (/, ?, n, N, *, #) — never counted during render.
     pub match_stats: Option<(usize, usize)>,
+    /// Cursor and view when the search prompt opened. Vim's incsearch model:
+    /// every keystroke evaluates the whole pattern from here (not from
+    /// wherever the previous keystroke moved the cursor), and cancelling or
+    /// failing the search restores this position.
+    pub origin: Option<SearchOrigin>,
+}
+
+/// Position saved when a `/` or `?` prompt opens, restored on cancel/failure.
+#[derive(Debug, Clone, Copy)]
+pub struct SearchOrigin {
+    pub line: usize,
+    pub col: usize,
+    pub viewport_offset: usize,
+    pub h_offset: usize,
 }
 
 impl SearchState {
@@ -364,6 +378,7 @@ impl SearchState {
         self.saved_input = None;
         self.pending_register = false;
         self.match_stats = None;
+        self.origin = None;
     }
 
     /// Start a new search
@@ -375,6 +390,7 @@ impl SearchState {
         self.saved_input = None;
         self.pending_register = false;
         self.match_stats = None;
+        self.origin = None;
     }
 
     /// Insert a character at cursor (cursor is character index, not byte index)
@@ -537,6 +553,9 @@ impl SearchState {
 
     /// Execute search and save pattern
     pub fn execute(&mut self) -> Option<String> {
+        // n/N follow the direction of the latest `/` or `?`, even when it
+        // repeated the previous pattern with an empty input (Vim behavior).
+        self.last_direction = self.direction;
         if self.input.is_empty() {
             // Use last pattern if input is empty
             self.last_pattern.clone()
@@ -544,7 +563,6 @@ impl SearchState {
             let pattern = self.input.clone();
             self.record_history(pattern.clone());
             self.last_pattern = Some(pattern.clone());
-            self.last_direction = self.direction;
             Some(pattern)
         }
     }
@@ -6908,6 +6926,7 @@ impl Editor {
     pub fn enter_search_forward(&mut self) {
         self.mode = Mode::Search;
         self.search.start(SearchDirection::Forward);
+        self.record_search_origin();
         self.render_damage.mark_full();
     }
 
@@ -6915,12 +6934,34 @@ impl Editor {
     pub fn enter_search_backward(&mut self) {
         self.mode = Mode::Search;
         self.search.start(SearchDirection::Backward);
+        self.record_search_origin();
         self.render_damage.mark_full();
     }
 
-    /// Exit search mode
+    fn record_search_origin(&mut self) {
+        self.search.origin = Some(SearchOrigin {
+            line: self.cursor.line,
+            col: self.cursor.col,
+            viewport_offset: self.viewport_offset,
+            h_offset: self.h_offset,
+        });
+    }
+
+    /// Put the cursor and view back where the search prompt opened.
+    fn restore_search_origin(&mut self) {
+        if let Some(origin) = self.search.origin {
+            self.cursor.line = origin.line;
+            self.cursor.col = origin.col;
+            self.viewport_offset = origin.viewport_offset;
+            self.h_offset = origin.h_offset;
+        }
+    }
+
+    /// Exit search mode without executing (Esc / Ctrl+c), restoring the
+    /// position the prompt opened from like Vim's incsearch cancel.
     pub fn exit_search_mode(&mut self) {
         self.mode = Mode::Normal;
+        self.restore_search_origin();
         self.search.clear();
         self.search_matches.clear();
         self.render_damage.mark_full();
@@ -6942,6 +6983,9 @@ impl Editor {
     /// is limited to visible rows so rendering stays bounded.
     pub fn update_incremental_search(&mut self) {
         let pattern = self.search.input.clone();
+        // Evaluate the whole pattern from the origin every keystroke; when
+        // it stops matching (or is emptied), the view snaps back there.
+        self.restore_search_origin();
         if pattern.is_empty() {
             self.search_matches.clear();
             self.render_damage.mark_full();
@@ -6965,9 +7009,11 @@ impl Editor {
         let direction = self.search.direction;
         if let Some(pattern) = self.search.execute() {
             self.mode = Mode::Normal;
-            if self.cursor_starts_search_match(&pattern)
-                || self.do_search(&pattern, direction, true)
-            {
+            // The final search runs from the origin, like the incremental
+            // preview: the match the user saw is the match they get, and a
+            // failed pattern leaves the cursor where the prompt opened.
+            self.restore_search_origin();
+            if self.do_search(&pattern, direction, true) {
                 self.refresh_visible_search_matches(&pattern);
                 self.update_search_match_stats(&pattern);
             } else {
@@ -6979,40 +7025,38 @@ impl Editor {
             self.mode = Mode::Normal;
             self.set_status("No previous search pattern");
         }
+        self.search.origin = None;
     }
 
     /// Search for next occurrence (n)
-    pub fn search_next(&mut self) {
-        self.render_damage.mark_full();
-        if let Some(pattern) = self.search.last_pattern.clone() {
-            // Record jump before searching (search is a jump motion)
-            self.record_jump();
-            let direction = self.search.last_direction;
-            if self.do_search(&pattern, direction, true) {
-                self.refresh_visible_search_matches(&pattern);
-                self.update_search_match_stats(&pattern);
-            } else {
-                self.search_matches.clear();
-                self.search.match_stats = None;
-                self.set_status(format!("Pattern not found: {}", pattern));
-            }
-        } else {
-            self.set_status("No previous search pattern");
-        }
+    pub fn search_next(&mut self, count: usize) {
+        let direction = self.search.last_direction;
+        self.repeat_search(direction, count);
     }
 
     /// Search for previous occurrence (N)
-    pub fn search_prev(&mut self) {
+    pub fn search_prev(&mut self, count: usize) {
+        let direction = match self.search.last_direction {
+            SearchDirection::Forward => SearchDirection::Backward,
+            SearchDirection::Backward => SearchDirection::Forward,
+        };
+        self.repeat_search(direction, count);
+    }
+
+    /// Shared n/N body: one recorded jump, then `count` search hops.
+    fn repeat_search(&mut self, direction: SearchDirection, count: usize) {
         self.render_damage.mark_full();
         if let Some(pattern) = self.search.last_pattern.clone() {
             // Record jump before searching (search is a jump motion)
             self.record_jump();
-            // Reverse the direction
-            let direction = match self.search.last_direction {
-                SearchDirection::Forward => SearchDirection::Backward,
-                SearchDirection::Backward => SearchDirection::Forward,
-            };
-            if self.do_search(&pattern, direction, true) {
+            let mut found = true;
+            for _ in 0..count.max(1) {
+                if !self.do_search(&pattern, direction, true) {
+                    found = false;
+                    break;
+                }
+            }
+            if found {
                 self.refresh_visible_search_matches(&pattern);
                 self.update_search_match_stats(&pattern);
             } else {
@@ -7162,31 +7206,6 @@ impl Editor {
         }
     }
 
-    fn cursor_starts_search_match(&self, pattern: &str) -> bool {
-        if pattern.is_empty() {
-            return false;
-        }
-
-        let Some(line) = self.buffers[self.current_buffer_idx].line(self.cursor.line) else {
-            return false;
-        };
-
-        let pattern_len = pattern.chars().count();
-        let line_len = line.len_chars();
-        if self.cursor.col.saturating_add(pattern_len) > line_len {
-            return false;
-        }
-
-        let mut line_chars = line.slice(self.cursor.col..line_len).chars();
-        for expected in pattern.chars() {
-            if line_chars.next() != Some(expected) {
-                return false;
-            }
-        }
-
-        true
-    }
-
     /// Search for word under cursor forward (*)
     pub fn search_word_forward(&mut self) {
         self.render_damage.mark_full();
@@ -7254,9 +7273,20 @@ impl Editor {
 
         self.record_jump();
         self.mode = Mode::Visual;
-        self.visual = VisualSelection::new(line, start_col);
+        let last_col = end_col.saturating_sub(1).max(start_col);
+        match direction {
+            // gn anchors at the match start and puts the cursor on its end;
+            // gN mirrors that (cursor on the start, anchored at the end).
+            SearchDirection::Forward => {
+                self.visual = VisualSelection::new(line, start_col);
+                self.cursor.col = last_col;
+            }
+            SearchDirection::Backward => {
+                self.visual = VisualSelection::new(line, last_col);
+                self.cursor.col = start_col;
+            }
+        }
         self.cursor.line = line;
-        self.cursor.col = end_col.saturating_sub(1).max(start_col);
         self.scroll_to_cursor();
     }
 
@@ -12228,15 +12258,63 @@ mod tests {
         editor.execute_search();
         assert_eq!(editor.search.match_stats, Some((1, 4)));
 
-        editor.search_next();
+        editor.search_next(1);
         assert_eq!(editor.search.match_stats, Some((2, 4)));
 
-        editor.search_prev();
+        editor.search_prev(1);
         assert_eq!(editor.search.match_stats, Some((1, 4)));
 
         // Counter shares the highlight lifecycle: any non-search movement clears it.
         editor.clear_search_highlights();
         assert_eq!(editor.search.match_stats, None);
+    }
+
+    // The oracle can't see h_offset (its lines never scroll horizontally), so
+    // the horizontal half of the origin restore needs a native regression.
+    #[test]
+    fn cancelled_search_restores_cursor_viewport_and_h_offset() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 10);
+        editor.settings.editor.wrap = false;
+        let mut content = format!("{}tail\n", "x".repeat(120));
+        for _ in 0..20 {
+            content.push_str("filler\n");
+        }
+        content.push_str("beta\n");
+        editor.replace_buffer_content(&content);
+        editor.cursor.col = 120;
+        editor.scroll_to_cursor();
+        assert!(
+            editor.h_offset > 0,
+            "setup needs a horizontally scrolled view"
+        );
+        let origin = (
+            editor.cursor.line,
+            editor.cursor.col,
+            editor.viewport_offset,
+            editor.h_offset,
+        );
+
+        editor.enter_search_forward();
+        for ch in "beta".chars() {
+            editor.search.insert_char(ch);
+            editor.update_incremental_search();
+        }
+        // The preview scrolled to the match near the bottom of the file.
+        assert_ne!(editor.cursor.line, origin.0);
+        assert_eq!(editor.h_offset, 0);
+
+        editor.exit_search_mode();
+
+        assert_eq!(
+            (
+                editor.cursor.line,
+                editor.cursor.col,
+                editor.viewport_offset,
+                editor.h_offset,
+            ),
+            origin
+        );
     }
 
     #[test]
@@ -12254,7 +12332,7 @@ mod tests {
         editor.cursor.line = 0;
         editor.cursor.col = 0;
 
-        editor.search_next();
+        editor.search_next(1);
 
         assert_eq!(editor.cursor.line, 1);
         let visible_rows = editor.text_rows();
@@ -12336,7 +12414,7 @@ mod tests {
         editor.execute_search();
 
         let first_match = (editor.cursor.line, editor.cursor.col);
-        editor.search_next();
+        editor.search_next(1);
 
         assert_eq!((editor.cursor.line, editor.cursor.col), first_match);
         assert_ne!(
@@ -12357,7 +12435,7 @@ mod tests {
         editor.execute_search();
 
         let first_match = (editor.cursor.line, editor.cursor.col);
-        editor.search_prev();
+        editor.search_prev(1);
 
         assert_eq!((editor.cursor.line, editor.cursor.col), first_match);
         assert_ne!(

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -186,10 +186,10 @@ pub enum KeyAction {
     EnterSearchForward,
     /// Enter search mode (backward)
     EnterSearchBackward,
-    /// Search next (n)
-    SearchNext,
-    /// Search previous (N)
-    SearchPrev,
+    /// Search next (n), repeated count times
+    SearchNext(usize),
+    /// Search previous (N), repeated count times
+    SearchPrev(usize),
     /// Search word under cursor forward (*)
     SearchWordForward,
     /// Search word under cursor backward (#)
@@ -1211,12 +1211,14 @@ impl InputState {
                 KeyAction::EnterSearchBackward
             }
             (KeyModifiers::NONE, KeyCode::Char('n')) => {
+                let count = self.effective_count();
                 self.reset();
-                KeyAction::SearchNext
+                KeyAction::SearchNext(count)
             }
             (KeyModifiers::SHIFT, KeyCode::Char('N')) => {
+                let count = self.effective_count();
                 self.reset();
-                KeyAction::SearchPrev
+                KeyAction::SearchPrev(count)
             }
             // Star search (* and #)
             (_, KeyCode::Char('*')) => {
@@ -2643,12 +2645,20 @@ mod tests {
             other => panic!("expected EnterSearchBackward, got {:?}", other),
         }
         match run(&[key('n')]) {
-            KeyAction::SearchNext => {}
-            other => panic!("expected SearchNext, got {:?}", other),
+            KeyAction::SearchNext(1) => {}
+            other => panic!("expected SearchNext(1), got {:?}", other),
+        }
+        match run(&[key('3'), key('n')]) {
+            KeyAction::SearchNext(3) => {}
+            other => panic!("expected SearchNext(3), got {:?}", other),
         }
         match run(&[shift('N')]) {
-            KeyAction::SearchPrev => {}
-            other => panic!("expected SearchPrev, got {:?}", other),
+            KeyAction::SearchPrev(1) => {}
+            other => panic!("expected SearchPrev(1), got {:?}", other),
+        }
+        match run(&[key('2'), shift('N')]) {
+            KeyAction::SearchPrev(2) => {}
+            other => panic!("expected SearchPrev(2), got {:?}", other),
         }
         match run(&[key('*')]) {
             KeyAction::SearchWordForward => {}

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -490,6 +490,41 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     vim_oracle("zz", "Center cursor line", "center cursor line"),
     vim_oracle("zt", "Move cursor line to top", "cursor line to top"),
     vim_oracle("zb", "Move cursor line to bottom", "cursor line to bottom"),
+    // Search-family batch. The prompt-editing keys (Ctrl+b/e/w/u, Ctrl+r,
+    // Up/Down) share key spellings with insert/scroll entries above, so they
+    // stay pinned by oracle cases without their own inventory rows.
+    vim_oracle("/", "Search forward", "search forward lands on match start"),
+    vim_oracle(
+        "?",
+        "Search backward",
+        "search backward lands on previous match",
+    ),
+    vim_oracle("n", "Go to next match", "next match"),
+    vim_oracle(
+        "N",
+        "Go to previous match",
+        "previous match reverses direction",
+    ),
+    vim_oracle(
+        "*",
+        "Search word under cursor forward",
+        "star searches word forward",
+    ),
+    vim_oracle(
+        "#",
+        "Search word under cursor backward",
+        "hash searches word backward",
+    ),
+    vim_oracle(
+        "gn",
+        "Search forward and select match",
+        "gn selects next match from outside",
+    ),
+    vim_oracle(
+        "gN",
+        "Search backward and select match",
+        "gN selects match backward",
+    ),
     KeybindCoverage {
         mode: KeybindMode::Normal,
         key: "1-9 (start screen)",

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7803,12 +7803,12 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.enter_search_backward();
         }
 
-        KeyAction::SearchNext => {
-            editor.search_next();
+        KeyAction::SearchNext(count) => {
+            editor.search_next(count);
         }
 
-        KeyAction::SearchPrev => {
-            editor.search_prev();
+        KeyAction::SearchPrev(count) => {
+            editor.search_prev(count);
         }
 
         KeyAction::SearchWordForward => {

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -9,12 +9,14 @@ mod editing_cases;
 mod insert_entry_cases;
 mod open_line_cases;
 mod replace_cases;
+mod search_cases;
 mod text_object_cases;
 
 use editing_cases::EDITING_CASES;
 use insert_entry_cases::INSERT_ENTRY_CASES;
 use open_line_cases::OPEN_LINE_CASES;
 use replace_cases::REPLACE_CASES;
+use search_cases::SEARCH_CASES;
 use text_object_cases::TEXT_OBJECT_CASES;
 
 #[derive(Debug, Clone, Copy)]
@@ -1008,6 +1010,10 @@ const ORACLE_CATEGORIES: &[OracleCategory] = &[
     OracleCategory {
         name: "replace",
         cases: REPLACE_CASES,
+    },
+    OracleCategory {
+        name: "search",
+        cases: SEARCH_CASES,
     },
     OracleCategory {
         name: "text-objects",

--- a/src/vim_oracle/search_cases.rs
+++ b/src/vim_oracle/search_cases.rs
@@ -1,0 +1,207 @@
+use super::OracleCase;
+
+/// Search-family cases: `/`, `?`, `n`, `N`, `*`, `#`, `gn`, `gN`, and the
+/// search prompt editing keys, verified against real Neovim. Both editors
+/// default to case-sensitive search with wrapscan on, so plain-text patterns
+/// compare directly. Nevi's search is a literal substring match (no regex),
+/// so every pattern here is literal on both sides.
+pub(super) const SEARCH_CASES: &[OracleCase] = &[
+    // Forward search basics.
+    OracleCase {
+        name: "search forward lands on match start",
+        initial_text: "alpha\nsome beta here\ngamma\n",
+        keys: "/beta<CR>",
+    },
+    OracleCase {
+        name: "search forward skips match at cursor",
+        initial_text: "beta x beta\n",
+        keys: "/beta<CR>",
+    },
+    OracleCase {
+        name: "search forward wraps to top",
+        initial_text: "beta\nalpha\ngamma\n",
+        keys: "G/beta<CR>",
+    },
+    OracleCase {
+        name: "search not found leaves cursor",
+        initial_text: "alpha\nbeta\n",
+        keys: "/zzz<CR>",
+    },
+    // Incremental typing moves the cursor while a prefix matches; a failed
+    // final pattern must land back on the original position like nvim.
+    OracleCase {
+        name: "search not found after partial match restores cursor",
+        initial_text: "alpha\nbetx\n",
+        keys: "/betz<CR>",
+    },
+    OracleCase {
+        name: "search is case sensitive",
+        initial_text: "Beta\nbeta\n",
+        keys: "/beta<CR>",
+    },
+    OracleCase {
+        name: "empty search repeats last pattern",
+        initial_text: "alpha\nbeta\nbeta tail\n",
+        keys: "/beta<CR>gg/<CR>",
+    },
+    // Backward search.
+    OracleCase {
+        name: "search backward lands on previous match",
+        initial_text: "beta\nalpha\nbeta\ngamma\n",
+        keys: "G?beta<CR>",
+    },
+    OracleCase {
+        name: "search backward wraps to bottom",
+        initial_text: "alpha\nbeta\n",
+        keys: "?beta<CR>",
+    },
+    OracleCase {
+        name: "search backward within line",
+        initial_text: "beta beta x\n",
+        keys: "$?beta<CR>",
+    },
+    // Empty ? repeats the last pattern backward AND flips the stored
+    // direction, so a following n keeps going backward.
+    OracleCase {
+        name: "empty backward search flips direction for n",
+        initial_text: "beta\nx\nbeta\nx\nbeta\n",
+        keys: "/beta<CR>G?<CR>n",
+    },
+    // n / N repeat.
+    OracleCase {
+        name: "next match",
+        initial_text: "beta\nbeta\nbeta\n",
+        keys: "/beta<CR>n",
+    },
+    OracleCase {
+        name: "next match wraps",
+        initial_text: "beta\nbeta\nbeta\n",
+        keys: "/beta<CR>nn",
+    },
+    OracleCase {
+        name: "previous match reverses direction",
+        initial_text: "beta\nbeta\nbeta\n",
+        keys: "/beta<CR>nN",
+    },
+    OracleCase {
+        name: "n after backward search continues backward",
+        initial_text: "beta\nalpha\nbeta\nbeta\n",
+        keys: "G?beta<CR>n",
+    },
+    OracleCase {
+        name: "counted next match",
+        initial_text: "beta\nbeta\nbeta\nbeta\n",
+        keys: "/beta<CR>2n",
+    },
+    OracleCase {
+        name: "counted previous match",
+        initial_text: "beta\nbeta\nbeta\nbeta\n",
+        keys: "/beta<CR>nn2N",
+    },
+    // Word-under-cursor search.
+    OracleCase {
+        name: "star searches word forward",
+        initial_text: "beta alpha\ngamma\nbeta tail\n",
+        keys: "*",
+    },
+    OracleCase {
+        name: "star wraps to only occurrence",
+        initial_text: "beta\nalpha\n",
+        keys: "*",
+    },
+    OracleCase {
+        name: "star from middle of word",
+        initial_text: "beta alpha beta\n",
+        keys: "ll*",
+    },
+    OracleCase {
+        name: "star then n continues forward",
+        initial_text: "beta\nalpha beta\nbeta\n",
+        keys: "*n",
+    },
+    OracleCase {
+        name: "hash searches word backward",
+        initial_text: "beta\nalpha\nbeta gamma\n",
+        keys: "G#",
+    },
+    OracleCase {
+        name: "hash from middle of word",
+        initial_text: "beta x\nbeta\n",
+        keys: "jl#",
+    },
+    // gn / gN select the match in visual mode. gn leaves the cursor on the
+    // match end, gN on the match start.
+    OracleCase {
+        name: "gn selects current match",
+        initial_text: "alpha\nbeta\ngamma beta\n",
+        keys: "/beta<CR>gn",
+    },
+    OracleCase {
+        name: "gn selects next match from outside",
+        initial_text: "alpha\nbeta\ngamma beta\n",
+        keys: "/beta<CR>gggn",
+    },
+    OracleCase {
+        name: "counted gn selects a later match",
+        initial_text: "beta\nbeta\nbeta\n",
+        keys: "/beta<CR>gg2gn",
+    },
+    OracleCase {
+        name: "gN selects match backward",
+        initial_text: "beta\nbeta\ngamma\n",
+        keys: "/beta<CR>GgN",
+    },
+    // Search prompt editing (vim cmdline keys).
+    OracleCase {
+        name: "prompt backspace reanchors at origin",
+        initial_text: "ac\nab\nac\n",
+        keys: "/ab<BS>c<CR>",
+    },
+    OracleCase {
+        name: "prompt ctrl-w deletes word",
+        initial_text: "alpha\nbeta\n",
+        keys: "/junk<C-w>beta<CR>",
+    },
+    OracleCase {
+        name: "prompt ctrl-u clears input",
+        initial_text: "alpha\nbeta\n",
+        keys: "/alpha<C-u>beta<CR>",
+    },
+    OracleCase {
+        name: "prompt ctrl-b inserts at start",
+        initial_text: "alpha\nbeta\n",
+        keys: "/eta<C-b>b<CR>",
+    },
+    OracleCase {
+        name: "prompt ctrl-e returns to end",
+        initial_text: "alpha\nbeta\n",
+        keys: "/et<C-b>b<C-e>a<CR>",
+    },
+    OracleCase {
+        name: "prompt history recall",
+        initial_text: "alpha\nbeta\nbeta tail\n",
+        keys: "/beta<CR>gg/<Up><CR>",
+    },
+    OracleCase {
+        name: "prompt register insert",
+        initial_text: "alpha\nbeta\nalpha end\n",
+        keys: "yiwj/<C-r>0<CR>",
+    },
+    // Cancelling restores the position the search started from.
+    OracleCase {
+        name: "escape cancels and restores cursor",
+        initial_text: "alpha\nbeta\n",
+        keys: "/beta<Esc>",
+    },
+    OracleCase {
+        name: "escape restores viewport after distant match",
+        initial_text: super::SCREEN_POSITION_TEXT,
+        keys: "50Gzz/line 090<Esc>",
+    },
+];
+
+// Known divergence, deliberately not an active case (it would fail CI):
+// vim's * searches with word boundaries (\<abc\>), Nevi searches the literal
+// word text, so * on "abc" also matches inside "abcdef".
+//   initial_text: "abc abcdef\nabc\n", keys: "*"
+//   nvim lands on (1, 0); Nevi lands on (0, 4).


### PR DESCRIPTION
Search had no memory of where it started. The incremental preview reevaluated the pattern from wherever the previous keystroke had moved the cursor, so backspacing could land on a match vim never picks, and escape or a failed pattern left the cursor stranded at the preview position. Search now records the origin when the prompt opens, evaluates every keystroke from there, and restores it on cancel or failure.

Also fixed along the way: `n` and `N` ignored counts, `gN` put the cursor on the match end instead of the start, and repeating a search with an empty prompt did not update the direction `n` follows.

Adds a search category to the vim oracle with 36 cases covering `/`, `?`, `n`, `N`, `*`, `#`, `gn`, `gN`, and the prompt editing keys, all verified against real Neovim, plus a native regression for the horizontal scroll restore. One divergence is filed instead of fixed here: #310. The KEYBINDINGS.md search tip claimed regex support that does not exist, it now says search is literal.
