### PR TITLE
fix: search whole words with * and #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- `*` and `#` now search for the whole word only, like Vim's `\<word\>`, so `*` on `abc` no longer stops inside `abcdef`. Everything that reuses the pattern follows along: `n`, `N`, `gn`, `gN`, the highlights, the match counter, and an empty `/` prompt. The pattern also goes into the search history, so `/` then Up recalls it. Typing `\<` and `\>` in a search works the same way; plain patterns still match inside words. (#310)
 - Search now anchors at the position where `/` or `?` was pressed, like Vim. Every keystroke evaluates the whole pattern from that origin instead of chasing the cursor around, so editing the pattern with backspace cannot land on an earlier match than Vim would. Escape cancels back to the original cursor and view, and a pattern with no match leaves the cursor where the search started.
 - Repeating a search with an empty prompt (`/` or `?` then Enter) now moves off a match under the cursor instead of standing still, and it updates the direction that `n` and `N` follow, so `n` after `?` and Enter keeps searching backward.
 - `n` and `N` now take a count, so `3n` jumps three matches ahead.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -435,7 +435,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `gn` | Search forward and select match |
 | `gN` | Search backward and select match |
 
-> **Note:** Search matches literal text and is case sensitive, like Vim with default settings. Regex patterns are not supported yet.
+> **Note:** Search matches literal text and is case sensitive, like Vim with default settings. Regex patterns are not supported yet, with one exception: the word boundary atoms `\<` and `\>` work, so `/\<abc\>` matches `abc` only as a whole word. `*` and `#` search for `\<word\>` like Vim, which is why they skip the word when it sits inside a longer one.
 
 ### Search Prompt Editing
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -14,7 +14,7 @@ the test suite enforces, so it cannot drift from what is actually verified.
   - 159 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **402 oracle cases**: motions (144), editing (132), insert-entry (11), open-line (20), replace (27), search (36), text-objects (30), undo-redo (2)
+- **410 oracle cases**: motions (144), editing (132), insert-entry (11), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
 - **0 tracked coverage gaps**
 - **224 of 438 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4,6 +4,7 @@ mod macros;
 mod marks;
 mod register;
 mod replace;
+mod search_pattern;
 mod undo;
 
 pub use buffer::Buffer;
@@ -14,6 +15,7 @@ pub use register::{RegisterContent, Registers};
 pub use undo::{Change, UndoEntry, UndoStack};
 
 use replace::ReplaceSession;
+use search_pattern::SearchPattern;
 
 use crate::commands::CommandLine;
 use crate::config::{KeymapLookup, LeaderAction, LeaderHint, Settings};
@@ -7074,6 +7076,7 @@ impl Editor {
     /// skipped in large-file mode so search stays a single buffer pass there.
     fn update_search_match_stats(&mut self, pattern: &str) {
         self.search.match_stats = None;
+        let pattern = SearchPattern::parse(pattern);
         if pattern.is_empty() || self.current_buffer_large_file_mode_active() {
             return;
         }
@@ -7087,8 +7090,7 @@ impl Editor {
             };
             let line_str: String = line.chars().collect();
             let mut search_from = 0;
-            while let Some(byte_pos) = line_str[search_from..].find(pattern) {
-                let match_byte_start = search_from + byte_pos;
+            while let Some(match_byte_start) = pattern.find(&line_str, search_from) {
                 total += 1;
                 // Byte→char conversion only matters on the cursor's line.
                 if line_idx == self.cursor.line
@@ -7096,7 +7098,7 @@ impl Editor {
                 {
                     current = Some(total);
                 }
-                search_from = match_byte_start + pattern.len();
+                search_from = match_byte_start + pattern.text.len();
             }
         }
 
@@ -7112,6 +7114,7 @@ impl Editor {
         self.search_matches.clear();
         self.render_damage.mark_full();
 
+        let pattern = SearchPattern::parse(pattern);
         if pattern.is_empty() {
             return;
         }
@@ -7121,7 +7124,7 @@ impl Editor {
             return;
         }
 
-        let pattern_len = pattern.chars().count();
+        let pattern_len = pattern.text.chars().count();
 
         // Find all matches in the buffer
         for line_idx in 0..total_lines {
@@ -7131,9 +7134,8 @@ impl Editor {
                 // Find all occurrences in this line
                 let mut search_from = 0;
                 while search_from < line_str.len() {
-                    if let Some(byte_pos) = line_str[search_from..].find(pattern) {
-                        let match_byte_start = search_from + byte_pos;
-                        let match_byte_end = match_byte_start + pattern.len();
+                    if let Some(match_byte_start) = pattern.find(&line_str, search_from) {
+                        let match_byte_end = match_byte_start + pattern.text.len();
 
                         // Convert byte positions to char positions
                         let start_col = Self::byte_to_char_idx(&line_str, match_byte_start);
@@ -7155,6 +7157,7 @@ impl Editor {
         self.search_matches.clear();
         self.render_damage.mark_full();
 
+        let pattern = SearchPattern::parse(pattern);
         if pattern.is_empty() {
             return;
         }
@@ -7168,7 +7171,7 @@ impl Editor {
         let end_line = viewport_offset
             .saturating_add(visible_rows)
             .min(total_lines);
-        let pattern_len = pattern.chars().count();
+        let pattern_len = pattern.text.chars().count();
 
         'lines: for line_idx in viewport_offset..end_line {
             if let Some(line) = self.buffers[self.current_buffer_idx].line(line_idx) {
@@ -7176,9 +7179,8 @@ impl Editor {
                 let mut search_from = 0;
 
                 while search_from < line_str.len() {
-                    if let Some(byte_pos) = line_str[search_from..].find(pattern) {
-                        let match_byte_start = search_from + byte_pos;
-                        let match_byte_end = match_byte_start + pattern.len();
+                    if let Some(match_byte_start) = pattern.find(&line_str, search_from) {
+                        let match_byte_end = match_byte_start + pattern.text.len();
                         let start_col = Self::byte_to_char_idx(&line_str, match_byte_start);
                         let end_col = start_col + pattern_len;
 
@@ -7208,41 +7210,34 @@ impl Editor {
 
     /// Search for word under cursor forward (*)
     pub fn search_word_forward(&mut self) {
-        self.render_damage.mark_full();
-        if let Some(word) = self.get_word_under_cursor() {
-            // Set as search pattern
-            self.search.last_pattern = Some(word.clone());
-            self.search.last_direction = SearchDirection::Forward;
-            if self.do_search(&word, SearchDirection::Forward, true) {
-                self.refresh_visible_search_matches(&word);
-                self.update_search_match_stats(&word);
-            } else {
-                self.search_matches.clear();
-                self.search.match_stats = None;
-                self.set_status(format!("Pattern not found: {}", word));
-            }
-        } else {
-            self.set_status("No word under cursor");
-        }
+        self.search_word_under_cursor(SearchDirection::Forward);
     }
 
     /// Search for word under cursor backward (#)
     pub fn search_word_backward(&mut self) {
+        self.search_word_under_cursor(SearchDirection::Backward);
+    }
+
+    /// Shared `*`/`#` body. Like Vim, the recorded pattern is `\<word\>`
+    /// (whole keyword only) and it goes into the search history, so `n`,
+    /// `gn`, and `/` followed by Up all see the same bounded pattern.
+    fn search_word_under_cursor(&mut self, direction: SearchDirection) {
         self.render_damage.mark_full();
-        if let Some(word) = self.get_word_under_cursor() {
-            // Set as search pattern
-            self.search.last_pattern = Some(word.clone());
-            self.search.last_direction = SearchDirection::Backward;
-            if self.do_search(&word, SearchDirection::Backward, true) {
-                self.refresh_visible_search_matches(&word);
-                self.update_search_match_stats(&word);
-            } else {
-                self.search_matches.clear();
-                self.search.match_stats = None;
-                self.set_status(format!("Pattern not found: {}", word));
-            }
-        } else {
+        let Some(word) = self.get_word_under_cursor() else {
             self.set_status("No word under cursor");
+            return;
+        };
+        let pattern = SearchPattern::whole_word(&word);
+        self.search.record_history(pattern.clone());
+        self.search.last_pattern = Some(pattern.clone());
+        self.search.last_direction = direction;
+        if self.do_search(&pattern, direction, true) {
+            self.refresh_visible_search_matches(&pattern);
+            self.update_search_match_stats(&pattern);
+        } else {
+            self.search_matches.clear();
+            self.search.match_stats = None;
+            self.set_status(format!("Pattern not found: {}", pattern));
         }
     }
 
@@ -7677,10 +7672,11 @@ impl Editor {
         wrap: bool,
     ) -> Option<(usize, usize, bool)> {
         let total_lines = self.buffers[self.current_buffer_idx].len_lines();
+        let pattern = SearchPattern::parse(pattern);
         if total_lines == 0 || pattern.is_empty() {
             return None;
         }
-        let pattern_len = pattern.chars().count();
+        let pattern_len = pattern.text.chars().count();
 
         match direction {
             SearchDirection::Forward => {
@@ -7691,8 +7687,7 @@ impl Editor {
                     let search_start = self.cursor.col + 1;
                     let search_start_byte = Self::char_to_byte_idx(&line_str, search_start);
                     if search_start_byte < line_str.len() {
-                        if let Some(pos) = line_str[search_start_byte..].find(pattern) {
-                            let byte_pos = search_start_byte + pos;
+                        if let Some(byte_pos) = pattern.find(&line_str, search_start_byte) {
                             return Some((
                                 self.cursor.line,
                                 Self::byte_to_char_idx(&line_str, byte_pos),
@@ -7706,13 +7701,16 @@ impl Editor {
                 for line_idx in (self.cursor.line + 1)..total_lines {
                     if let Some(line) = self.buffers[self.current_buffer_idx].line(line_idx) {
                         let line_str: String = line.chars().collect();
-                        if let Some(pos) = line_str.find(pattern) {
+                        if let Some(pos) = pattern.find(&line_str, 0) {
                             return Some((line_idx, Self::byte_to_char_idx(&line_str, pos), false));
                         }
                     }
                 }
 
-                // Wrap around if enabled
+                // Wrap around if enabled. On the cursor's line only a match
+                // starting at or before the cursor counts; the search is run
+                // on the whole line so the word boundary after the match is
+                // checked against the real neighbor, not a sliced end.
                 if wrap {
                     for line_idx in 0..=self.cursor.line {
                         if let Some(line) = self.buffers[self.current_buffer_idx].line(line_idx) {
@@ -7723,8 +7721,9 @@ impl Editor {
                                 line_str.chars().count()
                             };
                             let end_byte = Self::char_to_byte_idx(&line_str, end_col);
-                            if let Some(pos) =
-                                line_str[..end_byte.min(line_str.len())].find(pattern)
+                            if let Some(pos) = pattern
+                                .find(&line_str, 0)
+                                .filter(|pos| pos + pattern.text.len() <= end_byte)
                             {
                                 return Some((
                                     line_idx,
@@ -7743,7 +7742,7 @@ impl Editor {
                     let line_str: String = line.chars().collect();
                     if self.cursor.col > 0 {
                         let end_byte = Self::char_to_byte_idx(&line_str, self.cursor.col);
-                        if let Some(pos) = line_str[..end_byte].rfind(pattern) {
+                        if let Some(pos) = pattern.rfind(&line_str, end_byte) {
                             return Some((
                                 self.cursor.line,
                                 Self::byte_to_char_idx(&line_str, pos),
@@ -7757,13 +7756,15 @@ impl Editor {
                 for line_idx in (0..self.cursor.line).rev() {
                     if let Some(line) = self.buffers[self.current_buffer_idx].line(line_idx) {
                         let line_str: String = line.chars().collect();
-                        if let Some(pos) = line_str.rfind(pattern) {
+                        if let Some(pos) = pattern.rfind(&line_str, line_str.len()) {
                             return Some((line_idx, Self::byte_to_char_idx(&line_str, pos), false));
                         }
                     }
                 }
 
-                // Wrap around if enabled
+                // Wrap around if enabled. Same whole-line reasoning as the
+                // forward wrap: the last match is taken, then filtered to
+                // start at or after the cursor.
                 if wrap {
                     for line_idx in (self.cursor.line..total_lines).rev() {
                         if let Some(line) = self.buffers[self.current_buffer_idx].line(line_idx) {
@@ -7774,14 +7775,15 @@ impl Editor {
                                 0
                             };
                             let start_byte = Self::char_to_byte_idx(&line_str, start_col);
-                            if start_byte < line_str.len() {
-                                if let Some(pos) = line_str[start_byte..].rfind(pattern) {
-                                    return Some((
-                                        line_idx,
-                                        Self::byte_to_char_idx(&line_str, start_byte + pos),
-                                        true,
-                                    ));
-                                }
+                            if let Some(pos) = pattern
+                                .rfind(&line_str, line_str.len())
+                                .filter(|&pos| pos >= start_byte)
+                            {
+                                return Some((
+                                    line_idx,
+                                    Self::byte_to_char_idx(&line_str, pos),
+                                    true,
+                                ));
                             }
                         }
                     }
@@ -12399,6 +12401,27 @@ mod tests {
         assert_ne!(
             editor.status_message.as_deref(),
             Some("Pattern not found: old_render_target_24000")
+        );
+    }
+
+    #[test]
+    fn star_highlights_and_counter_skip_embedded_words() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 8);
+        editor.replace_buffer_content("abc abcdef\nabc\n");
+
+        editor.search_word_forward();
+
+        // The oracle pins the cursor; this pins what it cannot see: the
+        // highlight set, the [current/total] counter, and the recorded
+        // pattern, none of which may include the `abc` inside `abcdef`.
+        assert_eq!((editor.cursor.line, editor.cursor.col), (1, 0));
+        assert_eq!(editor.search_matches, vec![(0, 0, 3), (1, 0, 3)]);
+        assert_eq!(editor.search.match_stats, Some((2, 2)));
+        assert_eq!(editor.search.last_pattern.as_deref(), Some("\\<abc\\>"));
+        assert_eq!(
+            editor.search.history.last().map(String::as_str),
+            Some("\\<abc\\>")
         );
     }
 

--- a/src/editor/search_pattern.rs
+++ b/src/editor/search_pattern.rs
@@ -1,0 +1,146 @@
+//! Literal search pattern with Vim's word-boundary atoms.
+//!
+//! Search is a plain substring match, with one borrowing from Vim's regex
+//! syntax: a leading `\<` requires the match to start a keyword and a
+//! trailing `\>` requires it to end one. `*` and `#` record `\<word\>`
+//! exactly like Vim does, so `n`, `N`, `gn`, `gN`, the highlights, the
+//! match counter, and an empty `/` prompt all respect the boundaries
+//! without a separate flag that could drift from the stored pattern.
+
+use super::Editor;
+
+pub struct SearchPattern<'a> {
+    /// The literal text once the boundary atoms are stripped.
+    pub text: &'a str,
+    word_start: bool,
+    word_end: bool,
+}
+
+impl<'a> SearchPattern<'a> {
+    pub fn parse(pattern: &'a str) -> Self {
+        let (text, word_start) = match pattern.strip_prefix("\\<") {
+            Some(rest) => (rest, true),
+            None => (pattern, false),
+        };
+        let (text, word_end) = match text.strip_suffix("\\>") {
+            Some(rest) => (rest, true),
+            None => (text, false),
+        };
+        Self {
+            text,
+            word_start,
+            word_end,
+        }
+    }
+
+    /// The pattern `*` and `#` record for a keyword under the cursor.
+    pub fn whole_word(word: &str) -> String {
+        format!("\\<{word}\\>")
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    /// Byte offset of the first match starting at or after `from`.
+    pub fn find(&self, haystack: &str, from: usize) -> Option<usize> {
+        let mut from = from;
+        while from <= haystack.len() {
+            let pos = from + haystack[from..].find(self.text)?;
+            if self.bounded(haystack, pos) {
+                return Some(pos);
+            }
+            // Step one char past the rejected start so overlapping
+            // occurrences are still considered.
+            from = pos + haystack[pos..].chars().next().map_or(1, char::len_utf8);
+        }
+        None
+    }
+
+    /// Byte offset of the last match that ends at or before `end`.
+    pub fn rfind(&self, haystack: &str, end: usize) -> Option<usize> {
+        let mut end = end;
+        loop {
+            let pos = haystack[..end].rfind(self.text)?;
+            if self.bounded(haystack, pos) {
+                return Some(pos);
+            }
+            // Retry with the window ending inside the rejected match so an
+            // overlapping earlier occurrence is still considered. The last
+            // char's start is a char boundary; `pos + len - 1` may not be.
+            let last_char_len = self.text.chars().next_back().map_or(1, char::len_utf8);
+            end = pos + self.text.len() - last_char_len;
+        }
+    }
+
+    /// Vim's `\<` needs a keyword char at the match start and none before
+    /// it; `\>` needs a keyword char at the match end and none after it.
+    fn bounded(&self, haystack: &str, pos: usize) -> bool {
+        let is_word = |ch: char| Editor::is_word_char(ch);
+        let match_end = pos + self.text.len();
+        let start_ok = !self.word_start
+            || (self.text.chars().next().is_some_and(is_word)
+                && !haystack[..pos].chars().next_back().is_some_and(is_word));
+        let end_ok = !self.word_end
+            || (self.text.chars().next_back().is_some_and(is_word)
+                && !haystack[match_end..].chars().next().is_some_and(is_word));
+        start_ok && end_ok
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SearchPattern;
+
+    #[test]
+    fn plain_pattern_matches_inside_words() {
+        let pat = SearchPattern::parse("abc");
+        assert_eq!(pat.find("xabcdef", 0), Some(1));
+        assert_eq!(pat.rfind("xabcdef", 7), Some(1));
+    }
+
+    #[test]
+    fn parse_strips_boundary_atoms() {
+        let pat = SearchPattern::parse("\\<abc\\>");
+        assert_eq!(pat.text, "abc");
+        assert!(pat.word_start && pat.word_end);
+        assert_eq!(SearchPattern::whole_word("abc"), "\\<abc\\>");
+        assert!(SearchPattern::parse("\\<\\>").is_empty());
+    }
+
+    #[test]
+    fn whole_word_skips_embedded_and_keeps_searching() {
+        let pat = SearchPattern::parse("\\<abc\\>");
+        assert_eq!(pat.find("abcdef abc_x abc", 0), Some(13));
+        assert_eq!(pat.find("abcdef abc_x abc", 14), None);
+        assert_eq!(pat.rfind("abc xabc abcx", 13), Some(0));
+        assert_eq!(pat.rfind("xabc abcx", 9), None);
+    }
+
+    #[test]
+    fn one_sided_atoms_check_one_side() {
+        assert_eq!(SearchPattern::parse("\\<abc").find("xabc abcd", 0), Some(5));
+        assert_eq!(SearchPattern::parse("abc\\>").find("abcd xabc", 0), Some(6));
+    }
+
+    #[test]
+    fn boundary_needs_a_keyword_char_on_the_inside() {
+        // `\<` never matches when the pattern itself starts with punctuation.
+        assert_eq!(SearchPattern::parse("\\<-x").find("a -x", 0), None);
+    }
+
+    #[test]
+    fn overlapping_occurrences_are_retried_both_directions() {
+        let pat = SearchPattern::parse("\\<aa\\>");
+        assert_eq!(pat.find("aaa aa", 0), Some(4));
+        assert_eq!(pat.rfind("aa aaa", 6), Some(0));
+    }
+
+    #[test]
+    fn multibyte_neighbors_are_word_chars() {
+        let pat = SearchPattern::parse("\\<abc\\>");
+        // `é` is two bytes, so the standalone word starts at byte 12.
+        assert_eq!(pat.find("éabc abcé abc", 0), Some(12));
+        assert_eq!(pat.rfind("abc éabc", 9), Some(0));
+    }
+}

--- a/src/vim_oracle/search_cases.rs
+++ b/src/vim_oracle/search_cases.rs
@@ -198,10 +198,60 @@ pub(super) const SEARCH_CASES: &[OracleCase] = &[
         initial_text: super::SCREEN_POSITION_TEXT,
         keys: "50Gzz/line 090<Esc>",
     },
+    // * and # search with word boundaries (\<word\>), so the word text inside
+    // a longer keyword is never a match. Every key that reuses the pattern
+    // (n, N, gn, gN, an empty / prompt) inherits the boundaries. The texts are
+    // deliberately asymmetric so a boundary bug cannot pass by landing on a
+    // match Vim reaches by a different route.
+    OracleCase {
+        name: "star skips match inside longer word",
+        initial_text: "abc abcdef\nabc\n",
+        keys: "*",
+    },
+    OracleCase {
+        name: "star with only embedded matches wraps to itself",
+        initial_text: "abc abcdef\n",
+        keys: "l*",
+    },
+    OracleCase {
+        name: "hash skips match inside longer word",
+        initial_text: "abc\nxabc abc\n",
+        keys: "j$#",
+    },
+    OracleCase {
+        name: "n after star keeps word boundaries",
+        initial_text: "abc abcdef\nabc\nabc_x abc\n",
+        keys: "*n",
+    },
+    OracleCase {
+        name: "gn after star selects the whole word only",
+        initial_text: "abc abcdef abc\n",
+        keys: "*gnd",
+    },
+    OracleCase {
+        name: "empty search repeat keeps star boundaries",
+        initial_text: "abc abcdef\nabcx\nabc\n",
+        keys: "*/<CR>",
+    },
+    // The boundary atoms can also be typed; this is the pattern * records.
+    OracleCase {
+        name: "typed word boundary pattern",
+        initial_text: "abcdef abc\n",
+        keys: "/\\<lt>abc\\><CR>",
+    },
+    // * adds \<abc\> to the search history: two Ups skip past the later
+    // /xyz entry and recall it. Without the history entry the second Up
+    // stays on xyz and the search lands back on line 3.
+    OracleCase {
+        name: "star records its pattern in search history",
+        initial_text: "abc abcdef\nabc\nxyz\n",
+        keys: "*/xyz<CR>/<Up><Up><CR>",
+    },
 ];
 
 // Known divergence, deliberately not an active case (it would fail CI):
-// vim's * searches with word boundaries (\<abc\>), Nevi searches the literal
-// word text, so * on "abc" also matches inside "abcdef".
-//   initial_text: "abc abcdef\nabc\n", keys: "*"
-//   nvim lands on (1, 0); Nevi lands on (0, 4).
+// backward search only considers matches that END before the cursor, Vim
+// considers matches that START before it, and `#` does not first move to
+// the word start like Vim's nv_ident does. Verified vs nvim 0.11.3:
+//   initial_text: "abcabc\n", keys: "ll?abc<CR>"  nvim (0, 0); Nevi (0, 3)
+//   initial_text: "x beta\n", keys: "3l#"         nvim (0, 2); Nevi (0, 3)


### PR DESCRIPTION
`*` on `abc` also matched the `abc` inside `abcdef`, and `n`, `gn`, the highlights and the counter all followed it there. Vim searches for `\<abc\>`.

Now `*` and `#` record `\<word\>` and the matcher understands `\<` and `\>`, so everything that reuses the pattern skips embedded matches. `/` then Up recalls the pattern like Vim. You can also type `\<` and `\>` yourself. Plain patterns still match inside words.

8 new oracle cases checked against real nvim, plus a regression for the highlights and counter. Found one more gap in backward search while in here, left a note next to the cases rather than fixing it in this PR.

Fixes #310
