### PR TITLE
fix: repeat counted i and a inserts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- A count before `i` or `a` now repeats the typed text like Vim, so `3ix<Esc>` gives `xxx`. `I`, `A`, `o`, and `O` already did this; the count is now set in one place for all six. (#296)
 - `*` and `#` now search for the whole word only, like Vim's `\<word\>`, so `*` on `abc` no longer stops inside `abcdef`. Everything that reuses the pattern follows along: `n`, `N`, `gn`, `gN`, the highlights, the match counter, and an empty `/` prompt. The pattern also goes into the search history, so `/` then Up recalls it. Typing `\<` and `\>` in a search works the same way; plain patterns still match inside words. (#310)
 - Search now anchors at the position where `/` or `?` was pressed, like Vim. Every keystroke evaluates the whole pattern from that origin instead of chasing the cursor around, so editing the pattern with backspace cannot land on an earlier match than Vim would. Escape cancels back to the original cursor and view, and a pattern with no match leaves the cursor where the search started.
 - Repeating a search with an empty prompt (`/` or `?` then Enter) now moves off a match under the cursor instead of standing still, and it updates the direction that `n` and `N` follow, so `n` after `?` and Enter keeps searching backward.

--- a/PARITY.md
+++ b/PARITY.md
@@ -14,7 +14,7 @@ the test suite enforces, so it cannot drift from what is actually verified.
   - 159 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **410 oracle cases**: motions (144), editing (132), insert-entry (11), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
+- **417 oracle cases**: motions (144), editing (133), insert-entry (17), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
 - **0 tracked coverage gaps**
 - **224 of 438 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -5439,9 +5439,10 @@ impl Editor {
             .prefer_current_cursor_after(self.cursor.line, self.cursor.col);
     }
 
-    /// Enter insert mode at end of line with Vim's counted-insert semantics.
-    pub fn enter_insert_mode_end_counted(&mut self, count: usize) {
-        self.enter_insert_mode_end();
+    /// Vim's counted insert: `3ix<Esc>` types the session's text three
+    /// times. Shared by every insert entry point (i, a, I, A, o, O) so none
+    /// of them can drop the count; a no-op when entry was refused.
+    pub fn set_insert_repeat_count(&mut self, count: usize) {
         if self.mode == Mode::Insert {
             self.insert_session_repeat_count = count.max(1);
         }
@@ -5475,14 +5476,6 @@ impl Editor {
         self.begin_change();
         self.undo_stack
             .prefer_current_cursor_after(self.cursor.line, self.cursor.col);
-    }
-
-    /// Enter insert mode at first non-blank with Vim's counted-insert semantics.
-    pub fn enter_insert_mode_start_counted(&mut self, count: usize) {
-        self.enter_insert_mode_start();
-        if self.mode == Mode::Insert {
-            self.insert_session_repeat_count = count.max(1);
-        }
     }
 
     /// Temporarily leave insert mode so the next normal command can run.
@@ -6355,14 +6348,6 @@ impl Editor {
         self.scroll_to_cursor();
     }
 
-    /// Open a line below and repeat the completed insertion `count` times.
-    pub fn open_line_below_counted(&mut self, count: usize) {
-        self.open_line_below();
-        if self.mode == Mode::Insert {
-            self.insert_session_repeat_count = count.max(1);
-        }
-    }
-
     /// Open a new line above and enter insert mode
     pub fn open_line_above(&mut self) {
         let redo_cursor = (self.cursor.line, self.cursor.col);
@@ -6391,14 +6376,6 @@ impl Editor {
         self.insert_session_open_line_indent = Some(indent);
         self.record_inserted_text(&insert_text);
         self.scroll_to_cursor();
-    }
-
-    /// Open a line above and repeat the completed insertion `count` times.
-    pub fn open_line_above_counted(&mut self, count: usize) {
-        self.open_line_above();
-        if self.mode == Mode::Insert {
-            self.insert_session_repeat_count = count.max(1);
-        }
     }
 
     /// Save the current buffer

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7671,11 +7671,12 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             match pos {
                 InsertPosition::AtCursor => editor.enter_insert_mode(),
                 InsertPosition::AfterCursor => editor.enter_insert_mode_append(),
-                InsertPosition::LineStart => editor.enter_insert_mode_start_counted(count),
-                InsertPosition::LineEnd => editor.enter_insert_mode_end_counted(count),
-                InsertPosition::NewLineBelow => editor.open_line_below_counted(count),
-                InsertPosition::NewLineAbove => editor.open_line_above_counted(count),
+                InsertPosition::LineStart => editor.enter_insert_mode_start(),
+                InsertPosition::LineEnd => editor.enter_insert_mode_end(),
+                InsertPosition::NewLineBelow => editor.open_line_below(),
+                InsertPosition::NewLineAbove => editor.open_line_above(),
             }
+            editor.set_insert_repeat_count(count);
             let action_elapsed = t_action.elapsed();
             let total = t_start.elapsed();
             if total.as_micros() > 1000 {

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -684,14 +684,18 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "\n",
         keys: "i<C-v><C-y>x<C-q><C-y><Esc>",
     },
-    // The literal must belong to the surrounding insert session for undo and
-    // dot repeat. A counted variant (3i<C-v>..) is blocked on the pre-existing
-    // bug that counted lowercase i never repeats; a <C-v><CR> variant is
-    // blocked on ropey treating a bare CR as a line break.
+    // The literal must belong to the surrounding insert session for undo,
+    // counts, and dot repeat. A <C-v><CR> variant is blocked on ropey
+    // treating a bare CR as a line break.
     OracleCase {
         name: "undo removes literal insert with its session",
         initial_text: "\n",
         keys: "i<C-v><C-y><Esc>u",
+    },
+    OracleCase {
+        name: "counted literal insert repeats the control char",
+        initial_text: "\n",
+        keys: "3i<C-v><C-y><Esc>",
     },
     OracleCase {
         name: "dot repeat replays literal insert",

--- a/src/vim_oracle/insert_entry_cases.rs
+++ b/src/vim_oracle/insert_entry_cases.rs
@@ -1,8 +1,40 @@
 use super::OracleCase;
 
 /// Insert-entry cases protect Vim's cursor placement, count, and undo semantics
-/// for the normal-mode `I` and `A` commands.
+/// for the normal-mode `i`, `a`, `I`, and `A` commands.
 pub(super) const INSERT_ENTRY_CASES: &[OracleCase] = &[
+    // Counted i and a repeat the typed text like I and A do. The texts put
+    // the cursor mid-line so a repeat at the wrong position shows up.
+    OracleCase {
+        name: "counted insert at cursor",
+        initial_text: "alpha\n",
+        keys: "l3ix<Esc>",
+    },
+    OracleCase {
+        name: "counted append after cursor",
+        initial_text: "alpha\n",
+        keys: "l3ax<Esc>",
+    },
+    OracleCase {
+        name: "counted append on empty line",
+        initial_text: "\n",
+        keys: "3ax<Esc>",
+    },
+    OracleCase {
+        name: "counted insert with newline",
+        initial_text: "alpha\n",
+        keys: "l2iab<CR><Esc>",
+    },
+    OracleCase {
+        name: "undo counted insert at cursor",
+        initial_text: "alpha\n",
+        keys: "l3ix<Esc>u",
+    },
+    OracleCase {
+        name: "dot repeat replays counted insert",
+        initial_text: "alpha\n",
+        keys: "3ix<Esc>$.",
+    },
     OracleCase {
         name: "insert at first nonblank",
         initial_text: "    alpha\n",


### PR DESCRIPTION
`3ix<Esc>` gave `x` instead of `xxx`. The dispatch passed the count to `I`, `A`, `o` and `O` but called the plain functions for `i` and `a`.

The count is now set once after every insert entry, and the four per-key wrappers that did it before are gone, so no entry point can miss it. `o` and `O` were already fine.

7 oracle cases checked against real nvim, including undo, dot repeat, a newline in the repeated text, and the counted `Ctrl-v` case that was waiting on this.

Fixes #296
