### PR TITLE
feat: add ctrl-a and ctrl-x number increment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- Added `Ctrl+a` and `Ctrl+x` to add to or subtract from the number at or after the cursor, with a count. Follows Neovim's default `nrformats=bin,hex`: decimal with a minus sign, `0x` hex, `0b` binary, leading zeros keep their width, hex digits keep their case. Works with `.` and undoes in one step. Verified against real Neovim in a new oracle category.
 - A count before `i` or `a` now repeats the typed text like Vim, so `3ix<Esc>` gives `xxx`. `I`, `A`, `o`, and `O` already did this; the count is now set in one place for all six. (#296)
 - `*` and `#` now search for the whole word only, like Vim's `\<word\>`, so `*` on `abc` no longer stops inside `abcdef`. Everything that reuses the pattern follows along: `n`, `N`, `gn`, `gN`, the highlights, the match counter, and an empty `/` prompt. The pattern also goes into the search history, so `/` then Up recalls it. Typing `\<` and `\>` in a search works the same way; plain patterns still match inside words. (#310)
 - Search now anchors at the position where `/` or `?` was pressed, like Vim. Every keystroke evaluates the whole pattern from that origin instead of chasing the cursor around, so editing the pattern with backspace cannot land on an earlier match than Vim would. Escape cancels back to the original cursor and view, and a pattern with no match leaves the cursor where the search started.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -383,6 +383,15 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 > - `ci"` - Change inside quotes
 > - `ya(` - Yank around parentheses
 
+### Numbers
+
+| Key | Action |
+|-----|--------|
+| `Ctrl+a` / `{n}Ctrl+a` | Add 1 (or count) to the number at or after the cursor |
+| `Ctrl+x` / `{n}Ctrl+x` | Subtract 1 (or count) from the number at or after the cursor |
+
+> **Note:** Like Neovim's default `nrformats=bin,hex`: decimal numbers with an optional `-`, `0x` hex, and `0b` binary. Leading zeros keep their width (`007` becomes `008`), hex digits keep their case, and the cursor lands on the last digit. Works with `.` and undoes in one step.
+
 ### Undo/Redo
 
 | Key | Action |

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 339 keybinds implemented, 88 planned Vim/Neovim parity defaults.**
+**Status: 341 keybinds implemented, 86 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md). This list comes
@@ -29,8 +29,8 @@ remain Vim-compatible unless Nevi intentionally documents a difference.
 ordering leans on the common proxies (vimtutor and cheat-sheet staples, what
 Neovim itself promotes to a default, plugin popularity like vim-unimpaired) and
 on what Nevi users actually ask for in issues — user reports move a key up
-immediately. The keys most hands reach for first: `Ctrl+a` / `Ctrl+x`,
-`Ctrl+^`, `ZQ`, the visual-mode operators (`gu` / `gU` /
+immediately. The keys most hands reach for first: `Ctrl+^`, `ZQ`, the
+visual-mode operators (`gu` / `gU` /
 `g~`, `r`, `J`, `=`), `gq` / `gw`, and among the larger areas, folds and
 quickfix before tabs and tags.
 
@@ -38,8 +38,6 @@ quickfix before tabs and tags.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+a` / `{n}Ctrl+a` | Add [count] to the number at or after the cursor |
-| `Ctrl+x` / `{n}Ctrl+x` | Subtract [count] from the number at or after the cursor |
 | `U` | Undo all latest changes on the last changed line |
 | `g-` | Go to older text state (undo over time) |
 | `g+` | Go to newer text state |

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **339 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **88 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **167 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 159 verified against real Neovim (v0.11.3) by the Vim oracle
+- **341 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **86 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **169 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 161 verified against real Neovim (v0.11.3) by the Vim oracle
   - 7 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **417 oracle cases**: motions (144), editing (133), insert-entry (17), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
+- **448 oracle cases**: motions (144), editing (133), increment (31), insert-entry (17), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
 - **0 tracked coverage gaps**
-- **224 of 438 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **226 of 440 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -122,6 +122,8 @@ claim protection.
 | `<C-w>` | Delete word before cursor in insert | `insert ctrl-w deletes word before cursor` |
 | `<C-a>` | Insert previously inserted text | `insert ctrl-a repeats last inserted text` |
 | `Ctrl+r {reg}` | Insert register contents | `insert ctrl-r pastes named register` |
+| `<C-a>` | Add count to the number at or after the cursor | `increment number after cursor` |
+| `<C-x>` | Subtract count from the number at or after the cursor | `decrement number after cursor` |
 | `v` | Character-wise visual mode | `visual charwise delete` |
 | `V` | Line-wise visual mode | `visual linewise delete` |
 | `<C-v>` | Block visual mode | `visual block delete` |

--- a/src/editor/increment.rs
+++ b/src/editor/increment.rs
@@ -1,0 +1,201 @@
+//! `Ctrl-a` / `Ctrl-x`: add to or subtract from the number at or after the
+//! cursor, following Neovim's default `nrformats=bin,hex`.
+//!
+//! Decimal numbers take a `-` directly before them as their sign, `0x` hex
+//! and `0b` binary numbers never do. A number with leading zeros keeps its
+//! width, hex digits follow the case of the letters already present, and
+//! decimal results cross zero while hex and binary wrap as unsigned 64-bit.
+//! The search for the number mirrors Vim's `do_addsub`: walk back over hex
+//! and binary digits to catch a cursor sitting inside `0x..`, otherwise take
+//! the first digit at or after the cursor and extend backwards.
+
+/// The span of the old number (in chars) and the text that replaces it.
+#[derive(Debug, PartialEq, Eq)]
+pub struct NumberChange {
+    pub start: usize,
+    pub len: usize,
+    pub text: String,
+}
+
+impl NumberChange {
+    /// Vim leaves the cursor on the last char of the new number.
+    pub fn cursor_col(&self) -> usize {
+        self.start + self.text.chars().count() - 1
+    }
+}
+
+pub fn add_to_number(chars: &[char], cursor: usize, delta: i64) -> Option<NumberChange> {
+    let at = |i: usize| chars.get(i).copied().unwrap_or('\0');
+    let is_digit = |c: char| c.is_ascii_digit();
+    let is_xdigit = |c: char| c.is_ascii_hexdigit();
+    let is_bdigit = |c: char| c == '0' || c == '1';
+    let hex_prefix_at =
+        |i: usize| i > 0 && matches!(at(i), 'x' | 'X') && at(i - 1) == '0' && is_xdigit(at(i + 1));
+    let bin_prefix_at =
+        |i: usize| i > 0 && matches!(at(i), 'b' | 'B') && at(i - 1) == '0' && is_bdigit(at(i + 1));
+
+    // Normal mode never puts the cursor past the last char; clamp so any
+    // caller gets Vim's answer instead of a decimal read of the tail.
+    let cursor = cursor.min(chars.len().saturating_sub(1));
+    let mut col = cursor;
+    while col > 0 && is_bdigit(at(col)) {
+        col -= 1;
+    }
+    while col > 0 && is_xdigit(at(col)) {
+        col -= 1;
+    }
+    if !hex_prefix_at(col) {
+        // Binary digits are also hex digits, so the walk above can overshoot
+        // a plain decimal; rescan over decimal digits only.
+        col = cursor;
+        while col > 0 && is_digit(at(col)) {
+            col -= 1;
+        }
+    }
+    if hex_prefix_at(col) || bin_prefix_at(col) {
+        col -= 1;
+    } else {
+        col = cursor;
+        while col < chars.len() && !is_digit(at(col)) {
+            col += 1;
+        }
+        while col > 0 && is_digit(at(col - 1)) {
+            col -= 1;
+        }
+    }
+
+    let first_digit = at(col);
+    if !is_digit(first_digit) {
+        return None;
+    }
+
+    let (radix, prefix_len) = if at(col) == '0' && hex_prefix_at(col + 1) {
+        (16, 2)
+    } else if at(col) == '0' && bin_prefix_at(col + 1) {
+        (2, 2)
+    } else {
+        (10, 0)
+    };
+    let digits_start = col + prefix_len;
+    let mut digits_end = digits_start;
+    while digits_end < chars.len() && at(digits_end).is_digit(radix) {
+        digits_end += 1;
+    }
+    let old_digits: String = chars[digits_start..digits_end].iter().collect();
+    // Vim clamps a number that does not fit instead of failing.
+    let n = u64::from_str_radix(&old_digits, radix).unwrap_or(u64::MAX);
+
+    let negative = radix == 10 && col > 0 && at(col - 1) == '-';
+    let (new_negative, new_n) = if radix == 10 {
+        let signed = if negative { -(n as i128) } else { n as i128 } + i128::from(delta);
+        (
+            signed < 0,
+            signed.unsigned_abs().min(u128::from(u64::MAX)) as u64,
+        )
+    } else {
+        (false, n.wrapping_add_signed(delta))
+    };
+
+    // The last letter in the old number decides the case, and the x/X of the
+    // prefix counts as a letter, so `0X1` produces uppercase digits.
+    let hex_upper = chars[col..digits_end]
+        .iter()
+        .filter(|c| c.is_ascii_alphabetic())
+        .next_back()
+        .is_some_and(|c| c.is_ascii_uppercase());
+    let new_digits = match radix {
+        2 => format!("{new_n:b}"),
+        16 if hex_upper => format!("{new_n:X}"),
+        16 => format!("{new_n:x}"),
+        _ => new_n.to_string(),
+    };
+
+    let start = if negative { col - 1 } else { col };
+    let mut text = String::new();
+    if new_negative {
+        text.push('-');
+    }
+    text.extend(&chars[col..digits_start]);
+    if first_digit == '0' {
+        let width = digits_end - digits_start;
+        text.extend(std::iter::repeat_n(
+            '0',
+            width.saturating_sub(new_digits.len()),
+        ));
+    }
+    text.push_str(&new_digits);
+
+    Some(NumberChange {
+        start,
+        len: digits_end - start,
+        text,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{NumberChange, add_to_number};
+
+    fn apply(line: &str, cursor: usize, delta: i64) -> Option<(String, usize)> {
+        let chars: Vec<char> = line.chars().collect();
+        let change = add_to_number(&chars, cursor, delta)?;
+        let mut out: String = chars[..change.start].iter().collect();
+        out.push_str(&change.text);
+        out.extend(&chars[change.start + change.len..]);
+        Some((out, change.cursor_col()))
+    }
+
+    #[test]
+    fn finds_number_at_or_after_cursor() {
+        assert_eq!(apply("x = 5", 0, 1), Some(("x = 6".into(), 4)));
+        assert_eq!(apply("abc 123 def", 5, 1), Some(("abc 124 def".into(), 6)));
+        assert_eq!(apply("1 2", 1, 1), Some(("1 3".into(), 2)));
+        assert_eq!(apply("12 abc", 5, 1), None);
+        assert_eq!(apply("", 0, 1), None);
+    }
+
+    #[test]
+    fn decimal_sign_crosses_zero() {
+        assert_eq!(apply("-1", 0, 1), Some(("0".into(), 0)));
+        assert_eq!(apply("0", 0, -1), Some(("-1".into(), 1)));
+        assert_eq!(apply("10", 0, -15), Some(("-5".into(), 1)));
+        assert_eq!(apply("x-5", 0, -1), Some(("x-6".into(), 2)));
+        assert_eq!(apply("-5", 1, 1), Some(("-4".into(), 1)));
+    }
+
+    #[test]
+    fn leading_zeros_keep_width() {
+        assert_eq!(apply("007", 0, 1), Some(("008".into(), 2)));
+        assert_eq!(apply("099", 0, 1), Some(("100".into(), 2)));
+        assert_eq!(apply("-007", 0, 1), Some(("-006".into(), 3)));
+        assert_eq!(apply("0x00ff", 0, 1), Some(("0x0100".into(), 5)));
+    }
+
+    #[test]
+    fn hex_and_binary() {
+        assert_eq!(apply("0x0f", 0, 1), Some(("0x10".into(), 3)));
+        assert_eq!(apply("0xff", 0, 1), Some(("0x100".into(), 4)));
+        assert_eq!(apply("0XAB", 0, -1), Some(("0XAA".into(), 3)));
+        assert_eq!(apply("0X9", 0, 1), Some(("0XA".into(), 2)));
+        assert_eq!(apply("0x1f", 3, 1), Some(("0x20".into(), 3)));
+        assert_eq!(apply("0x0f", 1, 1), Some(("0x10".into(), 3)));
+        assert_eq!(apply("-0x10", 0, 1), Some(("-0x11".into(), 4)));
+        assert_eq!(apply("0x0", 0, -1), Some(("0xffffffffffffffff".into(), 17)));
+        assert_eq!(apply("0b101", 0, 1), Some(("0b110".into(), 4)));
+        assert_eq!(apply("0b11", 3, 1), Some(("0b100".into(), 4)));
+        assert_eq!(apply("0b11", 9, 1), Some(("0b100".into(), 4)));
+    }
+
+    #[test]
+    fn change_reports_span_and_cursor() {
+        let chars: Vec<char> = "a -12 b".chars().collect();
+        assert_eq!(
+            add_to_number(&chars, 0, 12),
+            Some(NumberChange {
+                start: 2,
+                len: 3,
+                text: "0".into(),
+            })
+        );
+    }
+}

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -7556,6 +7556,9 @@ impl Editor {
         self.buffers[self.current_buffer_idx].replace_line(self.cursor.line, &new_line);
         self.buffers[self.current_buffer_idx].mark_modified();
         self.cursor.col = change.cursor_col();
+        // A number can grow by many chars (0x0 minus one is 18 wide), so
+        // with wrap off the view has to follow the cursor like any motion.
+        self.scroll_to_cursor();
         self.undo_stack
             .end_undo_group(self.cursor.line, self.cursor.col);
     }
@@ -12283,6 +12286,29 @@ mod tests {
 
     // The oracle can't see h_offset (its lines never scroll horizontally), so
     // the horizontal half of the origin restore needs a native regression.
+    #[test]
+    fn increment_keeps_grown_number_cursor_on_screen() {
+        let mut editor = Editor::default();
+        editor.set_size(40, 10);
+        editor.settings.editor.wrap = false;
+        editor.replace_buffer_content(&format!("{}0x0\n", "x".repeat(30)));
+        editor.cursor.col = 30;
+        editor.scroll_to_cursor();
+        assert_eq!(editor.h_offset, 0, "setup starts unscrolled");
+
+        // 0x0 minus one is 18 chars wide, pushing the cursor past the edge.
+        editor.add_to_number_at_cursor(-1);
+
+        assert_eq!(editor.cursor.col, 47);
+        assert!(
+            editor.cursor.col < editor.h_offset + editor.text_area_width(),
+            "cursor col {} not visible with h_offset {} and width {}",
+            editor.cursor.col,
+            editor.h_offset,
+            editor.text_area_width()
+        );
+    }
+
     #[test]
     fn cancelled_search_restores_cursor_viewport_and_h_offset() {
         let mut editor = Editor::default();

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1,5 +1,6 @@
 mod buffer;
 mod cursor;
+mod increment;
 mod macros;
 mod marks;
 mod register;
@@ -7525,6 +7526,38 @@ impl Editor {
     /// Check if a character is a word character (alphanumeric or underscore)
     fn is_word_char(ch: char) -> bool {
         ch.is_alphanumeric() || ch == '_'
+    }
+
+    /// `Ctrl-a` / `Ctrl-x`: add `delta` to the number at or after the cursor.
+    /// One undo step, cursor on the last digit like Vim; no number on the
+    /// rest of the line is a silent no-op.
+    pub fn add_to_number_at_cursor(&mut self, delta: i64) {
+        if self.reject_read_only_edit() {
+            return;
+        }
+        let Some(line) = self.buffers[self.current_buffer_idx].line(self.cursor.line) else {
+            return;
+        };
+        let line_str: String = line.chars().collect();
+        let chars: Vec<char> = line_str.chars().collect();
+        let Some(change) = increment::add_to_number(&chars, self.cursor.col, delta) else {
+            return;
+        };
+        let mut new_line: String = chars[..change.start].iter().collect();
+        new_line.push_str(&change.text);
+        new_line.extend(&chars[change.start + change.len..]);
+
+        self.begin_change();
+        self.undo_stack.record_change(Change::replace_line(
+            self.cursor.line,
+            line_str,
+            new_line.clone(),
+        ));
+        self.buffers[self.current_buffer_idx].replace_line(self.cursor.line, &new_line);
+        self.buffers[self.current_buffer_idx].mark_modified();
+        self.cursor.col = change.cursor_col();
+        self.undo_stack
+            .end_undo_group(self.cursor.line, self.cursor.col);
     }
 
     /// Search and replace text

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -561,6 +561,20 @@ status = "implemented"
 vim_default = true
 
 [[normal.editing]]
+key = "<C-a>"
+action = "add_to_number"
+desc = "Add count to the number at or after the cursor"
+status = "implemented"
+vim_default = true
+
+[[normal.editing]]
+key = "<C-x>"
+action = "subtract_from_number"
+desc = "Subtract count from the number at or after the cursor"
+status = "implemented"
+vim_default = true
+
+[[normal.editing]]
 key = "."
 action = "repeat_last_change"
 desc = "Repeat last change"

--- a/src/fuzz.rs
+++ b/src/fuzz.rs
@@ -160,6 +160,8 @@ const ALPHABET: &[FuzzKey] = &[
     // Scrolling, panes, jumps
     plain('z', "z"),
     ctrl('r', "<C-r>"),
+    ctrl('a', "<C-a>"),
+    ctrl('x', "<C-x>"),
     ctrl('d', "<C-d>"),
     ctrl('u', "<C-u>"),
     ctrl('f', "<C-f>"),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -165,6 +165,9 @@ pub enum KeyAction {
     ScrollLineDown(usize),
     /// Scroll viewport up count lines without moving the cursor (<C-y>)
     ScrollLineUp(usize),
+    /// Add the signed amount to the number at or after the cursor
+    /// (<C-a> is +count, <C-x> is -count)
+    AddToNumber(i64),
     /// Repeat last change (.). Carries the typed count, if any: Vim treats
     /// an explicit count (even `1.`) as replacing the change's own count.
     RepeatLastChange(Option<usize>),
@@ -1052,6 +1055,16 @@ impl InputState {
             (KeyModifiers::CONTROL, KeyCode::Char('y')) => {
                 self.reset();
                 KeyAction::ScrollLineUp(count)
+            }
+
+            // <C-a>/<C-x> - add to / subtract from the number under the cursor
+            (KeyModifiers::CONTROL, KeyCode::Char('a')) => {
+                self.reset();
+                KeyAction::AddToNumber(count as i64)
+            }
+            (KeyModifiers::CONTROL, KeyCode::Char('x')) => {
+                self.reset();
+                KeyAction::AddToNumber(-(count as i64))
             }
 
             // Insert mode entry (or text object modifier if operator pending)

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -1,6 +1,7 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub(crate) enum KeybindMode {
     Normal,
+    Insert,
     Leader,
 }
 
@@ -263,30 +264,40 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Last inserted text register",
         "last inserted text register",
     ),
-    vim_oracle(
+    insert_oracle(
         "<C-[>",
         "Exit insert mode",
         "ctrl-bracket exits insert like escape",
     ),
-    vim_oracle(
+    insert_oracle(
         "Backspace",
         "Delete character before cursor in insert",
         "insert backspace deletes typed chars",
     ),
-    vim_oracle(
+    insert_oracle(
         "<C-w>",
         "Delete word before cursor in insert",
         "insert ctrl-w deletes word before cursor",
     ),
-    vim_oracle(
+    insert_oracle(
         "<C-a>",
         "Insert previously inserted text",
         "insert ctrl-a repeats last inserted text",
     ),
-    vim_oracle(
+    insert_oracle(
         "Ctrl+r {reg}",
         "Insert register contents",
         "insert ctrl-r pastes named register",
+    ),
+    vim_oracle(
+        "<C-a>",
+        "Add count to the number at or after the cursor",
+        "increment number after cursor",
+    ),
+    vim_oracle(
+        "<C-x>",
+        "Subtract count from the number at or after the cursor",
+        "decrement number after cursor",
     ),
     vim_oracle("v", "Character-wise visual mode", "visual charwise delete"),
     vim_oracle("V", "Line-wise visual mode", "visual linewise delete"),
@@ -563,6 +574,24 @@ const fn vim_oracle(
 
 /// Nevi-owned behavior protected by a focused regression test rather than an
 /// oracle case (used where we deliberately deviate from Vim).
+/// Same as `vim_oracle`, for keys that act in insert mode. Kept separate so a
+/// key like `<C-a>` can be inventoried once per mode it means something in.
+const fn insert_oracle(
+    key: &'static str,
+    description: &'static str,
+    oracle_case: &'static str,
+) -> KeybindCoverage {
+    KeybindCoverage {
+        mode: KeybindMode::Insert,
+        key,
+        description,
+        kind: CoverageKind::VimOracle,
+        state: CoverageState::Protected {
+            test_id: oracle_case,
+        },
+    }
+}
+
 const fn nevi_regression(
     key: &'static str,
     description: &'static str,

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7783,6 +7783,10 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.scroll_pane_viewport(editor.active_pane_idx(), count as isize);
         }
 
+        KeyAction::AddToNumber(delta) => {
+            editor.add_to_number_at_cursor(delta);
+        }
+
         KeyAction::ScrollLineUp(count) => {
             let delta = -(count.min(isize::MAX as usize) as isize);
             editor.scroll_pane_viewport(editor.active_pane_idx(), delta);

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -6,6 +6,7 @@ use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 mod editing_cases;
+mod increment_cases;
 mod insert_entry_cases;
 mod open_line_cases;
 mod replace_cases;
@@ -13,6 +14,7 @@ mod search_cases;
 mod text_object_cases;
 
 use editing_cases::EDITING_CASES;
+use increment_cases::INCREMENT_CASES;
 use insert_entry_cases::INSERT_ENTRY_CASES;
 use open_line_cases::OPEN_LINE_CASES;
 use replace_cases::REPLACE_CASES;
@@ -998,6 +1000,10 @@ const ORACLE_CATEGORIES: &[OracleCategory] = &[
     OracleCategory {
         name: "editing",
         cases: EDITING_CASES,
+    },
+    OracleCategory {
+        name: "increment",
+        cases: INCREMENT_CASES,
     },
     OracleCategory {
         name: "insert-entry",

--- a/src/vim_oracle/increment_cases.rs
+++ b/src/vim_oracle/increment_cases.rs
@@ -1,0 +1,168 @@
+use super::OracleCase;
+
+/// `Ctrl-a` / `Ctrl-x` cases, verified against real Neovim with its default
+/// `nrformats=bin,hex`: decimal with a leading minus, `0x` hex, `0b` binary,
+/// no octal. Width is preserved when the number has leading zeros, hex digit
+/// case follows the existing digits, and the cursor lands on the last digit.
+pub(super) const INCREMENT_CASES: &[OracleCase] = &[
+    OracleCase {
+        name: "increment number after cursor",
+        initial_text: "x = 5\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "decrement number after cursor",
+        initial_text: "x = 5\n",
+        keys: "<C-x>",
+    },
+    OracleCase {
+        name: "count adds to the number",
+        initial_text: "x = 5\n",
+        keys: "5<C-a>",
+    },
+    OracleCase {
+        name: "count with two digits",
+        initial_text: "1\n",
+        keys: "10<C-a>",
+    },
+    OracleCase {
+        name: "cursor inside number uses the whole number",
+        initial_text: "abc 123 def\n",
+        keys: "5l<C-a>",
+    },
+    OracleCase {
+        name: "cursor after last number does nothing",
+        initial_text: "12 abc\n",
+        keys: "$<C-a>",
+    },
+    OracleCase {
+        name: "number on a later line is not found",
+        initial_text: "abc\n5\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "cursor between numbers takes the next one",
+        initial_text: "1 2\n",
+        keys: "l<C-a>",
+    },
+    OracleCase {
+        name: "number embedded in a word grows",
+        initial_text: "foo9bar\n",
+        keys: "<C-a>",
+    },
+    // Signed decimals.
+    OracleCase {
+        name: "negative one increments to zero",
+        initial_text: "-1\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "negative crosses zero with count",
+        initial_text: "-1\n",
+        keys: "3<C-a>",
+    },
+    OracleCase {
+        name: "zero decrements to negative",
+        initial_text: "0\n",
+        keys: "<C-x>",
+    },
+    OracleCase {
+        name: "count decrement goes negative",
+        initial_text: "10\n",
+        keys: "15<C-x>",
+    },
+    OracleCase {
+        name: "minus after a word char is still a sign",
+        initial_text: "x-5\n",
+        keys: "<C-x>",
+    },
+    OracleCase {
+        name: "cursor on the minus sign",
+        initial_text: "-5\n",
+        keys: "<C-a>",
+    },
+    // Leading zeros keep the width.
+    OracleCase {
+        name: "leading zeros keep width",
+        initial_text: "007\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "leading zeros grow when needed",
+        initial_text: "099\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "negative with leading zeros",
+        initial_text: "-007\n",
+        keys: "<C-a>",
+    },
+    // Hex.
+    OracleCase {
+        name: "hex increment keeps width",
+        initial_text: "0x0f\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "hex grows past its width",
+        initial_text: "0xff\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "hex keeps leading zeros",
+        initial_text: "0x00ff\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "hex keeps uppercase digits",
+        initial_text: "0XAB\n",
+        keys: "<C-x>",
+    },
+    OracleCase {
+        name: "hex cursor on a letter digit",
+        initial_text: "0x1f\n",
+        keys: "$<C-a>",
+    },
+    OracleCase {
+        name: "hex cursor on the x",
+        initial_text: "0x0f\n",
+        keys: "l<C-a>",
+    },
+    OracleCase {
+        name: "hex ignores a leading minus",
+        initial_text: "-0x10\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "hex zero wraps on decrement",
+        initial_text: "0x0\n",
+        keys: "<C-x>",
+    },
+    // Binary.
+    OracleCase {
+        name: "binary increment",
+        initial_text: "0b101\n",
+        keys: "<C-a>",
+    },
+    OracleCase {
+        name: "binary grows past its width",
+        initial_text: "0b11\n",
+        keys: "<C-a>",
+    },
+    // Repeat and undo.
+    OracleCase {
+        name: "dot repeats increment",
+        initial_text: "5\n",
+        keys: "<C-a>.",
+    },
+    OracleCase {
+        name: "dot repeats counted increment",
+        initial_text: "5\n",
+        keys: "3<C-a>.",
+    },
+    OracleCase {
+        name: "undo restores number",
+        initial_text: "x = 5\n",
+        keys: "<C-a>u",
+    },
+];


### PR DESCRIPTION
`Ctrl+a` and `Ctrl+x` add to or subtract from the number at or after the cursor, with a count. Same rules as nvim's default `nrformats=bin,hex`: decimal with a minus sign, `0x` hex, `0b` binary, no octal. Leading zeros keep their width, hex digits keep their case, cursor ends on the last digit. Undo is one step and `.` repeats it.

The number search is a port of nvim's `do_addsub`, which is what makes the odd cases line up: cursor on the `x` of `0x0f`, a minus right after a word character still counting as a sign, `0x0` wrapping on decrement.

31 oracle cases in a new category, all checked against real nvim. The keybind inventory gained an insert mode so the insert-mode `Ctrl+a` row and this one can both exist.

Visual mode `Ctrl+a` and `g Ctrl+a` are not part of this.
