### PR TITLE
feat: add ZQ and ctrl-^ alternate buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- Added `ZQ` to quit without saving, the same as `:q!`, and `Ctrl+^` to switch to the alternate buffer, the one the window showed before the current one. `Ctrl+^` reopens the file if its buffer was closed, and reports "No alternate file" when there is none. `Ctrl+6` works too, since that is the byte most terminals send for `Ctrl+^`.
 - Added `Ctrl+a` and `Ctrl+x` to add to or subtract from the number at or after the cursor, with a count. Follows Neovim's default `nrformats=bin,hex`: decimal with a minus sign, `0x` hex, `0b` binary, leading zeros keep their width, hex digits keep their case. Works with `.` and undoes in one step. Verified against real Neovim in a new oracle category.
 - A count before `i` or `a` now repeats the typed text like Vim, so `3ix<Esc>` gives `xxx`. `I`, `A`, `o`, and `O` already did this; the count is now set in one place for all six. (#296)
 - `*` and `#` now search for the whole word only, like Vim's `\<word\>`, so `*` on `abc` no longer stops inside `abcdef`. Everything that reuses the pattern follows along: `n`, `N`, `gn`, `gN`, the highlights, the match counter, and an empty `/` prompt. The pattern also goes into the search history, so `/` then Up recalls it. Typing `\<` and `\>` in a search works the same way; plain patterns still match inside words. (#310)

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -1024,6 +1024,8 @@ While typing an Ex command after `:`.
 | `:bd` / `:bdelete` | Close current buffer (fails if unsaved) |
 | `:bd!` / `:bdelete!` | Force close current buffer |
 
+> **Note:** The alternate file is tracked once for the whole editor, not per window like Vim, so switching buffers in one split also changes what `Ctrl+^` and the `"#` register point at in the other.
+
 ### Splits
 
 | Command | Action |

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -982,7 +982,7 @@ While typing an Ex command after `:`.
 | `:w!` / `:write!` | Force save file, overwriting external disk changes |
 | `:wa` / `:wall` | Save all files |
 | `:q` / `:quit` | Quit |
-| `:q!` / `:quit!` | Force quit (discard changes) |
+| `:q!` / `:quit!` / `ZQ` | Force quit (discard changes) |
 | `:qa` / `:qall` | Quit all |
 | `:qa!` / `:qall!` | Force quit all |
 | `:wq` | Save and quit |
@@ -1020,6 +1020,7 @@ While typing an Ex command after `:`.
 |---------|--------|
 | `:bn` | Next buffer |
 | `:bp` | Previous buffer |
+| `Ctrl+^` | Switch to the alternate buffer, the one this window showed last (reopens it if closed) |
 | `:bd` / `:bdelete` | Close current buffer (fails if unsaved) |
 | `:bd!` / `:bdelete!` | Force close current buffer |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 341 keybinds implemented, 86 planned Vim/Neovim parity defaults.**
+**Status: 343 keybinds implemented, 84 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md). This list comes
@@ -29,7 +29,7 @@ remain Vim-compatible unless Nevi intentionally documents a difference.
 ordering leans on the common proxies (vimtutor and cheat-sheet staples, what
 Neovim itself promotes to a default, plugin popularity like vim-unimpaired) and
 on what Nevi users actually ask for in issues — user reports move a key up
-immediately. The keys most hands reach for first: `Ctrl+^`, `ZQ`, the
+immediately. The keys most hands reach for first: the
 visual-mode operators (`gu` / `gU` /
 `g~`, `r`, `J`, `=`), `gq` / `gw`, and among the larger areas, folds and
 quickfix before tabs and tags.
@@ -81,8 +81,6 @@ quickfix before tabs and tags.
 
 | Keybind | Planned behavior |
 |---------|------------------|
-| `Ctrl+^` | Edit the alternate (previously edited) buffer |
-| `ZQ` | Quit without saving (like `:q!`) |
 | `[b` / `]b` | Go to the previous / next buffer (Neovim default) |
 | `[<Space>` / `]<Space>` | Add an empty line above / below the cursor (Neovim default) |
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **341 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **86 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **169 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+- **343 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **84 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **172 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
   - 161 verified against real Neovim (v0.11.3) by the Vim oracle
-  - 7 protected by focused Nevi regression tests
+  - 10 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
 - **448 oracle cases**: motions (144), editing (133), increment (31), insert-entry (17), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2)
 - **0 tracked coverage gaps**
-- **226 of 440 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **229 of 441 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -204,6 +204,9 @@ Nevi-owned behavior with no Vim equivalent to compare against.
 
 | Keybind | Behavior | Test |
 |---------|----------|----|
+| `ZZ` | Save if modified and quit | `normal_zz_writes_modified_file_and_quits` |
+| `ZQ` | Quit without saving | `normal_zq_quits_without_saving` |
+| `<C-^>` | Switch to the alternate buffer | `normal_ctrl_caret_toggles_between_the_last_two_buffers` |
 | `]m` | Move to next method/function start (tree-sitter) | `method_motion_jumps_between_function_starts` |
 | `[m` | Move to previous method/function start (tree-sitter) | `method_motion_jumps_between_function_starts` |
 | `]M` | Move to next method/function end (tree-sitter) | `method_motion_ends_land_on_closing_brace` |
@@ -232,7 +235,7 @@ like `dw` are tracked as single inventory entries, so their building-block
 rows may already be covered compositionally.)
 
 <details>
-<summary>214 untracked rows</summary>
+<summary>212 untracked rows</summary>
 
 | Keybind | Behavior |
 |---------|----------|
@@ -380,12 +383,10 @@ rows may already be covered compositionally.)
 | `:w!` / `:write!` | Force save file, overwriting external disk changes |
 | `:wa` / `:wall` | Save all files |
 | `:q` / `:quit` | Quit |
-| `:q!` / `:quit!` | Force quit (discard changes) |
 | `:qa` / `:qall` | Quit all |
 | `:qa!` / `:qall!` | Force quit all |
 | `:wq` | Save and quit |
 | `:wqa` / `:wqall` / `:xall` | Save all and quit |
-| `:x` / `:exit` / `ZZ` | Save if modified and quit |
 | `:xa` | Save all modified files and quit all |
 | `:e {file}` / `:edit {file}` | Edit/open a file |
 | `:e!` / `:edit!` | Reload current file and discard changes |

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -3366,6 +3366,31 @@ impl Editor {
         self.alternate_file_path = self.buffers[self.current_buffer_idx].path.clone();
     }
 
+    /// `Ctrl-^`: edit the alternate file, the one this window showed before
+    /// the current buffer (`:e #`). A closed alternate is read back from
+    /// disk, as Vim re-edits an unlisted buffer.
+    pub fn switch_to_alternate_buffer(&mut self) {
+        let Some(path) = self.alternate_file_path.clone() else {
+            self.set_status("No alternate file");
+            return;
+        };
+        let open_idx = self
+            .buffers
+            .iter()
+            .position(|buffer| buffer.path.as_ref() == Some(&path));
+        match open_idx {
+            Some(idx) if idx != self.current_buffer_idx => {
+                self.switch_to_buffer(idx);
+            }
+            Some(_) => self.set_status("No alternate file"),
+            None => {
+                if let Err(err) = self.open_file(path) {
+                    self.set_status(format!("Error: {}", err));
+                }
+            }
+        }
+    }
+
     // ============================================
     // Pane Management
     // ============================================
@@ -4077,6 +4102,9 @@ impl Editor {
                 pane.h_offset = 0;
             }
         } else {
+            // The closed file becomes the alternate, as in Vim, so Ctrl-^
+            // can bring it straight back.
+            self.remember_current_file_as_alternate();
             // Remove the current buffer
             self.buffers.remove(removed_idx);
             self.undo_stacks.remove(removed_idx);

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -57,6 +57,20 @@ desc = "Write if modified and quit"
 status = "implemented"
 vim_default = true
 
+[[normal.file]]
+key = "ZQ"
+action = "force_quit"
+desc = "Quit without saving"
+status = "implemented"
+vim_default = true
+
+[[normal.file]]
+key = "<C-^>"
+action = "alternate_buffer"
+desc = "Switch to the alternate buffer"
+status = "implemented"
+vim_default = true
+
 # ----------------------------------------------------------------------------
 # Movement - Basic cursor movement
 # ----------------------------------------------------------------------------

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -168,6 +168,10 @@ pub enum KeyAction {
     /// Add the signed amount to the number at or after the cursor
     /// (<C-a> is +count, <C-x> is -count)
     AddToNumber(i64),
+    /// Quit without saving, like `:q!` (ZQ)
+    ForceQuit,
+    /// Edit the alternate buffer, like `:e #` (<C-^>)
+    AlternateBuffer,
     /// Repeat last change (.). Carries the typed count, if any: Vim treats
     /// an explicit count (even `1.`) as replacing the change's own count.
     RepeatLastChange(Option<usize>),
@@ -939,6 +943,15 @@ impl InputState {
                 self.motion_or_operator(Motion::BigWordEnd, count)
             }
 
+            // <C-^> - alternate buffer. Legacy terminals send byte 0x1e, which
+            // crossterm reports as Ctrl+6; the kitty protocol reports Ctrl+^
+            // with Shift also held. Must sit before the `^` motion arm below,
+            // which accepts any modifier.
+            (modifiers, KeyCode::Char('^' | '6')) if modifiers.contains(KeyModifiers::CONTROL) => {
+                self.reset();
+                KeyAction::AlternateBuffer
+            }
+
             // Line motions
             (KeyModifiers::NONE, KeyCode::Char('0')) => {
                 self.motion_or_operator(Motion::LineStart, count)
@@ -1518,6 +1531,11 @@ impl InputState {
             ('Z', KeyModifiers::SHIFT, KeyCode::Char('Z')) => {
                 self.reset();
                 KeyAction::WriteQuitIfModified
+            }
+            // ZQ - quit without saving
+            ('Z', KeyModifiers::SHIFT, KeyCode::Char('Q')) => {
+                self.reset();
+                KeyAction::ForceQuit
             }
             // ]d - go to next diagnostic
             (']', KeyModifiers::NONE, KeyCode::Char('d')) => {
@@ -2380,6 +2398,33 @@ mod tests {
     #[test]
     fn normal_zz_maps_to_write_quit_if_modified() {
         assert_write_quit_if_modified(&[shift('Z'), shift('Z')]);
+    }
+
+    #[test]
+    fn normal_zq_maps_to_force_quit() {
+        match run(&[shift('Z'), shift('Q')]) {
+            KeyAction::ForceQuit => {}
+            other => panic!("expected ForceQuit, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn ctrl_caret_maps_to_alternate_buffer_in_every_spelling() {
+        // Legacy terminals send byte 0x1e, which crossterm reports as Ctrl+6;
+        // the kitty protocol reports the shifted key with Ctrl and Shift held.
+        for key in [
+            ctrl('^'),
+            ctrl('6'),
+            KeyEvent::new(
+                KeyCode::Char('^'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            ),
+        ] {
+            match run(&[key]) {
+                KeyAction::AlternateBuffer => {}
+                other => panic!("expected AlternateBuffer for {key:?}, got {other:?}"),
+            }
+        }
     }
 
     #[test]

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -74,6 +74,23 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
     // Method motions deliberately deviate from Vim's brace heuristic (they
     // use tree-sitter function boundaries), so they carry Nevi regression
     // tests instead of oracle cases.
+    // Quit and buffer keys cannot be oracle cases: quitting ends the nvim
+    // snapshot and the harness runs a single scratch buffer.
+    nevi_regression(
+        "ZZ",
+        "Save if modified and quit",
+        "normal_zz_writes_modified_file_and_quits",
+    ),
+    nevi_regression(
+        "ZQ",
+        "Quit without saving",
+        "normal_zq_quits_without_saving",
+    ),
+    nevi_regression(
+        "<C-^>",
+        "Switch to the alternate buffer",
+        "normal_ctrl_caret_toggles_between_the_last_two_buffers",
+    ),
     nevi_regression(
         "]m",
         "Move to next method/function start (tree-sitter)",

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -15613,6 +15613,60 @@ mod tests {
     }
 
     #[test]
+    fn normal_ctrl_caret_keeps_unsaved_edits_in_the_hidden_buffer() {
+        let tmp = unique_temp_dir("nevi_alternate_buffer_hidden_edit");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first.clone()).expect("open first");
+        editor.open_file(second.clone()).expect("open second");
+        editor.replace_buffer_content("second edited\n");
+
+        handle_key(&mut editor, ctrl_key('^'));
+        assert_eq!(editor.buffer().path.as_deref(), Some(first.as_path()));
+        handle_key(&mut editor, ctrl_key('^'));
+
+        assert_eq!(editor.buffer().path.as_deref(), Some(second.as_path()));
+        assert_eq!(editor.buffer().content(), "second edited\n");
+        assert!(editor.buffer().dirty);
+        assert_eq!(
+            std::fs::read_to_string(&second).expect("read second"),
+            "second\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_ctrl_caret_on_a_deleted_alternate_opens_it_as_a_new_file() {
+        let tmp = unique_temp_dir("nevi_alternate_buffer_deleted");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first.clone()).expect("open first");
+        editor.open_file(second.clone()).expect("open second");
+        editor.close_current_buffer();
+        std::fs::remove_file(&second).expect("delete second");
+
+        handle_key(&mut editor, ctrl_key('^'));
+
+        // Same as `:e` on a name that does not exist yet: an empty buffer
+        // under that path, ready to be written.
+        assert_eq!(editor.buffer().path.as_deref(), Some(second.as_path()));
+        assert!(editor.buffer().content().trim().is_empty());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
     fn normal_keymap_can_bind_custom_key_to_write_quit_if_modified() {
         let tmp = unique_temp_dir("nevi_normal_keymap_write_quit");
         std::fs::create_dir_all(&tmp).expect("create temp dir");

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7787,6 +7787,14 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.add_to_number_at_cursor(delta);
         }
 
+        KeyAction::ForceQuit => {
+            execute_command(editor, Command::ForceQuit);
+        }
+
+        KeyAction::AlternateBuffer => {
+            editor.switch_to_alternate_buffer();
+        }
+
         KeyAction::ScrollLineUp(count) => {
             let delta = -(count.min(isize::MAX as usize) as isize);
             editor.scroll_pane_viewport(editor.active_pane_idx(), delta);
@@ -15508,6 +15516,100 @@ mod tests {
 
         assert!(!editor.should_quit);
         assert_eq!(editor.status_message.as_deref(), Some("E: No filename"));
+    }
+
+    #[test]
+    fn normal_zq_quits_without_saving() {
+        let tmp = unique_temp_dir("nevi_normal_zq_quit");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "original\n").expect("write original");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open file");
+        editor.replace_buffer_content("local edit\n");
+
+        handle_key(&mut editor, shift_key('Z'));
+        handle_key(&mut editor, shift_key('Q'));
+
+        assert!(editor.should_quit);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read file"),
+            "original\n"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_zq_closes_only_the_active_pane_when_split() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("scratch\n");
+        editor.vsplit(None).expect("split");
+        assert_eq!(editor.panes().len(), 2);
+
+        handle_key(&mut editor, shift_key('Z'));
+        handle_key(&mut editor, shift_key('Q'));
+
+        assert!(!editor.should_quit);
+        assert_eq!(editor.panes().len(), 1);
+    }
+
+    #[test]
+    fn normal_ctrl_caret_toggles_between_the_last_two_buffers() {
+        let tmp = unique_temp_dir("nevi_alternate_buffer");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first.clone()).expect("open first");
+        editor.open_file(second.clone()).expect("open second");
+        assert_eq!(editor.buffer().path.as_deref(), Some(second.as_path()));
+
+        handle_key(&mut editor, ctrl_key('^'));
+        assert_eq!(editor.buffer().path.as_deref(), Some(first.as_path()));
+
+        handle_key(&mut editor, ctrl_key('^'));
+        assert_eq!(editor.buffer().path.as_deref(), Some(second.as_path()));
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_ctrl_caret_reopens_a_closed_alternate() {
+        let tmp = unique_temp_dir("nevi_alternate_buffer_reopen");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first.clone()).expect("open first");
+        editor.open_file(second.clone()).expect("open second");
+        editor.close_current_buffer();
+        assert_eq!(editor.buffer().path.as_deref(), Some(first.as_path()));
+
+        handle_key(&mut editor, ctrl_key('^'));
+
+        assert_eq!(editor.buffer().path.as_deref(), Some(second.as_path()));
+        assert_eq!(editor.buffer().content(), "second\n");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn normal_ctrl_caret_without_alternate_reports_and_stays() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("only\n");
+
+        handle_key(&mut editor, ctrl_key('^'));
+
+        assert_eq!(editor.buffer().content(), "only\n");
+        assert_eq!(editor.status_message.as_deref(), Some("No alternate file"));
     }
 
     #[test]


### PR DESCRIPTION
`ZQ` quits without saving, same path as `:q!`, so in a split it just closes the pane.

`Ctrl+^` goes to the alternate buffer. The path was already tracked for the `"#` register, so this switches to it, reopens it if the buffer was closed, or says "No alternate file". `Ctrl+6` works too since most terminals send the same byte.

Turned out the `^` motion arm accepted any modifier, so `Ctrl+^` was quietly acting as `^`. Fixed by ordering. Seven native tests, no oracle cases since quitting kills the nvim snapshot.
