### PR TITLE
fix: keep modified buffers when quitting from the last window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- `:q!`, `:wq`, `:x`, `ZZ`, and `ZQ` no longer exit while another buffer still has unsaved changes. Like Vim, they finish with the current buffer (saved or discarded as asked) and then show the first buffer that still needs a write, with the `No write since last change for buffer` message. `:qa!` remains the way to discard everything. `:wq`, `:x`, and `ZZ` in a split now close just that pane instead of exiting the editor. (#316)
 - Added `ZQ` to quit without saving, the same as `:q!`, and `Ctrl+^` to switch to the alternate buffer, the one the window showed before the current one. `Ctrl+^` reopens the file if its buffer was closed, and reports "No alternate file" when there is none. `Ctrl+6` works too, since that is the byte most terminals send for `Ctrl+^`.
 - Added `Ctrl+a` and `Ctrl+x` to add to or subtract from the number at or after the cursor, with a count. Follows Neovim's default `nrformats=bin,hex`: decimal with a minus sign, `0x` hex, `0b` binary, leading zeros keep their width, hex digits keep their case. Works with `.` and undoes in one step. Verified against real Neovim in a new oracle category.
 - A count before `i` or `a` now repeats the typed text like Vim, so `3ix<Esc>` gives `xxx`. `I`, `A`, `o`, and `O` already did this; the count is now set in one place for all six. (#296)

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -6870,6 +6870,27 @@ impl Editor {
             .collect()
     }
 
+    /// Vim's last-window rule (`check_changed_any`): exiting needs every
+    /// buffer accounted for. When another buffer still has unsaved changes,
+    /// drop the current one (the caller has saved it or chosen to discard
+    /// it) and show the first modified buffer instead; returns its name.
+    /// None means nothing else is modified and exiting is fine.
+    pub fn show_first_other_modified_buffer(&mut self) -> Option<String> {
+        let current = self.current_buffer_idx;
+        let another_is_modified = self
+            .buffers
+            .iter()
+            .enumerate()
+            .any(|(idx, buffer)| idx != current && buffer.dirty);
+        if !another_is_modified {
+            return None;
+        }
+        self.close_current_buffer();
+        let idx = self.buffers.iter().position(|buffer| buffer.dirty)?;
+        self.switch_to_buffer(idx);
+        Some(self.buffers[idx].display_name())
+    }
+
     /// Undo the last change
     pub fn undo(&mut self) {
         self.undo_stack

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10350,6 +10350,23 @@ fn rename_file_impl(
     }
 }
 
+/// Shared tail of `:q!`, `:wq`, `:x`, and `ZZ`, Vim's window-close rule: in a
+/// split only the pane goes; on the last pane exiting needs every buffer
+/// accounted for, so a buffer that still has unsaved changes is shown with
+/// Vim's E162 message instead. Only `:qa!` discards everything.
+fn close_pane_or_quit(editor: &mut Editor) -> CommandResult {
+    if editor.panes().len() > 1 {
+        editor.close_pane();
+        return CommandResult::Ok;
+    }
+    match editor.show_first_other_modified_buffer() {
+        Some(name) => {
+            CommandResult::Error(format!("No write since last change for buffer \"{name}\""))
+        }
+        None => CommandResult::Quit,
+    }
+}
+
 fn execute_command(editor: &mut Editor, cmd: Command) {
     let result = match cmd {
         Command::Write(path) => {
@@ -10469,20 +10486,12 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             }
         }
 
-        Command::ForceQuit => {
-            // If multiple panes, close just the active pane
-            if editor.panes().len() > 1 {
-                editor.close_pane();
-                CommandResult::Ok
-            } else {
-                CommandResult::Quit
-            }
-        }
+        Command::ForceQuit => close_pane_or_quit(editor),
 
         Command::WriteQuit => {
             if editor.buffer().path.is_some() {
                 match editor.save() {
-                    Ok(()) => CommandResult::Quit,
+                    Ok(()) => close_pane_or_quit(editor),
                     Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
                 }
             } else {
@@ -10494,14 +10503,14 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
             if editor.has_unsaved_changes() {
                 if editor.buffer().path.is_some() {
                     match editor.save() {
-                        Ok(()) => CommandResult::Quit,
+                        Ok(()) => close_pane_or_quit(editor),
                         Err(e) => CommandResult::Error(format!("Error saving: {}", e)),
                     }
                 } else {
                     CommandResult::Error("No filename".to_string())
                 }
             } else {
-                CommandResult::Quit
+                close_pane_or_quit(editor)
             }
         }
 
@@ -16507,6 +16516,136 @@ mod tests {
                 .as_deref()
                 .unwrap_or_default()
                 .contains("No write since last change")
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    // Vim's last-window rule: :q!, :wq, :x and ZZ may abandon the current
+    // buffer, but exiting needs every buffer accounted for. Another buffer
+    // with unsaved changes is shown instead of exiting. Only :qa! discards
+    // everything.
+    fn two_files_with_a_hidden_edit(
+        prefix: &str,
+    ) -> (std::path::PathBuf, std::path::PathBuf, Editor) {
+        let tmp = unique_temp_dir(prefix);
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let hidden = tmp.join("hidden.txt");
+        let current = tmp.join("current.txt");
+        std::fs::write(&hidden, "hidden\n").expect("write hidden");
+        std::fs::write(&current, "current\n").expect("write current");
+
+        let mut editor = Editor::default();
+        editor.open_file(hidden.clone()).expect("open hidden");
+        editor.buffer_mut().insert_char(0, 0, 'x');
+        editor.open_file(current.clone()).expect("open current");
+        (hidden, current, editor)
+    }
+
+    #[test]
+    fn force_quit_on_last_pane_shows_the_other_modified_buffer_instead_of_exiting() {
+        let (hidden, current, mut editor) = two_files_with_a_hidden_edit("nevi_force_quit_hidden");
+        editor.buffer_mut().insert_char(0, 0, 'y');
+
+        execute_command(&mut editor, Command::ForceQuit);
+
+        assert!(!editor.should_quit);
+        assert_eq!(editor.buffer().path.as_ref(), Some(&hidden));
+        assert_eq!(editor.buffer().content(), "xhidden\n");
+        // The current buffer's edit was discarded, as :q! asks.
+        assert_eq!(editor.buffer_count(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&current).expect("read current"),
+            "current\n"
+        );
+        assert!(
+            editor
+                .status_message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("No write since last change for buffer \"hidden.txt\"")
+        );
+
+        let _ = std::fs::remove_dir_all(hidden.parent().expect("tmp dir"));
+    }
+
+    #[test]
+    fn write_quit_on_last_pane_saves_then_shows_the_other_modified_buffer() {
+        let (hidden, current, mut editor) = two_files_with_a_hidden_edit("nevi_write_quit_hidden");
+        editor.buffer_mut().insert_char(0, 0, 'y');
+
+        execute_command(&mut editor, Command::WriteQuit);
+
+        assert!(!editor.should_quit);
+        assert_eq!(
+            std::fs::read_to_string(&current).expect("read current"),
+            "ycurrent\n"
+        );
+        assert_eq!(editor.buffer().path.as_ref(), Some(&hidden));
+        assert!(
+            editor
+                .status_message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("No write since last change for buffer")
+        );
+
+        let _ = std::fs::remove_dir_all(hidden.parent().expect("tmp dir"));
+    }
+
+    #[test]
+    fn zz_on_last_pane_shows_the_other_modified_buffer() {
+        let (hidden, _current, mut editor) = two_files_with_a_hidden_edit("nevi_zz_hidden");
+
+        handle_key(&mut editor, shift_key('Z'));
+        handle_key(&mut editor, shift_key('Z'));
+
+        assert!(!editor.should_quit);
+        assert_eq!(editor.buffer().path.as_ref(), Some(&hidden));
+
+        let _ = std::fs::remove_dir_all(hidden.parent().expect("tmp dir"));
+    }
+
+    #[test]
+    fn force_quit_exits_when_no_other_buffer_is_modified() {
+        let tmp = unique_temp_dir("nevi_force_quit_clean_others");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let first = tmp.join("first.txt");
+        let second = tmp.join("second.txt");
+        std::fs::write(&first, "first\n").expect("write first");
+        std::fs::write(&second, "second\n").expect("write second");
+
+        let mut editor = Editor::default();
+        editor.open_file(first).expect("open first");
+        editor.open_file(second).expect("open second");
+        editor.buffer_mut().insert_char(0, 0, 'y');
+
+        execute_command(&mut editor, Command::ForceQuit);
+
+        assert!(editor.should_quit);
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn write_quit_in_a_split_closes_only_the_pane() {
+        let tmp = unique_temp_dir("nevi_write_quit_split");
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("note.txt");
+        std::fs::write(&path, "note\n").expect("write note");
+
+        let mut editor = Editor::default();
+        editor.open_file(path.clone()).expect("open note");
+        editor.vsplit(None).expect("split");
+        editor.buffer_mut().insert_char(0, 0, 'y');
+
+        execute_command(&mut editor, Command::WriteQuit);
+
+        assert!(!editor.should_quit);
+        assert_eq!(editor.panes().len(), 1);
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read note"),
+            "ynote\n"
         );
 
         let _ = std::fs::remove_dir_all(&tmp);


### PR DESCRIPTION
`:q!` exited with other buffers still modified and took their edits with it. Turned out `:wq`, `:x` and `ZZ` had the same hole, and in a split they exited the whole editor instead of closing the pane.

All four now share one tail: close the pane in a split, otherwise finish with the current buffer and, if another one still has unsaved changes, switch to it with the `No write since last change for buffer` message instead of exiting. Checked against nvim, which does exactly that. `:qa!` is unchanged.

Five tests cover the four commands, the split case, and the plain exit when nothing else is dirty.

Fixes #316
