### PR TITLE
feat: add g* and g# word search without boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- Added `g*` and `g#`, the word searches that also match inside longer words. The plain word goes into the pattern and the history, so `n`, `N`, and `/` then Up all keep the looser match. Verified against real Neovim.
 - Added the visual-mode operators `gu`, `gU`, `g~`, `r{char}`, `J`, `gJ`, and `=` on a selection. `r{char}` replaces every selected character, `J` and `gJ` join the selected lines (at least two), and `=` re-indents them. Along the way, the existing `u`, `U`, and `~` on a block selection now change only the block instead of everything between its corners, and all case operators leave the cursor at the start of the selection like Vim. Verified against real Neovim in a new visual oracle category, except `=`, which follows Nevi's own indenter.
 - `:q!`, `:wq`, `:x`, `ZZ`, and `ZQ` no longer exit while another buffer still has unsaved changes. Like Vim, they finish with the current buffer (saved or discarded as asked) and then show the first buffer that still needs a write, with the `No write since last change for buffer` message. `:qa!` remains the way to discard everything. `:wq`, `:x`, and `ZZ` in a split now close just that pane instead of exiting the editor. (#316)
 - Added `ZQ` to quit without saving, the same as `:q!`, and `Ctrl+^` to switch to the alternate buffer, the one the window showed before the current one. `Ctrl+^` reopens the file if its buffer was closed, and reports "No alternate file" when there is none. `Ctrl+6` works too, since that is the byte most terminals send for `Ctrl+^`.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -441,6 +441,7 @@ Operators are commands that wait for a motion. For example, `d` (delete) + `w` (
 | `N` | Go to previous match |
 | `*` | Search word under cursor forward |
 | `#` | Search word under cursor backward |
+| `g*` / `g#` | Same as `*` / `#` but also match inside longer words |
 | `gn` | Search forward and select match |
 | `gN` | Search backward and select match |
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 350 keybinds implemented, 77 planned Vim/Neovim parity defaults.**
+**Status: 352 keybinds implemented, 75 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md). This list comes
@@ -58,13 +58,6 @@ the larger areas, folds and quickfix before tabs and tags.
 | `zh` / `zl` | Scroll the view one column left / right (no wrap) |
 | `zH` / `zL` | Scroll the view half a screen left / right |
 | `zs` / `ze` | Scroll so the cursor is at the start / end of the screen |
-
-### Search
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `g*` | Search the word under the cursor without word boundaries |
-| `g#` | Same as `g*`, backward |
 
 ### Jumps And Marks
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **350 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **77 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **182 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 170 verified against real Neovim (v0.11.3) by the Vim oracle
+- **352 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **75 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **184 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 172 verified against real Neovim (v0.11.3) by the Vim oracle
   - 11 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **474 oracle cases**: motions (144), editing (135), increment (31), insert-entry (17), open-line (20), replace (27), search (44), text-objects (30), undo-redo (2), visual (24)
+- **481 oracle cases**: motions (144), editing (135), increment (31), insert-entry (17), open-line (20), replace (27), search (51), text-objects (30), undo-redo (2), visual (24)
 - **0 tracked coverage gaps**
-- **238 of 445 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **239 of 446 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -204,6 +204,8 @@ claim protection.
 | `N` | Go to previous match | `previous match reverses direction` |
 | `*` | Search word under cursor forward | `star searches word forward` |
 | `#` | Search word under cursor backward | `hash searches word backward` |
+| `g*` | Search word under cursor forward, also inside longer words | `g-star finds match inside longer word` |
+| `g#` | Search word under cursor backward, also inside longer words | `g-hash finds match inside longer word backward` |
 | `gn` | Search forward and select match | `gn selects next match from outside` |
 | `gN` | Search backward and select match | `gN selects match backward` |
 

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -7237,24 +7237,39 @@ impl Editor {
 
     /// Search for word under cursor forward (*)
     pub fn search_word_forward(&mut self) {
-        self.search_word_under_cursor(SearchDirection::Forward);
+        self.search_word_under_cursor(SearchDirection::Forward, true);
     }
 
     /// Search for word under cursor backward (#)
     pub fn search_word_backward(&mut self) {
-        self.search_word_under_cursor(SearchDirection::Backward);
+        self.search_word_under_cursor(SearchDirection::Backward, true);
     }
 
-    /// Shared `*`/`#` body. Like Vim, the recorded pattern is `\<word\>`
-    /// (whole keyword only) and it goes into the search history, so `n`,
-    /// `gn`, and `/` followed by Up all see the same bounded pattern.
-    fn search_word_under_cursor(&mut self, direction: SearchDirection) {
+    /// g*: like `*` but the match may sit inside a longer word.
+    pub fn search_word_forward_anywhere(&mut self) {
+        self.search_word_under_cursor(SearchDirection::Forward, false);
+    }
+
+    /// g#: like `#` but the match may sit inside a longer word.
+    pub fn search_word_backward_anywhere(&mut self) {
+        self.search_word_under_cursor(SearchDirection::Backward, false);
+    }
+
+    /// Shared `*`/`#`/`g*`/`g#` body. Like Vim, the recorded pattern is
+    /// `\<word\>` for the whole-word forms and the bare word for the `g`
+    /// forms, and it goes into the search history, so `n`, `gn`, and `/`
+    /// followed by Up all see the same pattern.
+    fn search_word_under_cursor(&mut self, direction: SearchDirection, whole_word: bool) {
         self.render_damage.mark_full();
         let Some(word) = self.get_word_under_cursor() else {
             self.set_status("No word under cursor");
             return;
         };
-        let pattern = SearchPattern::whole_word(&word);
+        let pattern = if whole_word {
+            SearchPattern::whole_word(&word)
+        } else {
+            word
+        };
         self.search.record_history(pattern.clone());
         self.search.last_pattern = Some(pattern.clone());
         self.search.last_direction = direction;
@@ -12640,6 +12655,27 @@ mod tests {
         assert_eq!(
             editor.search.history.last().map(String::as_str),
             Some("\\<abc\\>")
+        );
+    }
+
+    #[test]
+    fn g_star_highlights_and_counter_include_embedded_words() {
+        let mut editor = Editor::default();
+        editor.set_size(80, 8);
+        editor.replace_buffer_content("abc abcdef\nabc\n");
+
+        editor.search_word_forward_anywhere();
+
+        // Mirror of the `*` test: with g* the embedded `abc` inside `abcdef`
+        // is a match for the highlights and the counter, and the recorded
+        // pattern is the bare word.
+        assert_eq!((editor.cursor.line, editor.cursor.col), (0, 4));
+        assert_eq!(editor.search_matches, vec![(0, 0, 3), (0, 4, 7), (1, 0, 3)]);
+        assert_eq!(editor.search.match_stats, Some((2, 3)));
+        assert_eq!(editor.search.last_pattern.as_deref(), Some("abc"));
+        assert_eq!(
+            editor.search.history.last().map(String::as_str),
+            Some("abc")
         );
     }
 

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -847,6 +847,20 @@ status = "implemented"
 vim_default = true
 
 [[normal.search]]
+key = "g*"
+action = "search_word_forward_anywhere"
+desc = "Search word under cursor forward, also inside longer words"
+status = "implemented"
+vim_default = true
+
+[[normal.search]]
+key = "g#"
+action = "search_word_backward_anywhere"
+desc = "Search word under cursor backward, also inside longer words"
+status = "implemented"
+vim_default = true
+
+[[normal.search]]
 key = "#"
 action = "search_word_backward"
 desc = "Search word under cursor backward"

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -201,6 +201,10 @@ pub enum KeyAction {
     SearchPrev(usize),
     /// Search word under cursor forward (*)
     SearchWordForward,
+    /// g*: like * but without word boundaries
+    SearchWordForwardAnywhere,
+    /// g#: like # but without word boundaries
+    SearchWordBackwardAnywhere,
     /// Search word under cursor backward (#)
     SearchWordBackward,
     /// Search forward and select the match (gn)
@@ -1398,6 +1402,15 @@ impl InputState {
                 action
             }
             // g^ - move to first non-blank of current display line
+            // g* / g# - word search without the word boundaries
+            ('g', _, KeyCode::Char('*')) => {
+                self.reset();
+                KeyAction::SearchWordForwardAnywhere
+            }
+            ('g', _, KeyCode::Char('#')) => {
+                self.reset();
+                KeyAction::SearchWordBackwardAnywhere
+            }
             ('g', KeyModifiers::NONE, KeyCode::Char('^')) => {
                 let action = self.motion_or_operator(Motion::DisplayLineFirstNonBlank, count);
                 self.reset();
@@ -2729,6 +2742,14 @@ mod tests {
         match run(&[key('#')]) {
             KeyAction::SearchWordBackward => {}
             other => panic!("expected SearchWordBackward, got {:?}", other),
+        }
+        match run(&[key('g'), key('*')]) {
+            KeyAction::SearchWordForwardAnywhere => {}
+            other => panic!("expected SearchWordForwardAnywhere, got {:?}", other),
+        }
+        match run(&[key('g'), key('#')]) {
+            KeyAction::SearchWordBackwardAnywhere => {}
+            other => panic!("expected SearchWordBackwardAnywhere, got {:?}", other),
         }
         match run(&[key('g'), key('n')]) {
             KeyAction::SearchSelectNext(1) => {}

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -582,6 +582,16 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "hash searches word backward",
     ),
     vim_oracle(
+        "g*",
+        "Search word under cursor forward, also inside longer words",
+        "g-star finds match inside longer word",
+    ),
+    vim_oracle(
+        "g#",
+        "Search word under cursor backward, also inside longer words",
+        "g-hash finds match inside longer word backward",
+    ),
+    vim_oracle(
         "gn",
         "Search forward and select match",
         "gn selects next match from outside",

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -7832,6 +7832,14 @@ fn handle_normal_mode(editor: &mut Editor, key: KeyEvent) {
             editor.search_word_backward();
         }
 
+        KeyAction::SearchWordForwardAnywhere => {
+            editor.search_word_forward_anywhere();
+        }
+
+        KeyAction::SearchWordBackwardAnywhere => {
+            editor.search_word_backward_anywhere();
+        }
+
         KeyAction::SearchSelectNext(count) => {
             editor.search_select_next(count);
         }

--- a/src/vim_oracle/search_cases.rs
+++ b/src/vim_oracle/search_cases.rs
@@ -247,6 +247,43 @@ pub(super) const SEARCH_CASES: &[OracleCase] = &[
         initial_text: "abc abcdef\nabc\nxyz\n",
         keys: "*/xyz<CR>/<Up><Up><CR>",
     },
+    // g* and g# search the word without boundaries, so a match inside a
+    // longer word counts, and n keeps that looser pattern.
+    OracleCase {
+        name: "g-star finds match inside longer word",
+        initial_text: "abc abcdef\nabc\n",
+        keys: "g*",
+    },
+    OracleCase {
+        name: "g-hash finds match inside longer word backward",
+        initial_text: "abc\nxabc abc\n",
+        keys: "j$g#",
+    },
+    OracleCase {
+        name: "n after g-star keeps partial matching",
+        initial_text: "abc abcdef\nabc\n",
+        keys: "g*n",
+    },
+    OracleCase {
+        name: "g-star records plain pattern in search history",
+        initial_text: "abc\nxyz\nabcdef\n",
+        keys: "g*/xyz<CR>/<Up><Up><CR>",
+    },
+    OracleCase {
+        name: "N after g-star goes back through partial match",
+        initial_text: "abc abcdef\nabc\n",
+        keys: "g*nN",
+    },
+    OracleCase {
+        name: "g-star from middle of word uses whole keyword",
+        initial_text: "abcdef abc\n",
+        keys: "$hlg*",
+    },
+    OracleCase {
+        name: "gn after g-star selects partial match",
+        initial_text: "abc abcdef\n",
+        keys: "g*gnd",
+    },
 ];
 
 // Known divergence, deliberately not an active case (it would fail CI):


### PR DESCRIPTION
`g*` and `g#` search the word under the cursor without the `\<` `\>` boundaries, so they also stop inside longer words. After #310 this is the same search body with the wrap turned off.

The bare word is what gets recorded, so `n`, the highlights, the counter and `/` then Up all keep the looser match. Seven oracle cases checked against nvim, one of them only passes if the history entry is the bare word, plus a native test for the highlight set and counter.
