### PR TITLE
feat: add insert-mode ctrl-e and ctrl-y

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Vim Compatibility
 
+- Added the insert-mode `Ctrl+e` and `Ctrl+y` to insert the character below or above the cursor. The match is by screen column, so tabs and wide characters copy what you see under the cursor, and a press with nothing to copy does nothing. The copied character goes into the redo buffer like Vim, so `.` inserts the same text rather than copying again. While the completion popup is open, `Ctrl+y` accepts the selected item and `Ctrl+e` closes the popup. Verified against real Neovim.
 - Added the Neovim 0.11 defaults `[<Space>` and `]<Space>` to add empty lines above or below the cursor line, with a count, dot repeat, and one-step undo, and `[b` and `]b` to move through buffers with a count. A key that is waiting for its second half (`[`, `d`, `g`) now keeps the next press, so the Space leader no longer swallows `[<Space>`. Blank lines verified against real Neovim.
 - Session persistence now also covers the numbered delete-history registers `"1`-`"9` and the jumplist. After a restart, `"1p` recovers the last session's delete and `Ctrl+o` walks back through its navigation history. Jumps in unsaved scratch buffers stay session-only, and the jumplist is capped at 100 entries like the in-editor list.
 - Added `g*` and `g#`, the word searches that also match inside longer words. The plain word goes into the pattern and the history, so `n`, `N`, and `/` then Up all keep the looser match. Verified against real Neovim.

--- a/KEYBINDINGS.md
+++ b/KEYBINDINGS.md
@@ -540,6 +540,8 @@ View and edit recorded macros as readable key notation instead of re-recording.
 | `Ctrl+r {reg}` | Insert contents of register |
 | `Ctrl+o` | Run one normal-mode command, then return to insert |
 | `Ctrl+v {key}` or `Ctrl+q {key}` | Insert the next key literally (e.g. `Ctrl+v` `Ctrl+y` inserts the `0x19` control character, `Ctrl+v` `Tab` a real tab) |
+| `Ctrl+e` | Insert the character from the line below the cursor, by screen column (with the completion popup open, closes the popup instead) |
+| `Ctrl+y` | Insert the character from the line above the cursor, by screen column (with the completion popup open, accepts the selected item instead) |
 
 **Copilot (if enabled):**
 

--- a/KEYBINDS_ROADMAP.md
+++ b/KEYBINDS_ROADMAP.md
@@ -4,7 +4,7 @@ Nevi aims for full vim/neovim keybind compatibility. Defaults follow Neovim, and
 keybinds are configurable — sensible defaults out of the box, overridable to your
 own taste.
 
-**Status: 356 keybinds implemented, 71 planned Vim/Neovim parity defaults.**
+**Status: 358 keybinds implemented, 69 planned Vim/Neovim parity defaults.**
 
 This file tracks what's **planned** (not yet implemented). For the full list of
 keybinds that already work, see [KEYBINDINGS.md](KEYBINDINGS.md). This list comes
@@ -67,13 +67,6 @@ the larger areas, folds and quickfix before tabs and tags.
 | `` `[ `` / `` `] `` | Jump to the exact start / end of the last change or yank |
 | `'<` / `'>` | Jump to the first / last line of the last visual selection |
 | `` `< `` / `` `> `` | Jump to the exact start / end of the last visual selection |
-
-### Insert Mode
-
-| Keybind | Planned behavior |
-|---------|------------------|
-| `Ctrl+e` | Insert the character from the line below the cursor |
-| `Ctrl+y` | Insert the character from the line above the cursor |
 
 ### Command-Line Mode Defaults
 

--- a/PARITY.md
+++ b/PARITY.md
@@ -9,14 +9,14 @@ the test suite enforces, so it cannot drift from what is actually verified.
 
 ## Summary
 
-- **356 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **71 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
-- **188 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
-  - 174 verified against real Neovim (v0.11.3) by the Vim oracle
+- **358 keybinds implemented** ([KEYBINDINGS.md](KEYBINDINGS.md)), **69 planned** ([KEYBINDS_ROADMAP.md](KEYBINDS_ROADMAP.md))
+- **190 keybinds in the coverage inventory**, each mapped to the automated test that protects it:
+  - 176 verified against real Neovim (v0.11.3) by the Vim oracle
   - 13 protected by focused Nevi regression tests
   - 1 covered as default-keymap plumbing with dedicated tests
-- **490 oracle cases**: motions (144), editing (144), increment (31), insert-entry (17), open-line (20), replace (27), search (51), text-objects (30), undo-redo (2), visual (24)
+- **503 oracle cases**: motions (144), editing (157), increment (31), insert-entry (17), open-line (20), replace (27), search (51), text-objects (30), undo-redo (2), visual (24)
 - **0 tracked coverage gaps**
-- **241 of 448 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
+- **243 of 450 documented keybind rows map to an inventoried keybind**; the rest work today but are not yet individually tracked ([full list below](#documented-but-not-yet-inventoried))
 
 ## How the Vim oracle works
 
@@ -124,6 +124,8 @@ claim protection.
 | `<C-w>` | Delete word before cursor in insert | `insert ctrl-w deletes word before cursor` |
 | `<C-a>` | Insert previously inserted text | `insert ctrl-a repeats last inserted text` |
 | `Ctrl+r {reg}` | Insert register contents | `insert ctrl-r pastes named register` |
+| `<C-e>` | Insert the character below the cursor | `insert ctrl-e copies char from line below` |
+| `<C-y>` | Insert the character above the cursor | `insert ctrl-y copies char from line above` |
 | `<C-a>` | Add count to the number at or after the cursor | `increment number after cursor` |
 | `<C-x>` | Subtract count from the number at or after the cursor | `decrement number after cursor` |
 | `v` | Character-wise visual mode | `visual charwise delete` |

--- a/src/dot_repeat.rs
+++ b/src/dot_repeat.rs
@@ -116,6 +116,19 @@ impl DotRepeat {
         self.replaying = false;
     }
 
+    /// Replace the key just observed with the keys `.` should replay for it.
+    /// Vim's redo buffer stores what a key inserted rather than the key when
+    /// the result depends on context: insert `<C-e>`/`<C-y>` copy a character
+    /// from a neighbouring line, and `.` must re-insert that same character.
+    /// An empty `keys` drops the key from the change entirely.
+    pub fn replace_last_key(&mut self, keys: &[KeyEvent]) {
+        if self.replaying || self.candidate.is_empty() {
+            return;
+        }
+        self.candidate.pop();
+        self.candidate.extend_from_slice(keys);
+    }
+
     /// Drop the in-flight candidate. The `.` keystroke (and its count) must
     /// never become the recorded change.
     pub fn abandon_candidate(&mut self) {
@@ -216,6 +229,22 @@ mod tests {
         dot.observe(Mode::Insert, false, 3, 0, esc());
         dot.observe(Mode::Normal, false, 3, 0, key('j'));
         assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "ihi␛");
+    }
+
+    #[test]
+    fn replaced_key_is_what_gets_replayed() {
+        let mut dot = DotRepeat::default();
+        let ctrl_e = KeyEvent::new(KeyCode::Char('e'), KeyModifiers::CONTROL);
+        dot.observe(Mode::Normal, false, 1, 0, key('i'));
+        // Insert <C-e> copied a `c`; Vim redoes the `c`, not the key.
+        dot.observe(Mode::Insert, false, 1, 0, ctrl_e);
+        dot.replace_last_key(&[key('c')]);
+        // A second press copied nothing and must vanish from the change.
+        dot.observe(Mode::Insert, false, 2, 0, ctrl_e);
+        dot.replace_last_key(&[]);
+        dot.observe(Mode::Insert, false, 2, 0, esc());
+        dot.observe(Mode::Normal, false, 2, 0, key('j'));
+        assert_eq!(chars(&dot.take_replay_keys(None).unwrap()), "ic␛");
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -4686,6 +4686,27 @@ impl Editor {
         }
     }
 
+    /// The character covering screen column `display_col` in `chars`, like
+    /// Vim's `ins_copychar`: a tab or wide character that spans the column
+    /// is returned whole. None once the line ends before the column.
+    fn char_at_display_col(
+        chars: impl Iterator<Item = char>,
+        display_col: usize,
+        tab_width: usize,
+    ) -> Option<char> {
+        let mut width = 0;
+        for ch in chars.take_while(|ch| *ch != '\n') {
+            if width >= display_col {
+                return Some(ch);
+            }
+            width += Self::display_char_width(ch, tab_width);
+            if width > display_col {
+                return Some(ch);
+            }
+        }
+        None
+    }
+
     fn display_width_between_cols(
         line: &str,
         start_col: usize,
@@ -5878,6 +5899,35 @@ impl Editor {
             ));
             self.buffers[self.current_buffer_idx].insert_str(line_idx, insert_col, &inserted_text);
         }
+    }
+
+    /// Vim's insert-mode `Ctrl+y` / `Ctrl+e`: insert the character that sits
+    /// in the cursor's screen column on the line above / below, and return
+    /// it. Matching by display width means the copied character is the one
+    /// the eye sees under the cursor even past tabs or wide characters.
+    /// Nothing happens when there is no such line or it ends before the
+    /// column (Vim beeps). Inserted like a literal, so no auto pair fires.
+    pub fn insert_char_from_adjacent_line(&mut self, above: bool) -> Option<char> {
+        let source_line = if above {
+            self.cursor.line.checked_sub(1)?
+        } else {
+            self.cursor.line + 1
+        };
+        let tab_width = self.get_effective_tab_width();
+        let buffer = self.buffer();
+        if source_line >= buffer.addressable_line_count() {
+            return None;
+        }
+        let display_col: usize = buffer
+            .line(self.cursor.line)?
+            .chars()
+            .take(self.cursor.col)
+            .map(|ch| Self::display_char_width(ch, tab_width))
+            .sum();
+        let ch =
+            Self::char_at_display_col(buffer.line(source_line)?.chars(), display_col, tab_width)?;
+        self.insert_char(ch);
+        Some(ch)
     }
 
     /// Insert a character at cursor position

--- a/src/finder/keybinds.toml
+++ b/src/finder/keybinds.toml
@@ -1438,6 +1438,20 @@ desc = "Execute one normal mode command"
 status = "implemented"
 vim_default = true
 
+[[insert.editing]]
+key = "<C-e>"
+action = "insert_char_below"
+desc = "Insert the character from the line below the cursor"
+status = "implemented"
+vim_default = true
+
+[[insert.editing]]
+key = "<C-y>"
+action = "insert_char_above"
+desc = "Insert the character from the line above the cursor"
+status = "implemented"
+vim_default = true
+
 # ----------------------------------------------------------------------------
 # Copilot (in insert mode) - ALL IMPLEMENTED
 # ----------------------------------------------------------------------------

--- a/src/keybind_coverage.rs
+++ b/src/keybind_coverage.rs
@@ -327,6 +327,16 @@ const KEYBIND_COVERAGE: &[KeybindCoverage] = &[
         "Insert register contents",
         "insert ctrl-r pastes named register",
     ),
+    insert_oracle(
+        "<C-e>",
+        "Insert the character below the cursor",
+        "insert ctrl-e copies char from line below",
+    ),
+    insert_oracle(
+        "<C-y>",
+        "Insert the character above the cursor",
+        "insert ctrl-y copies char from line above",
+    ),
     vim_oracle(
         "<C-a>",
         "Add count to the number at or after the cursor",

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -8354,8 +8354,10 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
                 editor.completion.select_next();
                 return;
             }
-            // Accept completion
-            (KeyModifiers::NONE, KeyCode::Enter) | (KeyModifiers::NONE, KeyCode::Tab) => {
+            // Accept completion (Ctrl+y is Vim's accept while the popup is up)
+            (KeyModifiers::NONE, KeyCode::Enter)
+            | (KeyModifiers::NONE, KeyCode::Tab)
+            | (KeyModifiers::CONTROL, KeyCode::Char('y')) => {
                 // Get completion info before modifying state
                 let completion_info = editor.completion.selected_item().cloned();
 
@@ -8396,8 +8398,8 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
                 editor.completion.hide();
                 return;
             }
-            // Cancel completion
-            (KeyModifiers::NONE, KeyCode::Esc) => {
+            // Cancel completion (Ctrl+e is Vim's close-popup while it is up)
+            (KeyModifiers::NONE, KeyCode::Esc) | (KeyModifiers::CONTROL, KeyCode::Char('e')) => {
                 editor.completion.hide();
                 return;
             }
@@ -8520,6 +8522,25 @@ fn handle_insert_mode(editor: &mut Editor, key: KeyEvent) {
         (KeyModifiers::CONTROL, KeyCode::Char('v'))
         | (KeyModifiers::CONTROL, KeyCode::Char('q')) => {
             editor.pending_insert_literal = true;
+        }
+
+        // Copy the character under the cursor's screen column from the line
+        // below / above (Ctrl+e / Ctrl+y). Vim's redo buffer keeps the copied
+        // character rather than the key, so `.` re-inserts the same text; a
+        // press that copied nothing leaves no trace in the change.
+        (KeyModifiers::CONTROL, KeyCode::Char('e'))
+        | (KeyModifiers::CONTROL, KeyCode::Char('y')) => {
+            let above = key.code == KeyCode::Char('y');
+            let replay: Vec<KeyEvent> = editor
+                .insert_char_from_adjacent_line(above)
+                .map(|ch| {
+                    vec![
+                        KeyEvent::new(KeyCode::Char('v'), KeyModifiers::CONTROL),
+                        KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE),
+                    ]
+                })
+                .unwrap_or_default();
+            editor.dot_repeat.replace_last_key(&replay);
         }
 
         // Execute one normal-mode command, then return to insert mode (Ctrl+o)
@@ -14379,6 +14400,91 @@ mod tests {
         handle_key(&mut editor, esc_key());
 
         assert_eq!(editor.buffer().content(), "\u{15}\n");
+    }
+
+    #[test]
+    fn insert_ctrl_e_copies_by_screen_column_past_a_tab() {
+        // The tab on the cursor line is 4 columns wide, so the character
+        // copied from below is the one under column 4, not char index 1.
+        // Tabs are oracle-invisible: nvim's tabstop is 8, Nevi's default 4.
+        let mut editor = Editor::default();
+        assert_eq!(editor.settings.editor.tab_width, 4);
+        editor.replace_buffer_content("\tX\nabcdefgh\n");
+        handle_key(&mut editor, key('l'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, ctrl_key('e'));
+        handle_key(&mut editor, esc_key());
+
+        assert_eq!(editor.buffer().content(), "\teX\nabcdefgh\n");
+    }
+
+    #[test]
+    fn insert_ctrl_y_copies_a_tab_that_spans_the_cursor_column() {
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("\tz\nabc\n");
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('l'));
+        handle_key(&mut editor, key('l'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, ctrl_key('y'));
+        handle_key(&mut editor, esc_key());
+
+        assert_eq!(editor.buffer().content(), "\tz\nab\tc\n");
+    }
+
+    #[test]
+    fn insert_ctrl_e_that_copied_nothing_is_dropped_from_dot_repeat() {
+        // On the last line <C-e> has nothing to copy. Replaying the key on
+        // another line would insert something Vim never did.
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("ab\ncd\n");
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, key('i'));
+        handle_key(&mut editor, ctrl_key('e'));
+        handle_key(&mut editor, key('x'));
+        handle_key(&mut editor, esc_key());
+        handle_key(&mut editor, key('k'));
+        handle_key(&mut editor, key('.'));
+
+        assert_eq!(editor.buffer().content(), "xab\nxcd\n");
+    }
+
+    #[test]
+    fn insert_ctrl_e_closes_the_completion_popup_instead_of_copying() {
+        // Vim: with the popup up, Ctrl+e ends completion and keeps the typed
+        // text. Without the popup this press would copy the `l` from below.
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("de\nbelow\n");
+        handle_key(&mut editor, shift_key('A'));
+        assert_eq!(editor.mode, Mode::Insert);
+        editor.show_completions(Vec::new(), 0, 0, false);
+        assert!(editor.completion.active);
+
+        handle_key(&mut editor, ctrl_key('e'));
+
+        assert!(!editor.completion.active);
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!(editor.buffer().content(), "de\nbelow\n");
+    }
+
+    #[test]
+    fn insert_ctrl_y_goes_to_the_completion_popup_instead_of_copying() {
+        // Vim: with the popup up, Ctrl+y accepts the selection (the same
+        // path as Enter and Tab). An empty popup keeps this test off the
+        // accept path's frecency file write; without the popup this press
+        // would copy the `o` from above.
+        let mut editor = Editor::default();
+        editor.replace_buffer_content("above\nde\n");
+        handle_key(&mut editor, key('j'));
+        handle_key(&mut editor, shift_key('A'));
+        assert_eq!(editor.mode, Mode::Insert);
+        editor.show_completions(Vec::new(), 1, 0, false);
+
+        handle_key(&mut editor, ctrl_key('y'));
+
+        assert!(!editor.completion.active);
+        assert_eq!(editor.mode, Mode::Insert);
+        assert_eq!(editor.buffer().content(), "above\nde\n");
     }
 
     #[test]

--- a/src/vim_oracle.rs
+++ b/src/vim_oracle.rs
@@ -1293,11 +1293,14 @@ vim.o.wrap = {}
 vim.api.nvim_win_set_width(0, {})
 vim.api.nvim_win_set_height(0, {})
 vim.api.nvim_feedkeys(keys, "xt", false)
+-- nvim_win_get_cursor reports a byte column; Nevi columns count characters,
+-- so use charcol() or any case whose cursor ends after a multibyte character
+-- diverges on the column alone.
 local pos = vim.api.nvim_win_get_cursor(0)
 local snapshot = {{
   lines = vim.api.nvim_buf_get_lines(0, 0, -1, false),
   cursor_line = pos[1] - 1,
-  cursor_col = pos[2],
+  cursor_col = vim.fn.charcol(".") - 1,
   viewport_top = vim.fn.line("w0") - 1,
   mode = vim.api.nvim_get_mode().mode,
 }}

--- a/src/vim_oracle/editing_cases.rs
+++ b/src/vim_oracle/editing_cases.rs
@@ -761,4 +761,81 @@ pub(super) const EDITING_CASES: &[OracleCase] = &[
         initial_text: "\n",
         keys: "i<C-v><C-y><Esc>.",
     },
+    // Insert <C-y>/<C-e> copy the character in the cursor's screen column
+    // from the line above/below, one per press. Texts are asymmetric so a
+    // copy from the wrong line or column shows up in the snapshot.
+    OracleCase {
+        name: "insert ctrl-y copies char from line above",
+        initial_text: "abc\nxyz\n",
+        keys: "jli<C-y><Esc>",
+    },
+    OracleCase {
+        name: "insert ctrl-e copies char from line below",
+        initial_text: "abc\nxyz\n",
+        keys: "li<C-e><Esc>",
+    },
+    // Each copy advances the cursor, so presses walk along the other line
+    // and stop inserting once it runs out.
+    OracleCase {
+        name: "repeated ctrl-e walks along the line below",
+        initial_text: "ab\nwxyz\n",
+        keys: "A<C-e><C-e><C-e><Esc>",
+    },
+    // No line to copy from, or a line that ends before the column: Vim
+    // beeps and stays in insert mode.
+    OracleCase {
+        name: "ctrl-y on the first line inserts nothing",
+        initial_text: "abc\n",
+        keys: "li<C-y>Q<Esc>",
+    },
+    OracleCase {
+        name: "ctrl-e on the last line inserts nothing",
+        initial_text: "abc\nxyz\n",
+        keys: "jli<C-e>Q<Esc>",
+    },
+    OracleCase {
+        name: "ctrl-e past the end of a shorter line inserts nothing",
+        initial_text: "abcdef\nxy\n",
+        keys: "4li<C-e>Q<Esc>",
+    },
+    // Columns are screen columns: a wide character counts for two, and a
+    // character that spans the cursor column is copied whole.
+    OracleCase {
+        name: "ctrl-y matches wide characters by screen column",
+        initial_text: "日本\nabcd\n",
+        keys: "jlli<C-y><Esc>",
+    },
+    OracleCase {
+        name: "ctrl-e from a wide character copies the char in its column",
+        initial_text: "日本\nabcd\n",
+        keys: "li<C-e><Esc>",
+    },
+    OracleCase {
+        name: "ctrl-e inside a wide character copies the spanning char",
+        initial_text: "abcd\n日本\n",
+        keys: "3li<C-e><Esc>",
+    },
+    // Copied like a literal: no auto pair for a paren.
+    OracleCase {
+        name: "ctrl-e copies an open paren without auto pairing",
+        initial_text: "x\n(\n",
+        keys: "i<C-e><Esc>",
+    },
+    OracleCase {
+        name: "undo removes ctrl-y copies with the session",
+        initial_text: "abc\nxyz\n",
+        keys: "ji<C-y><C-y><Esc>u",
+    },
+    OracleCase {
+        name: "counted insert repeats the copied character",
+        initial_text: "ab\ncd\n",
+        keys: "3i<C-e><Esc>",
+    },
+    // Vim's redo buffer holds the copied character, not the key, so `.`
+    // re-inserts the same text instead of copying from the new neighbour.
+    OracleCase {
+        name: "dot repeat re-inserts the copied character not the key",
+        initial_text: "ab\ncd\nef\n",
+        keys: "i<C-e><Esc>j.",
+    },
 ];


### PR DESCRIPTION
Adds the insert-mode Ctrl+e and Ctrl+y from Vim: insert the character sitting under the cursor's screen column on the line below or above. Matching is by screen column, so tabs and wide characters copy what you see, a character that spans the column is copied whole, and a press with nothing to copy does nothing. The character is inserted like a literal, so no auto pair fires.

Dot repeat follows Vim's redo buffer: it stores the copied character rather than the key, so `.` inserts the same text instead of copying from a new neighbour. With the completion popup open, Ctrl+y accepts the selected item and Ctrl+e closes the popup.

Thirteen oracle cases verified against real Neovim, plus regression tests for tab alignment (Nevi's tab width differs from Neovim's, so that part is checked natively), the popup keys, and the dot repeat edge. Also fixes the oracle harness comparing Neovim's byte column against Nevi's character column, which made any case ending after a multibyte character impossible to pass.