### PR TITLE
Add sign_column option (nvim signcolumn) and :set signcolumn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 ### Configuration
 
+- Added `sign_column` to `[editor]` with the same values as nvim's `signcolumn`. `auto` shows the two-cell git/diagnostic gutter only while the buffer has something to mark, so a plain file renders flush left like `nvim --clean`. `yes` (the default, unchanged behavior) always reserves it, and `no` hides it. `:set signcolumn=auto` switches it at runtime. Completion, hover, signature help, and code action popups now share the cursor's gutter math instead of their own, so they line up with the cursor whether the sign column or line numbers are on or off, and signature help and code actions now account for the pane's position in a split. (#330)
 - Fixed `[ruby]` in `languages.toml` being ignored. Ruby files (`.rb`, `.rake`, `.gemspec`, `.ru`, `.podspec`) resolved to their raw extension instead of the `ruby` key, so formatter and tab width settings never applied. The generated `languages.toml` template now includes a commented Ruby example. (#273)
 
 ## 0.3.0 - 2026-08-25

--- a/README.md
+++ b/README.md
@@ -272,6 +272,9 @@ A template config file is created automatically on first run. Here's an example:
 tab_width = 2
 format_on_save = true
 relative_numbers = true
+# Git/diagnostic gutter: "auto" (only while a sign exists, like nvim), "yes", "no".
+# `:set signcolumn=auto` switches it at runtime.
+sign_column = "yes"
 scroll_off = 8
 # Wheel scrolls the buffer, clicks move the cursor (like nvim's mouse=nvi).
 # Set to false to leave the mouse to the terminal; at runtime `:set nomouse`

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -82,6 +82,34 @@ impl UiStyle {
     }
 }
 
+/// Gutter sign column mode, the same three values as nvim's `signcolumn`.
+/// The column is two cells: git marker then diagnostic glyph.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SignColumn {
+    /// Only while the buffer has a git change or diagnostic to mark. Text
+    /// shifts right by two cells when the first sign appears (nvim default).
+    Auto,
+    /// Always reserved, so text never shifts. Nevi's default because git
+    /// signs and LSP are built in and nearly every edited file gets a sign.
+    #[default]
+    Yes,
+    /// Never drawn; git and diagnostic markers are not shown in the gutter.
+    No,
+}
+
+impl SignColumn {
+    /// Parse a `:set signcolumn=<value>` argument.
+    pub fn parse(value: &str) -> Option<Self> {
+        match value {
+            "auto" => Some(Self::Auto),
+            "yes" => Some(Self::Yes),
+            "no" => Some(Self::No),
+            _ => None,
+        }
+    }
+}
+
 /// Autosave mode configuration
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -110,6 +138,8 @@ pub struct EditorSettings {
     pub line_numbers: bool,
     /// Show relative line numbers (default: false)
     pub relative_numbers: bool,
+    /// Gutter sign column: "auto", "yes", or "no" (default: yes)
+    pub sign_column: SignColumn,
     /// Highlight current line (default: false)
     pub cursor_line: bool,
     /// Lines to keep visible above/below cursor (default: 0)
@@ -144,6 +174,7 @@ impl Default for EditorSettings {
             tab_width: 4,
             line_numbers: true,
             relative_numbers: false,
+            sign_column: SignColumn::Yes,
             cursor_line: false,
             scroll_off: 8, // Neovim-like default
             auto_indent: true,
@@ -1029,6 +1060,7 @@ fn default_config_template() -> &'static str {
 # tab_width = 4              # Spaces per tab
 # line_numbers = true        # Show line numbers
 # relative_numbers = false   # Show relative line numbers
+# sign_column = "yes"        # Git/diagnostic gutter: "auto" (only when a sign exists, like nvim), "yes", "no"
 # cursor_line = false        # Highlight current line
 # scroll_off = 8             # Lines to keep visible above/below cursor
 # auto_indent = true         # Smart indentation on new lines
@@ -1776,6 +1808,25 @@ mod tests {
         assert!(!s.editor.mouse);
         let s: Settings = toml::from_str("").expect("parse empty");
         assert!(s.editor.mouse);
+    }
+
+    #[test]
+    fn sign_column_defaults_to_yes_and_parses_all_modes() {
+        assert_eq!(EditorSettings::default().sign_column, SignColumn::Yes);
+        let s: Settings = toml::from_str("").expect("parse empty");
+        assert_eq!(s.editor.sign_column, SignColumn::Yes);
+        for (text, expected) in [
+            ("auto", SignColumn::Auto),
+            ("yes", SignColumn::Yes),
+            ("no", SignColumn::No),
+        ] {
+            let toml_text = format!("[editor]\nsign_column = \"{text}\"\n");
+            let s: Settings = toml::from_str(&toml_text).expect("parse sign_column");
+            assert_eq!(s.editor.sign_column, expected, "{text}");
+            assert_eq!(SignColumn::parse(text), Some(expected));
+        }
+        assert!(toml::from_str::<Settings>("[editor]\nsign_column = \"maybe\"\n").is_err());
+        assert_eq!(SignColumn::parse("maybe"), None);
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -1010,6 +1010,10 @@ struct GitStatusScan {
     scan_duration: Duration,
 }
 
+/// Sign column width in cells when shown: one for the git marker, one for
+/// the diagnostic glyph. See `Editor::sign_column_width`.
+const SIGN_COLUMN_WIDTH: usize = 2;
+
 pub struct Editor {
     /// All open buffers
     buffers: Vec<Buffer>,
@@ -4652,24 +4656,61 @@ impl Editor {
         self.pane_text_area_width(self.active_pane)
     }
 
-    /// Text area width for an arbitrary pane (its rect minus sign column,
-    /// line numbers, and separator).
+    /// Text area width for an arbitrary pane (its rect minus the gutter).
     fn pane_text_area_width(&self, pane_idx: usize) -> usize {
-        let (pane_width, buffer) = if pane_idx < self.panes.len() {
+        let (pane_width, buffer_idx) = if pane_idx < self.panes.len() {
             (
                 self.panes[pane_idx].rect.width as usize,
-                &self.buffers[self.panes[pane_idx].buffer_idx],
+                self.panes[pane_idx].buffer_idx,
             )
         } else {
-            (self.term_width as usize, self.buffer())
+            (self.term_width as usize, self.current_buffer_idx)
         };
-        const SIGN_COLUMN_WIDTH: usize = 2;
-        let line_num_width = buffer.addressable_line_count().to_string().len().max(3);
-        if self.settings.editor.line_numbers {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH + line_num_width + 1)
-        } else {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH)
+        pane_width.saturating_sub(self.gutter_width(buffer_idx))
+    }
+
+    /// Cells the sign column takes for `buffer_idx`: 2 (git marker, then
+    /// diagnostic glyph) or 0, per `[editor] sign_column`. Mirrors nvim's
+    /// `signcolumn`: `yes` always reserves it so text never shifts, `no`
+    /// never draws it, `auto` shows it only while the buffer has a sign.
+    /// Decided per buffer, not per pane, so a split never changes it.
+    pub fn sign_column_width(&self, buffer_idx: usize) -> usize {
+        use crate::config::SignColumn;
+        match self.settings.editor.sign_column {
+            SignColumn::Yes => SIGN_COLUMN_WIDTH,
+            SignColumn::No => 0,
+            SignColumn::Auto if self.buffer_has_signs(buffer_idx) => SIGN_COLUMN_WIDTH,
+            SignColumn::Auto => 0,
         }
+    }
+
+    fn buffer_has_signs(&self, buffer_idx: usize) -> bool {
+        let Some(path) = self.buffers.get(buffer_idx).and_then(|b| b.path.as_ref()) else {
+            return false;
+        };
+        let has_git_hunk = self
+            .git_diffs
+            .get(&path.to_string_lossy().to_string())
+            .is_some_and(|diff| !diff.hunks.is_empty());
+        has_git_hunk
+            || self
+                .diagnostics
+                .get(&crate::lsp::path_to_uri(path))
+                .is_some_and(|diags| !diags.is_empty())
+    }
+
+    /// Pane-relative column where buffer text starts: the sign column plus,
+    /// when line numbers are on, the number width and its separator space.
+    /// Every gutter/text boundary (render fill, cursor placement, popup
+    /// anchors, mouse hit-testing) must go through this so they agree.
+    pub fn gutter_width(&self, buffer_idx: usize) -> usize {
+        let mut width = self.sign_column_width(buffer_idx);
+        if self.settings.editor.line_numbers {
+            if let Some(buffer) = self.buffers.get(buffer_idx) {
+                width += buffer.addressable_line_count().to_string().len().max(3) + 1;
+            }
+        }
+        width
     }
 
     fn effective_wrap_width(&self) -> usize {
@@ -12895,6 +12936,62 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sign_column_width_follows_setting_and_buffer_signs() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.replace_buffer_content("123\n");
+        let path = PathBuf::from("/nevi-tests/sign-column.rs");
+        editor.buffer_mut().path = Some(path.clone());
+
+        // yes: reserved even with nothing to show (today's behavior, the default)
+        assert_eq!(editor.sign_column_width(0), 2);
+        assert_eq!(editor.gutter_width(0), 2 + 3 + 1);
+
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        assert_eq!(editor.sign_column_width(0), 0, "auto with no signs");
+        editor.settings.editor.line_numbers = false;
+        assert_eq!(editor.gutter_width(0), 0, "issue #330: text flush left");
+        assert_eq!(editor.pane_text_area_width(0), 80);
+
+        editor.set_git_diff(
+            path.to_string_lossy().to_string(),
+            crate::git::GitDiff {
+                hunks: vec![crate::git::GitHunk {
+                    line: 0,
+                    status: crate::git::GitLineStatus::Modified,
+                }],
+            },
+        );
+        assert_eq!(editor.sign_column_width(0), 2, "auto with a git hunk");
+        assert_eq!(editor.pane_text_area_width(0), 78);
+
+        editor.set_git_diff(path.to_string_lossy().to_string(), Default::default());
+        assert_eq!(editor.sign_column_width(0), 0, "auto after hunks clear");
+        editor.set_diagnostics(
+            crate::lsp::path_to_uri(&path),
+            vec![crate::lsp::Diagnostic {
+                line: 0,
+                end_line: 0,
+                col_start: 0,
+                col_end: 1,
+                severity: crate::lsp::DiagnosticSeverity::Warning,
+                message: "w".to_string(),
+                source: None,
+                code: None,
+            }],
+        );
+        assert_eq!(editor.sign_column_width(0), 2, "auto with a diagnostic");
+
+        editor.settings.editor.sign_column = SignColumn::No;
+        assert_eq!(
+            editor.sign_column_width(0),
+            0,
+            "no hides it even with signs"
+        );
     }
 
     #[test]

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -2594,9 +2594,10 @@ impl Editor {
 
     /// Update diagnostics for a file URI
     pub fn set_diagnostics(&mut self, uri: String, diags: Vec<Diagnostic>) {
-        let diags = if let Some(buffer) = self.buffers.iter().find(|buffer| {
+        let buffer_idx = self.buffers.iter().position(|buffer| {
             buffer.path.as_ref().map(crate::lsp::path_to_uri).as_deref() == Some(uri.as_str())
-        }) {
+        });
+        let diags = if let Some(buffer) = buffer_idx.and_then(|idx| self.buffers.get(idx)) {
             diags
                 .into_iter()
                 .map(|diag| Self::diagnostic_lsp_to_buffer_cols(buffer, diag))
@@ -2605,16 +2606,42 @@ impl Editor {
             diags
         };
 
-        for row in self.diagnostic_render_rows_for_uri(
-            &uri,
-            self.diagnostics.get(&uri).map(Vec::as_slice),
-            &diags,
-        ) {
-            self.render_damage.mark_editor_row(row);
-        }
+        self.with_sign_column_repaint(buffer_idx, |editor| {
+            for row in editor.diagnostic_render_rows_for_uri(
+                &uri,
+                editor.diagnostics.get(&uri).map(Vec::as_slice),
+                &diags,
+            ) {
+                editor.render_damage.mark_editor_row(row);
+            }
 
-        self.diagnostics.insert(uri, diags);
-        self.rebuild_diag_rollup();
+            editor.diagnostics.insert(uri, diags);
+            editor.rebuild_diag_rollup();
+        });
+    }
+
+    /// Run `update`, then force a full repaint if it changed the sign column
+    /// width of `buffer_idx`. Only `sign_column = "auto"` can change it, and
+    /// when it does every row moves, not just the rows the update marked.
+    fn with_sign_column_repaint(
+        &mut self,
+        buffer_idx: Option<usize>,
+        update: impl FnOnce(&mut Self),
+    ) {
+        let before = buffer_idx.map(|idx| self.sign_column_width(idx));
+        update(self);
+        if buffer_idx.is_some_and(|idx| Some(self.sign_column_width(idx)) != before) {
+            self.sign_column_width_changed();
+        }
+    }
+
+    /// The gutter just grew or shrank for a whole buffer. Every row moves, so
+    /// the frame needs a full repaint, and the scroll offsets were computed
+    /// against the old text width, so a cursor on the last visible column
+    /// (or last wrapped row) would otherwise be drawn outside the pane.
+    pub fn sign_column_width_changed(&mut self) {
+        self.render_damage.mark_full();
+        self.scroll_to_cursor();
     }
 
     /// Rebuild the per-path diagnostic rollup used by the explorer's folder
@@ -3081,7 +3108,19 @@ impl Editor {
 
     /// Set git diff for a file path
     pub fn set_git_diff(&mut self, path: String, diff: crate::git::GitDiff) {
-        self.git_diffs.insert(path, diff);
+        let buffer_idx = self.buffer_idx_for_git_path(&path);
+        self.with_sign_column_repaint(buffer_idx, |editor| {
+            editor.git_diffs.insert(path, diff);
+        });
+    }
+
+    fn buffer_idx_for_git_path(&self, path: &str) -> Option<usize> {
+        self.buffers.iter().position(|buffer| {
+            buffer
+                .path
+                .as_ref()
+                .is_some_and(|p| p.to_string_lossy().as_ref() == path)
+        })
     }
 
     /// Get git status for a specific line in the current buffer
@@ -3117,7 +3156,11 @@ impl Editor {
             self.set_git_diff(path, diff);
         } else if let Some(path) = self.buffer().path.as_ref() {
             // File not tracked by git or new file - clear any existing diff
-            self.git_diffs.remove(&path.to_string_lossy().to_string());
+            let key = path.to_string_lossy().to_string();
+            let buffer_idx = Some(self.current_buffer_idx);
+            self.with_sign_column_repaint(buffer_idx, |editor| {
+                editor.git_diffs.remove(&key);
+            });
         }
     }
 
@@ -3134,7 +3177,17 @@ impl Editor {
                 git_diffs.insert(path, diff);
             }
         }
+        // Under sign_column = auto a buffer gaining or losing its last hunk
+        // moves its whole gutter; callers of this refresh don't always repaint.
+        let widths_before: Vec<usize> = (0..self.buffers.len())
+            .map(|idx| self.sign_column_width(idx))
+            .collect();
         self.git_diffs = git_diffs;
+        let changed =
+            (0..self.buffers.len()).any(|idx| self.sign_column_width(idx) != widths_before[idx]);
+        if changed {
+            self.sign_column_width_changed();
+        }
     }
 
     fn git_diff_for_buffer(
@@ -12991,6 +13044,115 @@ mod tests {
             editor.sign_column_width(0),
             0,
             "no hides it even with signs"
+        );
+    }
+
+    /// Diagnostics normally dirty only their own rows. Under `auto` the first
+    /// or last sign changes the gutter width, which moves every row, so that
+    /// update has to repaint the whole frame (otherwise a partial render
+    /// would shift the touched rows and leave the rest behind).
+    #[test]
+    fn auto_sign_column_width_change_forces_full_repaint() {
+        use crate::config::SignColumn;
+        use crate::git::{GitDiff, GitHunk, GitLineStatus};
+        let mut editor = Editor::default();
+        editor.set_size(80, 12);
+        editor.replace_buffer_content("123\n456\n");
+        let path = PathBuf::from("/nevi-tests/sign-column-repaint.rs");
+        editor.buffer_mut().path = Some(path.clone());
+        let uri = crate::lsp::path_to_uri(&path);
+        let diag = |line: usize| crate::lsp::Diagnostic {
+            line,
+            end_line: line,
+            col_start: 0,
+            col_end: 1,
+            severity: crate::lsp::DiagnosticSeverity::Warning,
+            message: "w".to_string(),
+            source: None,
+            code: None,
+        };
+
+        // Default `yes`: width is fixed, so only the diagnostic's row is dirty.
+        editor.render_damage.clear_after_full_render();
+        editor.set_diagnostics(uri.clone(), vec![diag(0)]);
+        assert!(!editor.render_damage.requires_full_render());
+        assert_eq!(editor.render_damage.dirty_editor_rows(), vec![0]);
+        editor.set_diagnostics(uri.clone(), vec![]);
+
+        editor.settings.editor.sign_column = SignColumn::Auto;
+
+        editor.render_damage.clear_after_full_render();
+        editor.set_diagnostics(uri.clone(), vec![diag(0)]);
+        assert!(editor.render_damage.requires_full_render(), "0 -> 2 cells");
+
+        editor.render_damage.clear_after_full_render();
+        editor.set_diagnostics(uri.clone(), vec![diag(0), diag(1)]);
+        assert!(
+            !editor.render_damage.requires_full_render(),
+            "width unchanged"
+        );
+        assert_eq!(editor.render_damage.dirty_editor_rows(), vec![0, 1]);
+
+        editor.render_damage.clear_after_full_render();
+        editor.set_diagnostics(uri, vec![]);
+        assert!(editor.render_damage.requires_full_render(), "2 -> 0 cells");
+
+        let key = path.to_string_lossy().to_string();
+        editor.render_damage.clear_after_full_render();
+        editor.set_git_diff(
+            key.clone(),
+            GitDiff {
+                hunks: vec![GitHunk {
+                    line: 1,
+                    status: GitLineStatus::Added,
+                }],
+            },
+        );
+        assert!(editor.render_damage.requires_full_render(), "git 0 -> 2");
+        editor.render_damage.clear_after_full_render();
+        editor.set_git_diff(key, GitDiff::default());
+        assert!(editor.render_damage.requires_full_render(), "git 2 -> 0");
+    }
+
+    /// Same as the `:set` case, but the width flips because a diagnostic
+    /// arrived, with no keypress to trigger a rescroll.
+    #[test]
+    fn auto_sign_column_change_keeps_cursor_in_view() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.update_pane_rects();
+        editor.settings.editor.line_numbers = false;
+        editor.settings.editor.scroll_off = 0;
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        editor.replace_buffer_content(&format!("{}\n", "x".repeat(60)));
+        let path = PathBuf::from("/nevi-tests/sign-column-scroll.rs");
+        editor.buffer_mut().path = Some(path.clone());
+        editor.cursor.col = 40;
+        editor.scroll_to_cursor();
+        assert_eq!(editor.h_offset, 11);
+
+        editor.set_diagnostics(
+            crate::lsp::path_to_uri(&path),
+            vec![crate::lsp::Diagnostic {
+                line: 0,
+                end_line: 0,
+                col_start: 0,
+                col_end: 1,
+                severity: crate::lsp::DiagnosticSeverity::Error,
+                message: "e".to_string(),
+                source: None,
+                code: None,
+            }],
+        );
+
+        assert_eq!(
+            editor.h_offset, 13,
+            "gutter appeared: text area is 28 wide now"
+        );
+        assert_eq!(
+            editor.panes[editor.active_pane].h_offset, 13,
+            "pane mirror synced"
         );
     }
 

--- a/src/mouse.rs
+++ b/src/mouse.rs
@@ -233,6 +233,35 @@ mod tests {
     }
 
     #[test]
+    fn click_maps_columns_without_a_sign_column() {
+        use crate::config::SignColumn;
+        let mut editor = single_pane_editor(120, 40);
+        editor.settings.editor.line_numbers = false;
+        // No path, so no signs: under auto the gutter is 0 cells wide.
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        let x = editor.panes()[0].rect.x;
+
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), x + 2, 0),
+        );
+        assert_eq!(
+            editor.cursor.col, 2,
+            "no gutter: screen col 2 is buffer col 2"
+        );
+
+        editor.settings.editor.sign_column = SignColumn::Yes;
+        handle_mouse_event(
+            &mut editor,
+            mouse(MouseEventKind::Down(MouseButton::Left), x + 2, 0),
+        );
+        assert_eq!(
+            editor.cursor.col, 0,
+            "2-cell gutter: same cell is the first character"
+        );
+    }
+
+    #[test]
     fn click_beyond_eol_clamps_to_line_end() {
         let mut editor = editor_with_lines(100);
         let gutter = gutter_width(&editor, 0);

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -10579,6 +10579,7 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
                 match value.as_deref().and_then(crate::config::SignColumn::parse) {
                     Some(mode) => {
                         editor.settings.editor.sign_column = mode;
+                        editor.sign_column_width_changed();
                         CommandResult::Ok
                     }
                     None => {
@@ -11732,6 +11733,168 @@ mod tests {
             row.starts_with(&format!(" {error_glyph}  1 123 ")),
             "yes with line numbers: sign cells, number, separator, text; row={row:?}"
         );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    /// Row and column of the last `CSI row;col H` in the stream, which is
+    /// where `position_cursor` leaves the terminal cursor.
+    fn final_cursor_cell(rendered: &str) -> (usize, usize) {
+        let mut last = (0, 0);
+        for (start, _) in rendered.match_indices("\x1b[") {
+            let body = &rendered[start + 2..];
+            let Some(end) = body.find(|c: char| ('@'..='~').contains(&c)) else {
+                continue;
+            };
+            if &body[end..end + 1] == "H" {
+                let mut parts = body[..end]
+                    .split(';')
+                    .map(|n| n.parse::<usize>().unwrap_or(1));
+                last = (
+                    parts.next().unwrap_or(1).saturating_sub(1),
+                    parts.next().unwrap_or(1).saturating_sub(1),
+                );
+            }
+        }
+        last
+    }
+
+    #[test]
+    fn cursor_cell_follows_the_sign_column_width() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.settings.editor.line_numbers = false;
+        editor.replace_buffer_content("123\n");
+        editor.cursor.col = 1;
+
+        assert_eq!(final_cursor_cell(&render_editor_to_string(&editor)), (0, 3));
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        assert_eq!(final_cursor_cell(&render_editor_to_string(&editor)), (0, 1));
+        editor.settings.editor.line_numbers = true;
+        assert_eq!(
+            final_cursor_cell(&render_editor_to_string(&editor)),
+            (0, 3 + 1 + 1)
+        );
+    }
+
+    /// Enabling the gutter shrinks the text area by two cells. The scroll
+    /// offsets were computed against the old width, so without a rescroll a
+    /// cursor on the last visible column is drawn outside the pane.
+    #[test]
+    fn set_signcolumn_rescrolls_so_the_cursor_stays_inside_the_pane() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.update_pane_rects();
+        editor.settings.editor.line_numbers = false;
+        editor.settings.editor.scroll_off = 0;
+        editor.settings.editor.sign_column = SignColumn::No;
+        editor.replace_buffer_content(&format!("{}\n", "x".repeat(60)));
+        editor.cursor.col = 40;
+        editor.scroll_to_cursor();
+        assert_eq!(
+            editor.h_offset, 11,
+            "40 - 30 + 1: cursor on the last of 30 columns"
+        );
+        assert_eq!(
+            final_cursor_cell(&render_editor_to_string(&editor)),
+            (0, 29)
+        );
+
+        execute_command(
+            &mut editor,
+            Command::Set("signcolumn".to_string(), Some("yes".to_string())),
+        );
+
+        assert_eq!(
+            editor.h_offset, 13,
+            "rescrolled for the 28-column text area"
+        );
+        assert_eq!(
+            final_cursor_cell(&render_editor_to_string(&editor)),
+            (0, 29)
+        );
+    }
+
+    #[test]
+    fn set_signcolumn_rescrolls_wrapped_view_after_reflow() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(20, 6); // 4 text rows
+        editor.update_pane_rects();
+        editor.settings.editor.line_numbers = false;
+        editor.settings.editor.scroll_off = 0;
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 9999;
+        editor.settings.editor.sign_column = SignColumn::No;
+        // Line 0 takes 3 rows at width 20 and 4 rows at width 18.
+        editor.replace_buffer_content(&format!("{}\nsecond\n", "a".repeat(56)));
+        editor.cursor.line = 1;
+        editor.scroll_to_cursor();
+        assert_eq!(editor.viewport_offset, 0);
+        assert_eq!(final_cursor_cell(&render_editor_to_string(&editor)), (3, 0));
+
+        execute_command(
+            &mut editor,
+            Command::Set("signcolumn".to_string(), Some("yes".to_string())),
+        );
+
+        let (row, col) = final_cursor_cell(&render_editor_to_string(&editor));
+        assert!(row < 4, "cursor row {row} must stay inside the 4 text rows");
+        assert_eq!(col, 2, "text starts after the 2-cell gutter");
+        assert_eq!(
+            editor.viewport_offset, 1,
+            "view scrolled so line 1 is visible"
+        );
+    }
+
+    #[test]
+    fn gutter_git_markers_render_in_the_first_sign_cell() {
+        use crate::git::{GitDiff, GitHunk, GitLineStatus};
+        let tmp = std::env::temp_dir().join(format!("nevi_git_gutter_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("g.rs");
+        std::fs::write(&path, "one\ntwo\nthree\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.settings.editor.line_numbers = false;
+        editor.open_file(path).expect("open file");
+        let key = editor
+            .buffer()
+            .path
+            .as_ref()
+            .expect("path")
+            .to_string_lossy()
+            .to_string();
+        editor.set_git_diff(
+            key,
+            GitDiff {
+                hunks: vec![
+                    GitHunk {
+                        line: 0,
+                        status: GitLineStatus::Added,
+                    },
+                    GitHunk {
+                        line: 1,
+                        status: GitLineStatus::Modified,
+                    },
+                    GitHunk {
+                        line: 2,
+                        status: GitLineStatus::Deleted,
+                    },
+                ],
+            },
+        );
+
+        let rendered = render_editor_to_string(&editor);
+        assert_eq!(screen_row_text(&rendered, 0), "▎ one");
+        assert_eq!(screen_row_text(&rendered, 1), "▎ two");
+        assert_eq!(screen_row_text(&rendered, 2), "▁ three");
+
+        editor.settings.editor.sign_column = crate::config::SignColumn::No;
+        assert_eq!(screen_row_text(&render_editor_to_string(&editor), 0), "one");
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1473,12 +1473,7 @@ impl Terminal {
         let highlight_cursor_line = editor.settings.editor.cursor_line;
         let pane_width = pane.rect.width as usize;
 
-        const SIGN_COLUMN_WIDTH: usize = 2;
-        let text_area_width = if show_line_numbers {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH + line_num_width + 1)
-        } else {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH)
-        };
+        let text_area_width = pane_width.saturating_sub(editor.gutter_width(pane.buffer_idx));
 
         for screen_row in rows {
             let pane_row = screen_row.saturating_sub(pane.rect.y as usize);
@@ -1787,15 +1782,8 @@ impl Terminal {
         let pane_height = rect.height as usize;
         let pane_width = rect.width as usize;
 
-        // Sign column width (for diagnostic icons)
-        const SIGN_COLUMN_WIDTH: usize = 2;
-
-        // Calculate effective text width (excluding sign column and line numbers)
-        let text_area_width = if show_line_numbers {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH + line_num_width + 1)
-        } else {
-            pane_width.saturating_sub(SIGN_COLUMN_WIDTH)
-        };
+        // Text width after the gutter (sign column + line numbers)
+        let text_area_width = pane_width.saturating_sub(editor.gutter_width(pane.buffer_idx));
 
         // Calculate wrap width: use configured wrap_width or text_area_width, whichever is smaller
         let effective_wrap_width = if wrap_enabled {
@@ -1845,6 +1833,56 @@ impl Terminal {
         Ok(())
     }
 
+    /// Paint one row's two sign cells: the git marker, then the highest
+    /// severity diagnostic glyph (error > warning > info > hint). Callers
+    /// skip this entirely when `Editor::sign_column_width` is 0.
+    fn render_sign_cells(
+        &mut self,
+        editor: &Editor,
+        theme: &crate::theme::Theme,
+        git_status: Option<crate::git::GitLineStatus>,
+        (has_error, has_warning, has_info, has_hint): (bool, bool, bool, bool),
+        editor_fg: Color,
+        row_bg: Color,
+    ) -> anyhow::Result<()> {
+        use crate::git::GitLineStatus;
+        let git_cell = match git_status {
+            Some(GitLineStatus::Added) => Some((theme.git.added, "▎")),
+            Some(GitLineStatus::Modified) => Some((theme.git.modified, "▎")),
+            Some(GitLineStatus::Deleted) => Some((theme.git.deleted, "▁")),
+            None => None,
+        };
+        let glyphs = editor.ui_glyphs();
+        let diag_cell = if has_error {
+            Some((theme.diagnostic.error, glyphs.gutter_error))
+        } else if has_warning {
+            Some((theme.diagnostic.warning, glyphs.gutter_warn))
+        } else if has_info {
+            Some((theme.diagnostic.info, glyphs.gutter_info))
+        } else if has_hint {
+            Some((theme.diagnostic.hint, glyphs.gutter_hint))
+        } else {
+            None
+        };
+        for cell in [git_cell, diag_cell] {
+            match cell {
+                Some((color, glyph)) => {
+                    execute!(self.stdout, SetForegroundColor(color))?;
+                    terminal_print!(self, "{}", glyph);
+                    execute!(
+                        self.stdout,
+                        SetForegroundColor(editor_fg),
+                        SetBackgroundColor(row_bg)
+                    )?;
+                }
+                None => {
+                    terminal_print!(self, " ");
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Render pane with soft wrap enabled
     #[allow(clippy::too_many_arguments)]
     fn render_pane_wrapped(
@@ -1866,6 +1904,8 @@ impl Terminal {
     ) -> anyhow::Result<()> {
         // Get theme colors once at the start
         let theme = editor.theme();
+        let gutter_width = editor.gutter_width(pane.buffer_idx);
+        let sign_column_width = editor.sign_column_width(pane.buffer_idx);
         let cursor_line_bg = theme.ui.cursor_line;
         let editor_bg = theme.ui.background;
         let editor_fg = theme.ui.foreground;
@@ -1954,87 +1994,26 @@ impl Terminal {
                     SetForegroundColor(editor_fg)
                 )?;
 
-                // Sign column (git signs + diagnostic icons) - only on first segment
-                // Layout: [Git Sign][Diagnostic] = 2 chars total
-                if segment.is_first {
-                    // Git sign (first char)
-                    let git_status = if is_active {
-                        buffer_path.and_then(|p| editor.git_status_for_line_in_file(p, file_line))
-                    } else {
-                        None
-                    };
-
-                    match git_status {
-                        Some(crate::git::GitLineStatus::Added) => {
-                            execute!(self.stdout, SetForegroundColor(theme.git.added))?;
-                            terminal_print!(self, "▎");
-                            execute!(
-                                self.stdout,
-                                SetForegroundColor(editor_fg),
-                                SetBackgroundColor(row_bg)
-                            )?;
-                        }
-                        Some(crate::git::GitLineStatus::Modified) => {
-                            execute!(self.stdout, SetForegroundColor(theme.git.modified))?;
-                            terminal_print!(self, "▎");
-                            execute!(
-                                self.stdout,
-                                SetForegroundColor(editor_fg),
-                                SetBackgroundColor(row_bg)
-                            )?;
-                        }
-                        Some(crate::git::GitLineStatus::Deleted) => {
-                            execute!(self.stdout, SetForegroundColor(theme.git.deleted))?;
-                            terminal_print!(self, "▁");
-                            execute!(
-                                self.stdout,
-                                SetForegroundColor(editor_fg),
-                                SetBackgroundColor(row_bg)
-                            )?;
-                        }
-                        None => {
-                            terminal_print!(self, " ");
-                        }
-                    }
-
-                    // Diagnostic sign (second char) - priority: error > warning > info > hint
-                    if has_error {
-                        execute!(self.stdout, SetForegroundColor(theme.diagnostic.error))?;
-                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_error);
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    } else if has_warning {
-                        execute!(self.stdout, SetForegroundColor(theme.diagnostic.warning))?;
-                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_warn);
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    } else if has_info {
-                        execute!(self.stdout, SetForegroundColor(theme.diagnostic.info))?;
-                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_info);
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    } else if has_hint {
-                        execute!(self.stdout, SetForegroundColor(theme.diagnostic.hint))?;
-                        terminal_print!(self, "{}", editor.ui_glyphs().gutter_hint);
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
+                // Sign column (git marker + diagnostic glyph), first segment only
+                if sign_column_width > 0 {
+                    if segment.is_first {
+                        let git_status = if is_active {
+                            buffer_path
+                                .and_then(|p| editor.git_status_for_line_in_file(p, file_line))
+                        } else {
+                            None
+                        };
+                        self.render_sign_cells(
+                            editor,
+                            theme,
+                            git_status,
+                            (has_error, has_warning, has_info, has_hint),
+                            editor_fg,
+                            row_bg,
                         )?;
                     } else {
-                        terminal_print!(self, " ");
+                        terminal_print!(self, "  "); // continuation rows keep the gutter blank
                     }
-                } else {
-                    terminal_print!(self, "  "); // Empty sign column for continuation lines
                 }
 
                 // Line number (only on first segment)
@@ -2103,13 +2082,7 @@ impl Terminal {
                     RenderLineTextScope::WrappedSegment,
                 )?;
 
-                // Fill remaining space (sign column = 2)
-                let mut chars_printed =
-                    2 + if show_line_numbers {
-                        line_num_width + 1
-                    } else {
-                        0
-                    } + rendered_cols;
+                let mut chars_printed = gutter_width + rendered_cols;
 
                 // Render inline diagnostic on first segment only
                 if segment.is_first && is_active {
@@ -2173,7 +2146,7 @@ impl Terminal {
                 SetForegroundColor(editor_fg)
             )?;
 
-            terminal_print!(self, "  "); // Empty sign column
+            terminal_print!(self, "{:w$}", "", w = sign_column_width); // empty sign column
 
             execute!(self.stdout, SetForegroundColor(Color::Blue))?;
             let eob = editor.ui_glyphs().eob;
@@ -2184,12 +2157,8 @@ impl Terminal {
             }
             execute!(self.stdout, SetForegroundColor(editor_fg))?;
 
-            // Fill remaining space (sign column = 2)
-            let chars_printed = 2 + if show_line_numbers {
-                line_num_width + 2
-            } else {
-                1
-            };
+            // Gutter plus the one-cell end-of-buffer glyph
+            let chars_printed = gutter_width + 1;
             for _ in chars_printed..pane_width {
                 terminal_print!(self, " ");
             }
@@ -2221,6 +2190,8 @@ impl Terminal {
     ) -> anyhow::Result<()> {
         // Get theme colors once
         let theme = editor.theme();
+        let gutter_width = editor.gutter_width(pane.buffer_idx);
+        let sign_column_width = editor.sign_column_width(pane.buffer_idx);
         let cursor_line_bg = theme.ui.cursor_line;
         let editor_bg = theme.ui.background;
         let editor_fg = theme.ui.foreground;
@@ -2280,84 +2251,21 @@ impl Terminal {
                     (e, w, i, h)
                 };
 
-                // Sign column (git signs + diagnostic icons)
-                // Layout: [Git Sign][Diagnostic] = 2 chars total
-
-                // Git sign (first char)
-                let git_status = if is_active {
-                    buffer_path.and_then(|p| editor.git_status_for_line_in_file(p, file_line))
-                } else {
-                    None
-                };
-
-                match git_status {
-                    Some(crate::git::GitLineStatus::Added) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.added))?;
-                        terminal_print!(self, "▎");
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    }
-                    Some(crate::git::GitLineStatus::Modified) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.modified))?;
-                        terminal_print!(self, "▎");
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    }
-                    Some(crate::git::GitLineStatus::Deleted) => {
-                        execute!(self.stdout, SetForegroundColor(theme.git.deleted))?;
-                        terminal_print!(self, "▁");
-                        execute!(
-                            self.stdout,
-                            SetForegroundColor(editor_fg),
-                            SetBackgroundColor(row_bg)
-                        )?;
-                    }
-                    None => {
-                        terminal_print!(self, " ");
-                    }
-                }
-
-                // Diagnostic sign (second char) - priority: error > warning > info > hint
-                if has_error {
-                    execute!(self.stdout, SetForegroundColor(theme.diagnostic.error))?;
-                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_error);
-                    execute!(
-                        self.stdout,
-                        SetForegroundColor(editor_fg),
-                        SetBackgroundColor(row_bg)
+                // Sign column (git marker + diagnostic glyph)
+                if sign_column_width > 0 {
+                    let git_status = if is_active {
+                        buffer_path.and_then(|p| editor.git_status_for_line_in_file(p, file_line))
+                    } else {
+                        None
+                    };
+                    self.render_sign_cells(
+                        editor,
+                        theme,
+                        git_status,
+                        (has_error, has_warning, has_info, has_hint),
+                        editor_fg,
+                        row_bg,
                     )?;
-                } else if has_warning {
-                    execute!(self.stdout, SetForegroundColor(theme.diagnostic.warning))?;
-                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_warn);
-                    execute!(
-                        self.stdout,
-                        SetForegroundColor(editor_fg),
-                        SetBackgroundColor(row_bg)
-                    )?;
-                } else if has_info {
-                    execute!(self.stdout, SetForegroundColor(theme.diagnostic.info))?;
-                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_info);
-                    execute!(
-                        self.stdout,
-                        SetForegroundColor(editor_fg),
-                        SetBackgroundColor(row_bg)
-                    )?;
-                } else if has_hint {
-                    execute!(self.stdout, SetForegroundColor(theme.diagnostic.hint))?;
-                    terminal_print!(self, "{}", editor.ui_glyphs().gutter_hint);
-                    execute!(
-                        self.stdout,
-                        SetForegroundColor(editor_fg),
-                        SetBackgroundColor(row_bg)
-                    )?;
-                } else {
-                    terminal_print!(self, " ");
                 }
 
                 // Line number (if enabled)
@@ -2434,13 +2342,7 @@ impl Terminal {
                         RenderLineTextScope::LogicalLine,
                     )?;
 
-                    // Track characters printed for fill calculation (sign column = 2)
-                    let mut chars_printed =
-                        2 + if show_line_numbers {
-                            line_num_width + 1
-                        } else {
-                            0
-                        } + rendered_cols;
+                    let mut chars_printed = gutter_width + rendered_cols;
 
                     // Render ghost text on cursor line when completion is active
                     if is_cursor_line
@@ -2592,7 +2494,7 @@ impl Terminal {
                 }
             } else {
                 // Empty line - sign column + line indicator
-                terminal_print!(self, "  "); // Empty sign column
+                terminal_print!(self, "{:w$}", "", w = sign_column_width); // empty sign column
 
                 execute!(self.stdout, SetForegroundColor(Color::Blue))?;
                 let eob = editor.ui_glyphs().eob;
@@ -2607,12 +2509,8 @@ impl Terminal {
                     SetBackgroundColor(row_bg)
                 )?;
 
-                // Fill remaining space (sign column = 2)
-                let chars_printed = 2 + if show_line_numbers {
-                    line_num_width + 2
-                } else {
-                    1
-                };
+                // Gutter plus the one-cell end-of-buffer glyph
+                let chars_printed = gutter_width + 1;
                 for _ in chars_printed..pane_width {
                     terminal_print!(self, " ");
                 }
@@ -3067,14 +2965,6 @@ impl Terminal {
 
     /// Position the cursor based on editor mode
     fn position_cursor(&mut self, editor: &Editor) -> anyhow::Result<()> {
-        let show_line_numbers = editor.settings.editor.line_numbers;
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
-
         match editor.mode {
             Mode::Command => {
                 // Cursor in command line
@@ -3160,6 +3050,7 @@ impl Terminal {
             _ => {
                 // Cursor in active pane's buffer
                 let active_pane = &editor.panes()[editor.active_pane_idx()];
+                let gutter_width = editor.gutter_width(active_pane.buffer_idx);
                 let wrap_enabled = editor.settings.editor.wrap;
                 let wrap_width = editor.settings.editor.wrap_width;
                 let tab_width = editor.get_effective_tab_width();
@@ -3167,12 +3058,8 @@ impl Terminal {
                 let (cursor_row, cursor_col) = if wrap_enabled {
                     // Calculate visual position with wrapping
                     let buffer = editor.buffer();
-                    // Account for sign column (2) + line numbers
-                    let text_area_width = if show_line_numbers {
-                        active_pane.rect.width as usize - 2 - line_num_width - 1
-                    } else {
-                        active_pane.rect.width as usize - 2
-                    };
+                    let text_area_width =
+                        (active_pane.rect.width as usize).saturating_sub(gutter_width);
                     let effective_wrap_width = wrap_width.min(text_area_width);
 
                     // Count visual rows from viewport_offset to cursor line
@@ -3260,12 +3147,7 @@ impl Terminal {
                         }
                     }
 
-                    // Sign column (2) + line numbers + cursor position
-                    let col = 2 + if show_line_numbers {
-                        line_num_width + 1 + cursor_visual_col
-                    } else {
-                        cursor_visual_col
-                    };
+                    let col = gutter_width + cursor_visual_col;
 
                     (cursor_visual_row, col)
                 } else {
@@ -3287,11 +3169,7 @@ impl Terminal {
                             )
                         })
                         .unwrap_or(0);
-                    let cursor_col = 2 + if show_line_numbers {
-                        line_num_width + 1 + display_col
-                    } else {
-                        display_col
-                    };
+                    let cursor_col = gutter_width + display_col;
                     (cursor_row, cursor_col)
                 };
 
@@ -3751,13 +3629,8 @@ impl Terminal {
         let pane_x = active_pane.rect.x;
         let pane_y = active_pane.rect.y;
 
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
-        let cursor_in_pane_col = (line_num_width + 1 + completion.trigger_col) as u16;
+        let cursor_in_pane_col =
+            (editor.gutter_width(active_pane.buffer_idx) + completion.trigger_col) as u16;
         let cursor_in_pane_row = (editor
             .cursor
             .line
@@ -4214,13 +4087,8 @@ impl Terminal {
         let pane_x = active_pane.rect.x;
         let pane_y = active_pane.rect.y;
 
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
-        let cursor_in_pane_col = (line_num_width + 1 + editor.cursor.col) as u16;
+        let cursor_in_pane_col =
+            (editor.gutter_width(active_pane.buffer_idx) + editor.cursor.col) as u16;
         let cursor_in_pane_row = (editor.cursor.line - editor.viewport_offset) as u16;
 
         // Convert to screen coordinates
@@ -4455,15 +4323,11 @@ impl Terminal {
         let active_idx = help.active_signature.min(help.signatures.len() - 1);
         let signature = &help.signatures[active_idx];
 
-        // Calculate popup position (above cursor)
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
-        let cursor_screen_col = (line_num_width + 1 + editor.cursor.col) as u16;
-        let cursor_screen_row = (editor.cursor.line - editor.viewport_offset) as u16;
+        // Anchor to the cursor's screen cell (pane offset + gutter + column)
+        let cursor_screen_col = Self::text_area_x(editor) + editor.cursor.col as u16;
+        let active_pane = &editor.panes()[editor.active_pane_idx()];
+        let cursor_screen_row =
+            active_pane.rect.y + editor.cursor.line.saturating_sub(editor.viewport_offset) as u16;
 
         // Calculate dimensions based on signature
         let popup_width = (signature.label.chars().count() + 4).min(80).max(30) as u16;
@@ -4590,20 +4454,21 @@ impl Terminal {
         Ok(())
     }
 
-    fn diagnostic_float_text_area_x(editor: &Editor) -> u16 {
+    /// Screen column where the active pane's text starts (pane x + gutter).
+    /// Popups anchored to the cursor must build on this, not on their own
+    /// gutter math, so they stay aligned when the sign column or line
+    /// numbers are toggled.
+    fn text_area_x(editor: &Editor) -> u16 {
         let active_pane = &editor.panes()[editor.active_pane_idx()];
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3) as u16;
-        active_pane.rect.x.saturating_add(2 + line_num_width + 1)
+        active_pane
+            .rect
+            .x
+            .saturating_add(editor.gutter_width(active_pane.buffer_idx) as u16)
     }
 
     fn diagnostic_float_width(editor: &Editor, max_line_width: usize) -> u16 {
         let active_pane = &editor.panes()[editor.active_pane_idx()];
-        let text_area_x = Self::diagnostic_float_text_area_x(editor);
+        let text_area_x = Self::text_area_x(editor);
         let pane_right = active_pane.rect.x.saturating_add(active_pane.rect.width);
         let max_width = pane_right
             .saturating_sub(text_area_x)
@@ -4642,7 +4507,7 @@ impl Terminal {
             )
         };
 
-        let text_area_x = Self::diagnostic_float_text_area_x(editor);
+        let text_area_x = Self::text_area_x(editor);
         let cursor_col = editor.cursor.col.saturating_sub(active_pane.h_offset) as u16;
         let cursor_screen_col = text_area_x.saturating_add(cursor_col);
         let pane_right = active_pane.rect.x.saturating_add(active_pane.rect.width);
@@ -5185,14 +5050,10 @@ impl Terminal {
         let popup_height = (picker.items.len() as u16 + 2).min(max_height);
 
         // Position near cursor
-        let line_num_width = editor
-            .buffer()
-            .addressable_line_count()
-            .to_string()
-            .len()
-            .max(3);
-        let cursor_screen_col = (2 + line_num_width + 1 + editor.cursor.col) as u16;
-        let cursor_screen_row = (editor.cursor.line - editor.viewport_offset) as u16;
+        let cursor_screen_col = Self::text_area_x(editor) + editor.cursor.col as u16;
+        let active_pane = &editor.panes()[editor.active_pane_idx()];
+        let cursor_screen_row =
+            active_pane.rect.y + editor.cursor.line.saturating_sub(editor.viewport_offset) as u16;
 
         let popup_x = cursor_screen_col.min(editor.term_width.saturating_sub(popup_width + 2));
         let popup_y = if cursor_screen_row + popup_height + 1 < editor.term_height {
@@ -10712,6 +10573,19 @@ fn execute_command(editor: &mut Editor, cmd: Command) {
                 editor.settings.editor.mouse = false;
                 CommandResult::Ok
             }
+            // nvim's `:set signcolumn=auto|yes|no` (`scl` is its short name);
+            // the persistent form is `[editor] sign_column` in config.toml.
+            "signcolumn" | "scl" => {
+                match value.as_deref().and_then(crate::config::SignColumn::parse) {
+                    Some(mode) => {
+                        editor.settings.editor.sign_column = mode;
+                        CommandResult::Ok
+                    }
+                    None => {
+                        CommandResult::Error("signcolumn: expected auto, yes, or no".to_string())
+                    }
+                }
+            }
             _ => CommandResult::Error(format!("Unknown option: {}", option)),
         },
 
@@ -11752,6 +11626,183 @@ mod tests {
             rendered.contains('~'),
             "minimal mode keeps end-of-buffer tildes; output={rendered:?}"
         );
+    }
+
+    /// Text painted on one screen row, decoded from the ANSI stream: only
+    /// `CSI row;col H` moves are honored, every other escape is dropped.
+    fn screen_row_text(rendered: &str, row: usize) -> String {
+        let chars: Vec<char> = rendered.chars().collect();
+        let mut cells: Vec<char> = Vec::new();
+        let (mut cur_row, mut cur_col) = (0usize, 0usize);
+        let mut i = 0;
+        while i < chars.len() {
+            if chars[i] == '\x1b' {
+                match chars.get(i + 1) {
+                    Some('[') => {
+                        let start = i + 2;
+                        let mut j = start;
+                        while j < chars.len() && !('@'..='~').contains(&chars[j]) {
+                            j += 1;
+                        }
+                        if chars.get(j) == Some(&'H') {
+                            let params: String = chars[start..j].iter().collect();
+                            let mut parts = params.split(';').map(|n| n.parse().unwrap_or(1usize));
+                            cur_row = parts.next().unwrap_or(1).saturating_sub(1);
+                            cur_col = parts.next().unwrap_or(1).saturating_sub(1);
+                        }
+                        i = j + 1;
+                    }
+                    Some(']') => {
+                        while i < chars.len() && chars[i] != '\x07' {
+                            i += 1;
+                        }
+                        i += 1;
+                    }
+                    _ => i += 1,
+                }
+                continue;
+            }
+            if cur_row == row {
+                if cells.len() <= cur_col {
+                    cells.resize(cur_col + 1, ' ');
+                }
+                cells[cur_col] = chars[i];
+            }
+            cur_col += 1;
+            i += 1;
+        }
+        cells.into_iter().collect::<String>().trim_end().to_string()
+    }
+
+    /// Issue #330: with line numbers off and nothing to mark, `auto` puts
+    /// the text flush left like nvim; `yes` keeps the two-cell gutter.
+    #[test]
+    fn sign_column_auto_hides_gutter_until_a_sign_appears() {
+        use crate::config::SignColumn;
+        let tmp = std::env::temp_dir().join(format!("nevi_sign_column_{}", std::process::id()));
+        std::fs::create_dir_all(&tmp).expect("create temp dir");
+        let path = tmp.join("f");
+        std::fs::write(&path, "123\n").expect("write file");
+
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.settings.editor.line_numbers = false;
+        editor.open_file(path.clone()).expect("open file");
+
+        assert_eq!(
+            screen_row_text(&render_editor_to_string(&editor), 0),
+            "  123"
+        );
+
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        assert_eq!(screen_row_text(&render_editor_to_string(&editor), 0), "123");
+
+        editor.set_diagnostics(
+            crate::lsp::path_to_uri(&path),
+            vec![crate::lsp::Diagnostic {
+                line: 0,
+                end_line: 0,
+                col_start: 0,
+                col_end: 1,
+                severity: crate::lsp::DiagnosticSeverity::Error,
+                message: "boom".to_string(),
+                source: None,
+                code: None,
+            }],
+        );
+        // The row continues with the inline diagnostic text, so check the prefix.
+        let error_glyph = editor.ui_glyphs().gutter_error;
+        let row = screen_row_text(&render_editor_to_string(&editor), 0);
+        assert!(
+            row.starts_with(&format!(" {error_glyph}123 ")),
+            "auto grows the gutter once the buffer has a sign; row={row:?}"
+        );
+
+        editor.settings.editor.sign_column = SignColumn::No;
+        let row = screen_row_text(&render_editor_to_string(&editor), 0);
+        assert!(
+            row.starts_with("123 "),
+            "no never draws the column, even with a diagnostic; row={row:?}"
+        );
+
+        editor.settings.editor.line_numbers = true;
+        editor.settings.editor.sign_column = SignColumn::Yes;
+        let row = screen_row_text(&render_editor_to_string(&editor), 0);
+        assert!(
+            row.starts_with(&format!(" {error_glyph}  1 123 ")),
+            "yes with line numbers: sign cells, number, separator, text; row={row:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn sign_column_auto_applies_to_wrapped_rendering_too() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(30, 6);
+        editor.settings.editor.line_numbers = false;
+        editor.settings.editor.wrap = true;
+        editor.settings.editor.wrap_width = 5;
+        editor.settings.editor.sign_column = SignColumn::Auto;
+        editor.replace_buffer_content("abcdefgh\n");
+
+        let rendered = render_editor_to_string(&editor);
+        assert_eq!(screen_row_text(&rendered, 0), "abcde");
+        assert_eq!(screen_row_text(&rendered, 1), "fgh");
+    }
+
+    #[test]
+    fn text_area_x_tracks_sign_column_and_line_numbers() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        editor.set_size(80, 24);
+        editor.replace_buffer_content("fn main() {}\n");
+        let pane_x = editor.panes()[editor.active_pane_idx()].rect.x;
+
+        assert_eq!(Terminal::text_area_x(&editor), pane_x + 2 + 3 + 1);
+        editor.settings.editor.line_numbers = false;
+        assert_eq!(Terminal::text_area_x(&editor), pane_x + 2);
+        editor.settings.editor.sign_column = SignColumn::No;
+        assert_eq!(Terminal::text_area_x(&editor), pane_x);
+        editor.settings.editor.line_numbers = true;
+        assert_eq!(Terminal::text_area_x(&editor), pane_x + 3 + 1);
+    }
+
+    #[test]
+    fn set_signcolumn_changes_the_setting_and_rejects_bad_values() {
+        use crate::config::SignColumn;
+        let mut editor = Editor::default();
+        for (option, value, expected) in [
+            ("signcolumn", "auto", SignColumn::Auto),
+            ("scl", "no", SignColumn::No),
+            ("signcolumn", "yes", SignColumn::Yes),
+        ] {
+            execute_command(
+                &mut editor,
+                Command::Set(option.to_string(), Some(value.to_string())),
+            );
+            assert_eq!(
+                editor.settings.editor.sign_column, expected,
+                ":set {option}={value}"
+            );
+        }
+        for bad in [Some("maybe".to_string()), None] {
+            execute_command(&mut editor, Command::Set("signcolumn".to_string(), bad));
+            assert_eq!(
+                editor.settings.editor.sign_column,
+                SignColumn::Yes,
+                "unchanged"
+            );
+            assert!(
+                editor
+                    .status_message
+                    .as_deref()
+                    .is_some_and(|m| m.contains("signcolumn: expected auto, yes, or no")),
+                "status={:?}",
+                editor.status_message
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Adds the option nvim has for the sign column instead of changing the default, which is what #330 was really missing.

`[editor] sign_column = "auto" | "yes" | "no"`. `auto` shows the git/diagnostic gutter only while the buffer has something to mark, so a plain file renders flush left like `nvim --clean`. `yes` is the default and is exactly what nevi does today, so existing configs see no change. `no` hides it. `:set signcolumn=auto` (or `:set scl=auto`) switches it at runtime.

The gutter width now comes from one `Editor` helper instead of a hardcoded 2 spread over about twenty places (render fill, wrap width, cursor placement, tilde rows, mouse hit testing, popup anchors). The duplicated sign painting in the wrap and nowrap renderers collapsed into one function. Completion, hover, signature help and code actions use the same helper, so they anchor where the cursor actually is. Signature help and code actions also add the pane's offset now, which they ignored in splits.

Tests cover config parsing and the default, the width helper across all three modes with git and diagnostic signs, rendered rows for the `123` repro with numbers off (nowrap and wrap), the popup anchor helper, and the `:set` arm. Full suite and the render frame budget gate pass.

Not in this PR: popups still compute their row from the buffer line and ignore soft wrap. That is #333.

Closes #330
